### PR TITLE
Implement admin access management page

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Layout/MainLayout.razor
+++ b/src/RegistraceOvcina.Web/Components/Layout/MainLayout.razor
@@ -32,6 +32,7 @@
                         <Authorized>
                             <a class="nav-link" href="/admin/hry">Správa her</a>
                             <a class="nav-link" href="/admin/kralovstvi">Království</a>
+                            <a class="nav-link" href="/admin/organizatori">Organizátoři</a>
                         </Authorized>
                     </AuthorizeView>
                 </nav>

--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/UserManagement.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/UserManagement.razor
@@ -1,0 +1,277 @@
+@page "/admin/organizatori"
+@attribute [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
+
+@using RegistraceOvcina.Web.Features.Users
+@using RegistraceOvcina.Web.Infrastructure
+
+@inject UserAdministrationService UserAdministrationService
+
+<PageTitle>Organizátoři a správci</PageTitle>
+
+<div class="row g-4">
+    <div class="col-12">
+        <section class="card shadow-sm">
+            <div class="card-body p-4">
+                <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 mb-3">
+                    <div>
+                        <h1 class="h3 mb-2" data-testid="user-management-title">Organizátoři a správci</h1>
+                        <p class="text-secondary mb-0">Spravujte staff role a případné deaktivace přístupů na jednom místě.</p>
+                    </div>
+
+                    @if (pageModel is not null)
+                    {
+                        <div class="d-flex flex-wrap gap-4">
+                            <div>
+                                <div class="small text-secondary">Aktivní staff</div>
+                                <div class="h4 mb-0" data-testid="active-staff-count">@pageModel.ActiveStaffCount</div>
+                            </div>
+                            <div>
+                                <div class="small text-secondary">Aktivní správci</div>
+                                <div class="h4 mb-0" data-testid="active-admin-count">@pageModel.AdminCount</div>
+                            </div>
+                            <div>
+                                <div class="small text-secondary">Účty celkem</div>
+                                <div class="h4 mb-0" data-testid="user-count">@pageModel.TotalUsers</div>
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                @if (!string.IsNullOrWhiteSpace(statusMessage))
+                {
+                    <div class="alert alert-success mb-0" role="status">@statusMessage</div>
+                }
+
+                @if (!string.IsNullOrWhiteSpace(errorMessage))
+                {
+                    <div class="alert alert-danger mb-0" role="alert">@errorMessage</div>
+                }
+            </div>
+        </section>
+    </div>
+
+    @if (pageModel is null)
+    {
+        <div class="col-12">
+            <p class="text-secondary">Načítám účty...</p>
+        </div>
+    }
+    else
+    {
+        <div class="col-12">
+            <section class="card shadow-sm">
+                <div class="card-body p-4">
+                    <h2 class="h4 mb-3">Aktuální staff</h2>
+
+                    @if (pageModel.StaffUsers.Count == 0)
+                    {
+                        <div class="empty-state">Zatím nejsou přiřazené žádné staff role.</div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive">
+                            <table class="table align-middle">
+                                <thead>
+                                    <tr>
+                                        <th>Uživatel</th>
+                                        <th>Stav</th>
+                                        <th>Role</th>
+                                        <th>Poslední přihlášení</th>
+                                        <th class="text-end">Akce</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var user in pageModel.StaffUsers)
+                                    {
+                                        <tr data-testid="@($"user-row-{user.Id}")" class="@GetRowClass(user)">
+                                            <td>
+                                                <div class="fw-semibold">@user.DisplayLabel</div>
+                                                <div class="small text-secondary">@user.Email</div>
+                                            </td>
+                                            <td>
+                                                <span class="badge @(user.IsActive ? "text-bg-success" : "text-bg-secondary")">
+                                                    @(user.IsActive ? "Aktivní" : "Deaktivovaný")
+                                                </span>
+                                                <div class="small text-secondary mt-2">Vytvořen @CzechTime.Format(user.CreatedAtUtc)</div>
+                                            </td>
+                                            <td>
+                                                <div class="d-flex flex-wrap gap-1">
+                                                    @if (user.IsAdmin)
+                                                    {
+                                                        <span class="badge text-bg-danger">Správce</span>
+                                                    }
+                                                    @if (user.IsOrganizer)
+                                                    {
+                                                        <span class="badge text-bg-primary">Organizátor</span>
+                                                    }
+                                                </div>
+                                                @if (user.IsLastActiveAdmin)
+                                                {
+                                                    <div class="small text-secondary mt-2">Poslední aktivní správce musí zůstat dostupný.</div>
+                                                }
+                                            </td>
+                                            <td>@FormatLastLogin(user.LastLoginAtUtc)</td>
+                                            <td class="text-end">
+                                                <div class="d-flex flex-wrap justify-content-end gap-1">
+                                                    <form method="post" action="/admin/organizatori/@user.Id/organizator">
+                                                        <AntiforgeryToken />
+                                                        <button type="submit"
+                                                                class="btn btn-sm @(user.IsOrganizer ? "btn-outline-primary" : "btn-outline-secondary")"
+                                                                data-testid="@($"toggle-organizer-{user.Id}")">
+                                                            @(user.IsOrganizer ? "Odebrat organizátora" : "Přidat organizátora")
+                                                        </button>
+                                                    </form>
+                                                    <form method="post" action="/admin/organizatori/@user.Id/spravce">
+                                                        <AntiforgeryToken />
+                                                        <button type="submit"
+                                                                class="btn btn-sm @(user.IsAdmin ? "btn-outline-danger" : "btn-outline-secondary")"
+                                                                data-testid="@($"toggle-admin-{user.Id}")"
+                                                                title="@GetAdminActionTitle(user)"
+                                                                disabled="@(user.IsLastActiveAdmin && user.IsAdmin)">
+                                                            @(user.IsAdmin ? "Odebrat správce" : "Přidat správce")
+                                                        </button>
+                                                    </form>
+                                                    <form method="post"
+                                                          action="/admin/organizatori/@user.Id/aktivita"
+                                                          onsubmit="@(user.IsActive ? "return confirm('Opravdu deaktivovat tento účet?');" : null)">
+                                                        <AntiforgeryToken />
+                                                        <button type="submit"
+                                                                class="btn btn-sm @(user.IsActive ? "btn-outline-warning" : "btn-outline-success")"
+                                                                data-testid="@($"toggle-active-{user.Id}")"
+                                                                title="@GetActivityActionTitle(user)"
+                                                                disabled="@(user.IsLastActiveAdmin && user.IsActive)">
+                                                            @(user.IsActive ? "Deaktivovat" : "Aktivovat")
+                                                        </button>
+                                                    </form>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                </div>
+            </section>
+        </div>
+
+        <div class="col-12">
+            <section class="card shadow-sm">
+                <div class="card-body p-4">
+                    <h2 class="h4 mb-3">Ostatní účty</h2>
+
+                    @if (pageModel.OtherUsers.Count == 0)
+                    {
+                        <div class="empty-state">Všechny existující účty už mají staff roli.</div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive">
+                            <table class="table align-middle">
+                                <thead>
+                                    <tr>
+                                        <th>Uživatel</th>
+                                        <th>Stav</th>
+                                        <th>Poslední přihlášení</th>
+                                        <th class="text-end">Akce</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var user in pageModel.OtherUsers)
+                                    {
+                                        <tr data-testid="@($"user-row-{user.Id}")" class="@GetRowClass(user)">
+                                            <td>
+                                                <div class="fw-semibold">@user.DisplayLabel</div>
+                                                <div class="small text-secondary">@user.Email</div>
+                                            </td>
+                                            <td>
+                                                <span class="badge @(user.IsActive ? "text-bg-success" : "text-bg-secondary")">
+                                                    @(user.IsActive ? "Aktivní" : "Deaktivovaný")
+                                                </span>
+                                                <div class="small text-secondary mt-2">Vytvořen @CzechTime.Format(user.CreatedAtUtc)</div>
+                                            </td>
+                                            <td>@FormatLastLogin(user.LastLoginAtUtc)</td>
+                                            <td class="text-end">
+                                                <div class="d-flex flex-wrap justify-content-end gap-1">
+                                                    <form method="post" action="/admin/organizatori/@user.Id/organizator">
+                                                        <AntiforgeryToken />
+                                                        <button type="submit"
+                                                                class="btn btn-sm btn-outline-secondary"
+                                                                data-testid="@($"toggle-organizer-{user.Id}")">
+                                                            Přidat organizátora
+                                                        </button>
+                                                    </form>
+                                                    <form method="post" action="/admin/organizatori/@user.Id/spravce">
+                                                        <AntiforgeryToken />
+                                                        <button type="submit"
+                                                                class="btn btn-sm btn-outline-secondary"
+                                                                data-testid="@($"toggle-admin-{user.Id}")">
+                                                            Přidat správce
+                                                        </button>
+                                                    </form>
+                                                    <form method="post"
+                                                          action="/admin/organizatori/@user.Id/aktivita"
+                                                          onsubmit="@(user.IsActive ? "return confirm('Opravdu deaktivovat tento účet?');" : null)">
+                                                        <AntiforgeryToken />
+                                                        <button type="submit"
+                                                                class="btn btn-sm @(user.IsActive ? "btn-outline-warning" : "btn-outline-success")"
+                                                                data-testid="@($"toggle-active-{user.Id}")">
+                                                            @(user.IsActive ? "Deaktivovat" : "Aktivovat")
+                                                        </button>
+                                                    </form>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                </div>
+            </section>
+        </div>
+    }
+</div>
+
+@code {
+    [SupplyParameterFromQuery(Name = "status")]
+    private string? status { get; set; }
+
+    [SupplyParameterFromQuery(Name = "error")]
+    private string? queryError { get; set; }
+
+    private UserAdministrationPage? pageModel;
+    private string? statusMessage;
+    private string? errorMessage;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        pageModel = await UserAdministrationService.GetPageAsync();
+        statusMessage = status switch
+        {
+            "organizer-added" => "Role organizátora byla přidána.",
+            "organizer-removed" => "Role organizátora byla odebrána.",
+            "admin-added" => "Role správce byla přidána.",
+            "admin-removed" => "Role správce byla odebrána.",
+            "user-activated" => "Účet byl znovu aktivován.",
+            "user-deactivated" => "Účet byl deaktivován.",
+            _ => null
+        };
+        errorMessage = queryError;
+    }
+
+    private static string FormatLastLogin(DateTime? lastLoginAtUtc) =>
+        lastLoginAtUtc is null ? "Nikdy" : CzechTime.Format(lastLoginAtUtc.Value);
+
+    private static string GetActivityActionTitle(ManagedUserSummary user) =>
+        user.IsLastActiveAdmin && user.IsActive
+            ? "Posledního aktivního správce nelze deaktivovat."
+            : string.Empty;
+
+    private static string GetAdminActionTitle(ManagedUserSummary user) =>
+        user.IsLastActiveAdmin && user.IsAdmin
+            ? "Poslední aktivní role správce musí zůstat přiřazená."
+            : string.Empty;
+
+    private static string GetRowClass(ManagedUserSummary user) => user.IsActive ? string.Empty : "table-light";
+}

--- a/src/RegistraceOvcina.Web/Features/Users/UserAdministrationService.cs
+++ b/src/RegistraceOvcina.Web/Features/Users/UserAdministrationService.cs
@@ -1,0 +1,260 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Security;
+
+namespace RegistraceOvcina.Web.Features.Users;
+
+public sealed class UserAdministrationService(IDbContextFactory<ApplicationDbContext> dbContextFactory, TimeProvider timeProvider)
+{
+    private static readonly string[] ManageableRoles = [RoleNames.Organizer, RoleNames.Admin];
+
+    public async Task<UserAdministrationPage> GetPageAsync(CancellationToken cancellationToken = default)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var users = await db.Users
+            .AsNoTracking()
+            .OrderBy(x => x.DisplayName)
+            .ThenBy(x => x.Email)
+            .ToListAsync(cancellationToken);
+
+        var roleAssignments = await db.UserRoles
+            .AsNoTracking()
+            .Join(
+                db.Roles.AsNoTracking(),
+                userRole => userRole.RoleId,
+                role => role.Id,
+                (userRole, role) => new
+                {
+                    userRole.UserId,
+                    RoleName = role.Name!
+                })
+            .Where(x => ManageableRoles.Contains(x.RoleName))
+            .ToListAsync(cancellationToken);
+
+        var rolesByUser = roleAssignments
+            .GroupBy(x => x.UserId)
+            .ToDictionary(
+                x => x.Key,
+                x => x.Select(y => y.RoleName).ToHashSet(StringComparer.Ordinal));
+
+        var summaries = users
+            .Select(user =>
+            {
+                var userRoles = rolesByUser.GetValueOrDefault(user.Id);
+                var isAdmin = userRoles?.Contains(RoleNames.Admin) == true;
+                var isOrganizer = userRoles?.Contains(RoleNames.Organizer) == true;
+
+                return new ManagedUserSummary(
+                    user.Id,
+                    user.DisplayName,
+                    user.Email ?? string.Empty,
+                    user.IsActive,
+                    isOrganizer,
+                    isAdmin,
+                    user.LastLoginAtUtc,
+                    user.CreatedAtUtc,
+                    false);
+            })
+            .OrderByDescending(x => x.IsActive)
+            .ThenByDescending(x => x.IsAdmin)
+            .ThenByDescending(x => x.IsOrganizer)
+            .ThenBy(x => x.DisplayName, StringComparer.CurrentCulture)
+            .ThenBy(x => x.Email, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var activeAdmins = summaries
+            .Where(x => x.IsAdmin && x.IsActive)
+            .Select(x => x.Id)
+            .ToList();
+
+        if (activeAdmins.Count == 1)
+        {
+            var protectedAdminId = activeAdmins[0];
+            summaries = summaries
+                .Select(x => x.Id == protectedAdminId ? x with { IsLastActiveAdmin = true } : x)
+                .ToList();
+        }
+
+        return new UserAdministrationPage(
+            summaries.Where(x => x.IsStaff).ToList(),
+            summaries.Where(x => !x.IsStaff).ToList(),
+            summaries.Count,
+            summaries.Count(x => x.IsStaff && x.IsActive),
+            summaries.Count(x => x.IsAdmin && x.IsActive));
+    }
+
+    public async Task<UserManagementChangeResult> ToggleRoleAsync(
+        string userId,
+        string roleName,
+        string actorUserId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!ManageableRoles.Contains(roleName, StringComparer.Ordinal))
+        {
+            throw new ValidationException("Tuto roli nelze na této stránce spravovat.");
+        }
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var nowUtc = timeProvider.GetUtcNow().UtcDateTime;
+
+        var user = await db.Users.SingleOrDefaultAsync(x => x.Id == userId, cancellationToken)
+            ?? throw new ValidationException("Uživatel nebyl nalezen.");
+
+        var role = await db.Roles.SingleOrDefaultAsync(x => x.Name == roleName, cancellationToken)
+            ?? throw new ValidationException($"Role '{roleName}' nebyla nalezena.");
+
+        var membership = await db.UserRoles.SingleOrDefaultAsync(
+            x => x.UserId == userId && x.RoleId == role.Id,
+            cancellationToken);
+
+        var granted = membership is null;
+        if (!granted && roleName == RoleNames.Admin)
+        {
+            await EnsureAnotherActiveAdminExistsAsync(db, user.Id, cancellationToken);
+        }
+
+        if (granted)
+        {
+            db.UserRoles.Add(new IdentityUserRole<string>
+            {
+                UserId = user.Id,
+                RoleId = role.Id
+            });
+        }
+        else
+        {
+            db.UserRoles.Remove(membership!);
+        }
+
+        user.SecurityStamp = Guid.NewGuid().ToString("N");
+
+        db.AuditLogs.Add(new AuditLog
+        {
+            EntityType = nameof(ApplicationUser),
+            EntityId = user.Id,
+            Action = granted ? "UserRoleGranted" : "UserRoleRevoked",
+            ActorUserId = actorUserId,
+            CreatedAtUtc = nowUtc,
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                user.Email,
+                user.DisplayName,
+                Role = roleName,
+                Granted = granted
+            })
+        });
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return new UserManagementChangeResult(GetRoleStatusCode(roleName, granted));
+    }
+
+    public async Task<UserManagementChangeResult> ToggleActiveAsync(
+        string userId,
+        string actorUserId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var nowUtc = timeProvider.GetUtcNow().UtcDateTime;
+
+        var user = await db.Users.SingleOrDefaultAsync(x => x.Id == userId, cancellationToken)
+            ?? throw new ValidationException("Uživatel nebyl nalezen.");
+
+        var activating = !user.IsActive;
+        if (!activating)
+        {
+            await EnsureAnotherActiveAdminExistsAsync(db, user.Id, cancellationToken);
+        }
+
+        user.IsActive = activating;
+        user.SecurityStamp = Guid.NewGuid().ToString("N");
+
+        db.AuditLogs.Add(new AuditLog
+        {
+            EntityType = nameof(ApplicationUser),
+            EntityId = user.Id,
+            Action = activating ? "UserActivated" : "UserDeactivated",
+            ActorUserId = actorUserId,
+            CreatedAtUtc = nowUtc,
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                user.Email,
+                user.DisplayName,
+                user.IsActive
+            })
+        });
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return new UserManagementChangeResult(activating ? "user-activated" : "user-deactivated");
+    }
+
+    private static async Task EnsureAnotherActiveAdminExistsAsync(
+        ApplicationDbContext db,
+        string userId,
+        CancellationToken cancellationToken)
+    {
+        var targetIsActiveAdmin = await (
+                from user in db.Users
+                join userRole in db.UserRoles on user.Id equals userRole.UserId
+                join role in db.Roles on userRole.RoleId equals role.Id
+                where user.Id == userId && user.IsActive && role.Name == RoleNames.Admin
+                select user.Id)
+            .AnyAsync(cancellationToken);
+
+        if (!targetIsActiveAdmin)
+        {
+            return;
+        }
+
+        var anotherActiveAdminExists = await (
+                from user in db.Users
+                join userRole in db.UserRoles on user.Id equals userRole.UserId
+                join role in db.Roles on userRole.RoleId equals role.Id
+                where user.Id != userId && user.IsActive && role.Name == RoleNames.Admin
+                select user.Id)
+            .AnyAsync(cancellationToken);
+
+        if (!anotherActiveAdminExists)
+        {
+            throw new ValidationException("Posledního aktivního správce nelze odebrat ani deaktivovat.");
+        }
+    }
+
+    private static string GetRoleStatusCode(string roleName, bool granted) =>
+        roleName switch
+        {
+            RoleNames.Organizer => granted ? "organizer-added" : "organizer-removed",
+            RoleNames.Admin => granted ? "admin-added" : "admin-removed",
+            _ => throw new InvalidOperationException($"Unsupported role '{roleName}'.")
+        };
+}
+
+public sealed record UserAdministrationPage(
+    IReadOnlyList<ManagedUserSummary> StaffUsers,
+    IReadOnlyList<ManagedUserSummary> OtherUsers,
+    int TotalUsers,
+    int ActiveStaffCount,
+    int AdminCount);
+
+public sealed record ManagedUserSummary(
+    string Id,
+    string DisplayName,
+    string Email,
+    bool IsActive,
+    bool IsOrganizer,
+    bool IsAdmin,
+    DateTime? LastLoginAtUtc,
+    DateTime CreatedAtUtc,
+    bool IsLastActiveAdmin)
+{
+    public bool IsStaff => IsOrganizer || IsAdmin;
+
+    public string DisplayLabel => string.IsNullOrWhiteSpace(DisplayName) ? Email : DisplayName;
+}
+
+public sealed record UserManagementChangeResult(string StatusCode);

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -16,6 +16,7 @@ using RegistraceOvcina.Web.Features.Games;
 using RegistraceOvcina.Web.Features.Payments;
 using RegistraceOvcina.Web.Features.Kingdoms;
 using RegistraceOvcina.Web.Features.Submissions;
+using RegistraceOvcina.Web.Features.Users;
 using RegistraceOvcina.Web.Security;
 
 namespace RegistraceOvcina.Web;
@@ -171,6 +172,7 @@ public class Program
         builder.Services.AddScoped<GameService>();
         builder.Services.AddScoped<KingdomService>();
         builder.Services.AddScoped<SubmissionService>();
+        builder.Services.AddScoped<UserAdministrationService>();
 
         var app = builder.Build();
 
@@ -383,6 +385,69 @@ public class Program
                     catch (ValidationException ex)
                     {
                         return Results.LocalRedirect($"/admin/hry/{gameId}/kralovstvi?error={Uri.EscapeDataString(ex.Message)}");
+                     }
+                 })
+             .RequireAuthorization(AuthorizationPolicies.AdminOnly);
+        app.MapPost(
+                "/admin/organizatori/{userId}/organizator",
+                async (string userId, HttpContext httpContext, UserManager<ApplicationUser> userManager, UserAdministrationService userAdministrationService) =>
+                {
+                    var user = await userManager.GetUserAsync(httpContext.User);
+                    if (user is null)
+                    {
+                        return Results.LocalRedirect($"/Account/Login?ReturnUrl={Uri.EscapeDataString("/admin/organizatori")}");
+                    }
+
+                    try
+                    {
+                        var result = await userAdministrationService.ToggleRoleAsync(userId, RoleNames.Organizer, user.Id);
+                        return Results.LocalRedirect($"/admin/organizatori?status={Uri.EscapeDataString(result.StatusCode)}");
+                    }
+                    catch (ValidationException ex)
+                    {
+                        return Results.LocalRedirect($"/admin/organizatori?error={Uri.EscapeDataString(ex.Message)}");
+                    }
+                })
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly);
+        app.MapPost(
+                "/admin/organizatori/{userId}/spravce",
+                async (string userId, HttpContext httpContext, UserManager<ApplicationUser> userManager, UserAdministrationService userAdministrationService) =>
+                {
+                    var user = await userManager.GetUserAsync(httpContext.User);
+                    if (user is null)
+                    {
+                        return Results.LocalRedirect($"/Account/Login?ReturnUrl={Uri.EscapeDataString("/admin/organizatori")}");
+                    }
+
+                    try
+                    {
+                        var result = await userAdministrationService.ToggleRoleAsync(userId, RoleNames.Admin, user.Id);
+                        return Results.LocalRedirect($"/admin/organizatori?status={Uri.EscapeDataString(result.StatusCode)}");
+                    }
+                    catch (ValidationException ex)
+                    {
+                        return Results.LocalRedirect($"/admin/organizatori?error={Uri.EscapeDataString(ex.Message)}");
+                    }
+                })
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly);
+        app.MapPost(
+                "/admin/organizatori/{userId}/aktivita",
+                async (string userId, HttpContext httpContext, UserManager<ApplicationUser> userManager, UserAdministrationService userAdministrationService) =>
+                {
+                    var user = await userManager.GetUserAsync(httpContext.User);
+                    if (user is null)
+                    {
+                        return Results.LocalRedirect($"/Account/Login?ReturnUrl={Uri.EscapeDataString("/admin/organizatori")}");
+                    }
+
+                    try
+                    {
+                        var result = await userAdministrationService.ToggleActiveAsync(userId, user.Id);
+                        return Results.LocalRedirect($"/admin/organizatori?status={Uri.EscapeDataString(result.StatusCode)}");
+                    }
+                    catch (ValidationException ex)
+                    {
+                        return Results.LocalRedirect($"/admin/organizatori?error={Uri.EscapeDataString(ex.Message)}");
                     }
                 })
             .RequireAuthorization(AuthorizationPolicies.AdminOnly);

--- a/tests/RegistraceOvcina.E2E/SmokeTests.cs
+++ b/tests/RegistraceOvcina.E2E/SmokeTests.cs
@@ -133,6 +133,51 @@ public sealed class SmokeTests : IClassFixture<AppFixture>
     }
 
     [Fact]
+    public async Task AdminCanManageOrganizerAndAdminRoles()
+    {
+        var adminPage = await _fixture.Browser.NewPageAsync();
+
+        await LoginAsync(adminPage, AdminEmail);
+        await adminPage.GotoAsync($"{_fixture.BaseUrl}/admin/organizatori", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle
+        });
+        await WaitForInteractiveReadyAsync(adminPage);
+
+        await adminPage.GetByTestId("user-management-title").WaitForAsync(new LocatorWaitForOptions
+        {
+            Timeout = 5000
+        });
+
+        await ToggleUserManagementActionAsync(
+            adminPage,
+            RegistrantEmail,
+            "Přidat organizátora",
+            "organizer-added",
+            "Role organizátora byla přidána.");
+
+        await ToggleUserManagementActionAsync(
+            adminPage,
+            RegistrantEmail,
+            "Přidat správce",
+            "admin-added",
+            "Role správce byla přidána.");
+
+        var managedRow = GetUserRow(adminPage, RegistrantEmail);
+        await managedRow.GetByRole(AriaRole.Button, new() { Name = "Odebrat organizátora" }).WaitForAsync(new LocatorWaitForOptions
+        {
+            Timeout = 5000
+        });
+        await managedRow.GetByRole(AriaRole.Button, new() { Name = "Odebrat správce" }).WaitForAsync(new LocatorWaitForOptions
+        {
+            Timeout = 5000
+        });
+
+        await AssertNoBlazorErrorsAsync(adminPage);
+        await adminPage.CloseAsync();
+    }
+
+    [Fact]
     public async Task AdminCanOpenFoodSummaryAndSeeAggregatedCounts()
     {
         var seeded = await SeedFoodSummaryAsync();
@@ -311,6 +356,32 @@ public sealed class SmokeTests : IClassFixture<AppFixture>
             WaitUntil = WaitUntilState.NetworkIdle
         });
         await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+    }
+
+    private static ILocator GetUserRow(IPage page, string email) =>
+        page.GetByText(email).Locator("xpath=ancestor::tr");
+
+    private async Task ToggleUserManagementActionAsync(
+        IPage page,
+        string email,
+        string buttonText,
+        string expectedStatusCode,
+        string expectedMessage)
+    {
+        var row = GetUserRow(page, email);
+
+        await Task.WhenAll(
+            page.WaitForURLAsync($"**/admin/organizatori?status={expectedStatusCode}", new PageWaitForURLOptions
+            {
+                Timeout = 5000
+            }),
+            row.GetByRole(AriaRole.Button, new() { Name = buttonText }).ClickAsync());
+
+        await WaitForInteractiveReadyAsync(page);
+        await page.GetByText(expectedMessage).WaitForAsync(new LocatorWaitForOptions
+        {
+            Timeout = 5000
+        });
     }
 
     private async Task<SeededFoodSummaryData> SeedFoodSummaryAsync()

--- a/tests/RegistraceOvcina.Web.Tests/UserAdministrationServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/UserAdministrationServiceTests.cs
@@ -1,0 +1,210 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using RegistraceOvcina.Web.Components.Pages.Admin;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.Users;
+using RegistraceOvcina.Web.Security;
+
+namespace RegistraceOvcina.Web.Tests;
+
+public sealed class UserAdministrationServiceTests
+{
+    [Fact]
+    public void UserManagementPage_RequiresAdminPolicy()
+    {
+        var authorizeAttribute = typeof(UserManagement)
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .OfType<AuthorizeAttribute>()
+            .Single();
+
+        Assert.Equal(AuthorizationPolicies.AdminOnly, authorizeAttribute.Policy);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_GroupsStaffUsersAndMarksLastActiveAdmin()
+    {
+        var options = CreateOptions();
+        var admin = CreateUser("admin-id", "Admin", "admin@example.cz", true);
+        var organizer = CreateUser("organizer-id", "Organizer", "organizer@example.cz", true);
+        var registrant = CreateUser("registrant-id", "Registrant", "registrant@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            SeedRole(db, "role-admin", RoleNames.Admin);
+            SeedRole(db, "role-organizer", RoleNames.Organizer);
+
+            db.Users.AddRange(admin, organizer, registrant);
+            db.UserRoles.AddRange(
+                new IdentityUserRole<string> { UserId = admin.Id, RoleId = "role-admin" },
+                new IdentityUserRole<string> { UserId = organizer.Id, RoleId = "role-organizer" });
+
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserAdministrationService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        var page = await service.GetPageAsync();
+
+        Assert.Equal(3, page.TotalUsers);
+        Assert.Equal(2, page.ActiveStaffCount);
+        Assert.Equal(1, page.AdminCount);
+        Assert.Equal(2, page.StaffUsers.Count);
+        Assert.Single(page.OtherUsers);
+        Assert.Contains(page.StaffUsers, x => x.Id == admin.Id && x.IsAdmin && x.IsLastActiveAdmin);
+        Assert.Contains(page.StaffUsers, x => x.Id == organizer.Id && x.IsOrganizer && !x.IsAdmin);
+        Assert.Equal(registrant.Id, page.OtherUsers[0].Id);
+    }
+
+    [Fact]
+    public async Task ToggleRoleAsync_AddsAndRemovesRolesAndWritesAuditLog()
+    {
+        var options = CreateOptions();
+        var actor = CreateUser("actor-id", "Admin", "admin@example.cz", true);
+        var target = CreateUser("target-id", "Target", "target@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            SeedRole(db, "role-admin", RoleNames.Admin);
+            SeedRole(db, "role-organizer", RoleNames.Organizer);
+
+            db.Users.AddRange(actor, target);
+            db.UserRoles.Add(new IdentityUserRole<string> { UserId = actor.Id, RoleId = "role-admin" });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserAdministrationService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        var added = await service.ToggleRoleAsync(target.Id, RoleNames.Organizer, actor.Id);
+        var removed = await service.ToggleRoleAsync(target.Id, RoleNames.Organizer, actor.Id);
+
+        Assert.Equal("organizer-added", added.StatusCode);
+        Assert.Equal("organizer-removed", removed.StatusCode);
+
+        await using var verificationDb = new ApplicationDbContext(options);
+        Assert.DoesNotContain(verificationDb.UserRoles, x => x.UserId == target.Id && x.RoleId == "role-organizer");
+
+        var audits = await verificationDb.AuditLogs
+            .Where(x => x.EntityId == target.Id)
+            .OrderBy(x => x.Id)
+            .ToListAsync();
+
+        Assert.Collection(
+            audits,
+            first => Assert.Equal("UserRoleGranted", first.Action),
+            second => Assert.Equal("UserRoleRevoked", second.Action));
+    }
+
+    [Fact]
+    public async Task ToggleRoleAsync_BlocksRemovingLastActiveAdmin()
+    {
+        var options = CreateOptions();
+        var actor = CreateUser("actor-id", "Admin", "admin@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            SeedRole(db, "role-admin", RoleNames.Admin);
+
+            db.Users.Add(actor);
+            db.UserRoles.Add(new IdentityUserRole<string> { UserId = actor.Id, RoleId = "role-admin" });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserAdministrationService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(() =>
+            service.ToggleRoleAsync(actor.Id, RoleNames.Admin, actor.Id));
+
+        Assert.Equal("Posledního aktivního správce nelze odebrat ani deaktivovat.", ex.Message);
+    }
+
+    [Fact]
+    public async Task ToggleActiveAsync_BlocksDeactivatingLastActiveAdminAndAuditsOtherDeactivation()
+    {
+        var options = CreateOptions();
+        var actor = CreateUser("actor-id", "Admin", "admin@example.cz", true);
+        var target = CreateUser("target-id", "Target", "target@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            SeedRole(db, "role-admin", RoleNames.Admin);
+
+            db.Users.AddRange(actor, target);
+            db.UserRoles.Add(new IdentityUserRole<string> { UserId = actor.Id, RoleId = "role-admin" });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserAdministrationService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        var result = await service.ToggleActiveAsync(target.Id, actor.Id);
+
+        Assert.Equal("user-deactivated", result.StatusCode);
+
+        await using (var verificationDb = new ApplicationDbContext(options))
+        {
+            var targetReloaded = await verificationDb.Users.SingleAsync(x => x.Id == target.Id);
+            Assert.False(targetReloaded.IsActive);
+
+            var audit = await verificationDb.AuditLogs.SingleAsync(x => x.EntityId == target.Id);
+            Assert.Equal("UserDeactivated", audit.Action);
+        }
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(() =>
+            service.ToggleActiveAsync(actor.Id, actor.Id));
+
+        Assert.Equal("Posledního aktivního správce nelze odebrat ani deaktivovat.", ex.Message);
+    }
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static ApplicationUser CreateUser(string id, string displayName, string email, bool isActive) =>
+        new()
+        {
+            Id = id,
+            DisplayName = displayName,
+            Email = email,
+            NormalizedEmail = email.ToUpperInvariant(),
+            UserName = email,
+            NormalizedUserName = email.ToUpperInvariant(),
+            EmailConfirmed = true,
+            IsActive = isActive,
+            SecurityStamp = "initial-stamp",
+            CreatedAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+    private static void SeedRole(ApplicationDbContext db, string roleId, string roleName)
+    {
+        if (db.Roles.Any(x => x.Id == roleId))
+        {
+            return;
+        }
+
+        db.Roles.Add(new IdentityRole
+        {
+            Id = roleId,
+            Name = roleName,
+            NormalizedName = roleName.ToUpperInvariant()
+        });
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now = new(new DateTime(2026, 4, 5, 12, 0, 0, DateTimeKind.Utc));
+
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}


### PR DESCRIPTION
## Summary
- add an admin-only access management page for staff roles and account activation
- add audited organizer/admin toggle actions with a last-active-admin safeguard
- cover the slice with service tests and admin E2E coverage

Closes #17