### PR TITLE
hotfix: fix production crash — EF Core 10 warning + auto-migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,8 +216,11 @@ jobs:
             )
           fi
 
+          # Constrain to a single replica while migrations are applied to avoid concurrent
+          # MigrateAsync() calls across replicas during rollout/scale-out.
           az containerapp update -n "$AZURE_CONTAINER_APP_NAME" -g "$AZURE_RESOURCE_GROUP" \
             --set-env-vars "${env_args[@]}" \
+            --min-replicas 1 --max-replicas 1 \
             --output none
         env:
           AZURE_POSTGRES_CONNECTION_STRING: ${{ secrets.AZURE_POSTGRES_CONNECTION_STRING }}

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -123,7 +123,7 @@ public class Program
             ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 
         // EF Core 10 false-positive: CLI reports no pending changes but runtime disagrees.
-        // Suppress globally until EF Core fixes this. CI migration checks catch real drift.
+        // Suppress globally until EF Core fixes this; model-to-migration drift is not validated here.
         builder.Services.AddDbContext<ApplicationDbContext>(options =>
             options.UseNpgsql(connectionString)
                    .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));


### PR DESCRIPTION
## Emergency fix

Production is down (500) because:
1. EF Core 10 `PendingModelChangesWarning` throws in Production (suppression was scoped to Dev/Testing only)
2. Database was dropped but `ApplyMigrationsOnStartup` was false in production

### Changes
- Restore global `PendingModelChangesWarning` suppression with documenting comment
- Set `Database__ApplyMigrationsOnStartup=true` in production deploy pipeline

After merge + deploy, also set `SeedData__ResetDatabase=false` on the container app.