### PR TITLE
fix: admin seeding in production + version footer v0.5.0

### DIFF
--- a/src/RegistraceOvcina.Web/Data/DatabaseInitializer.cs
+++ b/src/RegistraceOvcina.Web/Data/DatabaseInitializer.cs
@@ -42,6 +42,19 @@ public static class DatabaseInitializer
             }
         }
 
+        // Production admin accounts — always seed, regardless of SeedDemoUsers
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var nowUtc = DateTime.UtcNow;
+        var adminRoles = new[] { RoleNames.Registrant, RoleNames.Organizer, RoleNames.Admin };
+        var adminFallbackPassword = $"OAuth!{Guid.NewGuid():N}";
+
+        await EnsureUserAsync(userManager, "tomas.pajonk@hotmail.cz", adminFallbackPassword,
+            "Tomáš Pajonk", nowUtc, adminRoles);
+        await EnsureUserAsync(userManager, "stanam@email.cz", adminFallbackPassword,
+            "Stanam", nowUtc, adminRoles);
+        await EnsureUserAsync(userManager, "blanka.richtar@gmail.com", adminFallbackPassword,
+            "Blanka Richtar", nowUtc, adminRoles);
+
         var seedDemoUsers = configuration.GetValue<bool?>("SeedData:SeedDemoUsers")
             ?? (environment.IsDevelopment() || environment.IsEnvironment("Testing"));
 
@@ -49,9 +62,6 @@ public static class DatabaseInitializer
         {
             return;
         }
-
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
-        var nowUtc = DateTime.UtcNow;
 
         await EnsureUserAsync(
             userManager,
@@ -68,17 +78,6 @@ public static class DatabaseInitializer
             configuration["SeedData:RegistrantDisplayName"] ?? "Ukázkový registrující",
             nowUtc,
             [RoleNames.Registrant]);
-
-        // Production admin accounts (OAuth login — password is never used, just required by Identity)
-        var adminRoles = new[] { RoleNames.Registrant, RoleNames.Organizer, RoleNames.Admin };
-        var adminFallbackPassword = $"OAuth!{Guid.NewGuid():N}";
-
-        await EnsureUserAsync(userManager, "tomas.pajonk@hotmail.cz", adminFallbackPassword,
-            "Tomáš Pajonk", nowUtc, adminRoles);
-        await EnsureUserAsync(userManager, "stanam@email.cz", adminFallbackPassword,
-            "Stanam", nowUtc, adminRoles);
-        await EnsureUserAsync(userManager, "blanka.richtar@gmail.com", adminFallbackPassword,
-            "Blanka Richtar", nowUtc, adminRoles);
 
         await SeedGameDataAsync(db, nowUtc);
     }

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <Version>0.5.0</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Fix
- Move production admin account seeding (tomas.pajonk, stanam, blanka.richtar) before the SeedDemoUsers guard so admin roles are assigned in production
- Without this, OAuth login creates accounts with Registrant role only — no admin menu visible

## Version
- Add v0.5.0 version stamp in footer for deploy verification

## Cleanup
- Deleted 9 stale remote branches