### PR TITLE
fix: copy registration from most recent year

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Registrations/Dashboard.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Registrations/Dashboard.razor
@@ -92,7 +92,7 @@
                         @foreach (var game in games)
                         {
                             var existing = submissions?.FirstOrDefault(x => x.GameId == game.Id);
-                            var lastSubmission = submissions?.Where(x => x.GameId != game.Id && x.Status == SubmissionStatus.Submitted).FirstOrDefault();
+                            var lastSubmission = submissions?.Where(x => x.GameId != game.Id && x.Status == SubmissionStatus.Submitted).OrderByDescending(x => x.SubmittedAtUtc).FirstOrDefault();
 
                             <article class="card border-0 bg-light">
                                 <div class="card-body d-flex flex-column gap-3">


### PR DESCRIPTION
## Summary
- Fixed "repeat previous registration" offering the first year's registration instead of the most recent one
- Root cause: submissions were ordered by `LastEditedAtUtc` (edit time), so an older registration edited after submission (e.g. payment update) would appear first
- Fix: explicitly order by `SubmittedAtUtc DESC` when selecting the submission to copy from

## Test plan
- [ ] Register for multiple years, then verify the "Zopakovat z:" button offers the most recent year's registration
- [ ] Edit an older year's submission (e.g. trigger a payment update), verify it still offers the most recent year

🤖 Generated with [Claude Code](https://claude.com/claude-code)