### PR TITLE
[v0.8.0] feat: role management pages

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Layout/MainLayout.razor
+++ b/src/RegistraceOvcina.Web/Components/Layout/MainLayout.razor
@@ -43,6 +43,7 @@
                             <a class="nav-link" href="/admin/organizatori">Organizátoři</a>
                             <a class="nav-link" href="/admin/oznameni">Oznámení</a>
                             <a class="nav-link" href="/admin/osloveni">Oslovení</a>
+                            <a class="nav-link" href="/admin/roles">Role</a>
                         </Authorized>
                     </AuthorizeView>
                 </nav>

--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/Roles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/Roles.razor
@@ -1,0 +1,371 @@
+@page "/admin/roles"
+@attribute [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
+@rendermode InteractiveServer
+
+@inject RoleManager<ApplicationRole> RoleManager
+@inject UserManager<ApplicationUser> UserManager
+
+<PageTitle>Správa rolí</PageTitle>
+
+<div class="row g-4">
+    <div class="col-12">
+        <section class="card shadow-sm">
+            <div class="card-body p-4">
+                <h1 class="h3 mb-3">Správa rolí</h1>
+
+                @if (!string.IsNullOrEmpty(statusMessage))
+                {
+                    <div class="alert @(isError ? "alert-danger" : "alert-success") alert-dismissible fade show" role="alert">
+                        @statusMessage
+                        <button type="button" class="btn-close" @onclick="ClearStatus"></button>
+                    </div>
+                }
+
+                @* --- Create new role --- *@
+                <div class="card mb-4">
+                    <div class="card-body">
+                        <h3 class="h5 mb-3">Přidat novou roli</h3>
+                        <div class="row g-2 align-items-end">
+                            <div class="col-md-5">
+                                <label class="form-label">Název role</label>
+                                <input @bind="newRoleName" class="form-control" placeholder="Např. Courier" />
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">Kategorie</label>
+                                <select @bind="newRoleCategory" class="form-select">
+                                    <option value="game">Herní role</option>
+                                    <option value="staff">Organizační role</option>
+                                </select>
+                            </div>
+                            <div class="col-md-3">
+                                <button class="btn btn-primary w-100" @onclick="CreateRoleAsync">Přidat</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                @* --- Role list --- *@
+                @if (roleEntries is null)
+                {
+                    <p class="text-secondary">Načítám...</p>
+                }
+                else
+                {
+                    @foreach (var group in categoryOrder)
+                    {
+                        var roles = roleEntries.Where(r => r.Category == group.Key).ToList();
+                        if (roles.Count == 0) continue;
+
+                        <h3 class="h5 mt-4 mb-2">@group.Label</h3>
+                        <div class="table-responsive">
+                            <table class="table align-middle">
+                                <thead>
+                                    <tr>
+                                        <th>Název</th>
+                                        <th>Kategorie</th>
+                                        <th>Uživatelů</th>
+                                        <th>Akce</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var entry in roles)
+                                    {
+                                        @if (editingRoleId == entry.Id)
+                                        {
+                                            <tr>
+                                                <td>
+                                                    <input @bind="editRoleName" class="form-control form-control-sm" />
+                                                </td>
+                                                <td>
+                                                    <select @bind="editRoleCategory" class="form-select form-select-sm">
+                                                        <option value="game">Herní role</option>
+                                                        <option value="staff">Organizační role</option>
+                                                    </select>
+                                                </td>
+                                                <td>@entry.UserCount</td>
+                                                <td>
+                                                    <div class="d-flex gap-1">
+                                                        <button class="btn btn-sm btn-primary" @onclick="SaveEditAsync">Uložit</button>
+                                                        <button class="btn btn-sm btn-outline-secondary" @onclick="CancelEdit">Zrušit</button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        }
+                                        else
+                                        {
+                                            <tr>
+                                                <td>@entry.Name</td>
+                                                <td>
+                                                    <span class="badge @CategoryBadgeClass(entry.Category)">@CategoryLabel(entry.Category)</span>
+                                                </td>
+                                                <td>@entry.UserCount</td>
+                                                <td>
+                                                    @if (!entry.IsProtected)
+                                                    {
+                                                        <div class="d-flex gap-1">
+                                                            <button class="btn btn-sm btn-outline-primary" @onclick="() => StartEdit(entry)">Upravit</button>
+                                                            @if (confirmDeleteId == entry.Id)
+                                                            {
+                                                                <button class="btn btn-sm btn-danger" @onclick="() => DeleteRoleAsync(entry.Id)">Potvrdit smazání</button>
+                                                                <button class="btn btn-sm btn-outline-secondary" @onclick="CancelDelete">Zrušit</button>
+                                                            }
+                                                            else
+                                                            {
+                                                                <button class="btn btn-sm btn-outline-danger" @onclick="() => ConfirmDelete(entry.Id)">Smazat</button>
+                                                            }
+                                                        </div>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span class="text-muted small">Systémová role</span>
+                                                    }
+                                                </td>
+                                            </tr>
+                                        }
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                }
+            </div>
+        </section>
+    </div>
+</div>
+
+@code {
+    private static readonly string[] ProtectedRoleNames =
+    [
+        RoleNames.Admin,
+        RoleNames.Organizer,
+        RoleNames.Registrant,
+        RoleNames.Guest,
+    ];
+
+    private static readonly (string Key, string Label)[] categoryOrder =
+    [
+        ("system", "Systémové role"),
+        ("game", "Herní role"),
+        ("staff", "Organizační role"),
+    ];
+
+    private List<RoleEntry>? roleEntries;
+
+    // Create form
+    private string newRoleName = "";
+    private string newRoleCategory = "game";
+
+    // Edit form
+    private string? editingRoleId;
+    private string editRoleName = "";
+    private string editRoleCategory = "game";
+
+    // Delete confirmation
+    private string? confirmDeleteId;
+
+    // Status
+    private string? statusMessage;
+    private bool isError;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadRolesAsync();
+    }
+
+    private async Task LoadRolesAsync()
+    {
+        var allRoles = RoleManager.Roles.ToList();
+        var entries = new List<RoleEntry>();
+
+        foreach (var role in allRoles)
+        {
+            var usersInRole = await UserManager.GetUsersInRoleAsync(role.Name!);
+            entries.Add(new RoleEntry
+            {
+                Id = role.Id,
+                Name = role.Name!,
+                Category = role.Category,
+                UserCount = usersInRole.Count,
+                IsProtected = ProtectedRoleNames.Contains(role.Name!, StringComparer.OrdinalIgnoreCase),
+            });
+        }
+
+        roleEntries = entries.OrderBy(r => r.Name).ToList();
+    }
+
+    private async Task CreateRoleAsync()
+    {
+        if (string.IsNullOrWhiteSpace(newRoleName))
+        {
+            SetStatus("Zadejte název role.", true);
+            return;
+        }
+
+        if (await RoleManager.RoleExistsAsync(newRoleName.Trim()))
+        {
+            SetStatus($"Role \"{newRoleName.Trim()}\" již existuje.", true);
+            return;
+        }
+
+        var result = await RoleManager.CreateAsync(new ApplicationRole
+        {
+            Name = newRoleName.Trim(),
+            Category = newRoleCategory,
+        });
+
+        if (result.Succeeded)
+        {
+            SetStatus($"Role \"{newRoleName.Trim()}\" byla vytvořena.", false);
+            newRoleName = "";
+            newRoleCategory = "game";
+            await LoadRolesAsync();
+        }
+        else
+        {
+            SetStatus($"Chyba: {string.Join("; ", result.Errors.Select(e => e.Description))}", true);
+        }
+    }
+
+    private void StartEdit(RoleEntry entry)
+    {
+        editingRoleId = entry.Id;
+        editRoleName = entry.Name;
+        editRoleCategory = entry.Category;
+        confirmDeleteId = null;
+    }
+
+    private void CancelEdit()
+    {
+        editingRoleId = null;
+    }
+
+    private async Task SaveEditAsync()
+    {
+        if (string.IsNullOrWhiteSpace(editRoleName))
+        {
+            SetStatus("Název role nesmí být prázdný.", true);
+            return;
+        }
+
+        var role = await RoleManager.FindByIdAsync(editingRoleId!);
+        if (role is null)
+        {
+            SetStatus("Role nebyla nalezena.", true);
+            editingRoleId = null;
+            await LoadRolesAsync();
+            return;
+        }
+
+        var oldName = role.Name!;
+        var newName = editRoleName.Trim();
+
+        // Check if another role with the new name already exists
+        if (!string.Equals(oldName, newName, StringComparison.OrdinalIgnoreCase)
+            && await RoleManager.RoleExistsAsync(newName))
+        {
+            SetStatus($"Role \"{newName}\" již existuje.", true);
+            return;
+        }
+
+        role.Name = newName;
+        role.Category = editRoleCategory;
+
+        var result = await RoleManager.UpdateAsync(role);
+        if (result.Succeeded)
+        {
+            SetStatus($"Role \"{newName}\" byla uložena.", false);
+            editingRoleId = null;
+            await LoadRolesAsync();
+        }
+        else
+        {
+            SetStatus($"Chyba: {string.Join("; ", result.Errors.Select(e => e.Description))}", true);
+        }
+    }
+
+    private void ConfirmDelete(string roleId)
+    {
+        confirmDeleteId = roleId;
+        editingRoleId = null;
+    }
+
+    private void CancelDelete()
+    {
+        confirmDeleteId = null;
+    }
+
+    private async Task DeleteRoleAsync(string roleId)
+    {
+        var role = await RoleManager.FindByIdAsync(roleId);
+        if (role is null)
+        {
+            SetStatus("Role nebyla nalezena.", true);
+            confirmDeleteId = null;
+            await LoadRolesAsync();
+            return;
+        }
+
+        if (ProtectedRoleNames.Contains(role.Name!, StringComparer.OrdinalIgnoreCase))
+        {
+            SetStatus("Systémovou roli nelze smazat.", true);
+            confirmDeleteId = null;
+            return;
+        }
+
+        // Remove all users from the role first
+        var usersInRole = await UserManager.GetUsersInRoleAsync(role.Name!);
+        foreach (var user in usersInRole)
+        {
+            await UserManager.RemoveFromRoleAsync(user, role.Name!);
+        }
+
+        var result = await RoleManager.DeleteAsync(role);
+        if (result.Succeeded)
+        {
+            SetStatus($"Role \"{role.Name}\" byla smazána ({usersInRole.Count} uživatelů odebráno).", false);
+        }
+        else
+        {
+            SetStatus($"Chyba: {string.Join("; ", result.Errors.Select(e => e.Description))}", true);
+        }
+
+        confirmDeleteId = null;
+        await LoadRolesAsync();
+    }
+
+    private void SetStatus(string message, bool error)
+    {
+        statusMessage = message;
+        isError = error;
+    }
+
+    private void ClearStatus()
+    {
+        statusMessage = null;
+    }
+
+    private static string CategoryLabel(string category) => category switch
+    {
+        "system" => "Systémová",
+        "game" => "Herní",
+        "staff" => "Organizační",
+        _ => category,
+    };
+
+    private static string CategoryBadgeClass(string category) => category switch
+    {
+        "system" => "bg-secondary",
+        "game" => "bg-info text-dark",
+        "staff" => "bg-warning text-dark",
+        _ => "bg-light text-dark",
+    };
+
+    private sealed class RoleEntry
+    {
+        public required string Id { get; init; }
+        public required string Name { get; init; }
+        public required string Category { get; init; }
+        public required int UserCount { get; init; }
+        public required bool IsProtected { get; init; }
+    }
+}

--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/Roles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/Roles.razor
@@ -175,29 +175,42 @@
     private async Task LoadRolesAsync()
     {
         var allRoles = RoleManager.Roles.ToList();
-        var entries = new List<RoleEntry>();
 
-        foreach (var role in allRoles)
+        var countTasks = allRoles.Select(async role =>
         {
             var usersInRole = await UserManager.GetUsersInRoleAsync(role.Name!);
-            entries.Add(new RoleEntry
-            {
-                Id = role.Id,
-                Name = role.Name!,
-                Category = role.Category,
-                UserCount = usersInRole.Count,
-                IsProtected = ProtectedRoleNames.Contains(role.Name!, StringComparer.OrdinalIgnoreCase),
-            });
-        }
+            return (Role: role, Count: usersInRole.Count);
+        });
 
-        roleEntries = entries.OrderBy(r => r.Name).ToList();
+        var results = await Task.WhenAll(countTasks);
+
+        roleEntries = results
+            .Select(r => new RoleEntry
+            {
+                Id = r.Role.Id,
+                Name = r.Role.Name!,
+                Category = r.Role.Category,
+                UserCount = r.Count,
+                IsProtected = r.Role.Category == "system"
+                    || ProtectedRoleNames.Contains(r.Role.Name!, StringComparer.OrdinalIgnoreCase),
+            })
+            .OrderBy(r => r.Name)
+            .ToList();
     }
+
+    private static readonly string[] AllowedNewCategories = ["game", "staff"];
 
     private async Task CreateRoleAsync()
     {
         if (string.IsNullOrWhiteSpace(newRoleName))
         {
             SetStatus("Zadejte název role.", true);
+            return;
+        }
+
+        if (!AllowedNewCategories.Contains(newRoleCategory, StringComparer.OrdinalIgnoreCase))
+        {
+            SetStatus("Novou roli lze vytvořit pouze v kategorii Herní nebo Organizační.", true);
             return;
         }
 
@@ -256,6 +269,20 @@
             return;
         }
 
+        if (role.Category == "system"
+            || ProtectedRoleNames.Contains(role.Name!, StringComparer.OrdinalIgnoreCase))
+        {
+            SetStatus("Systémovou roli nelze upravovat.", true);
+            editingRoleId = null;
+            return;
+        }
+
+        if (!AllowedNewCategories.Contains(editRoleCategory, StringComparer.OrdinalIgnoreCase))
+        {
+            SetStatus("Kategorie role musí být Herní nebo Organizační.", true);
+            return;
+        }
+
         var oldName = role.Name!;
         var newName = editRoleName.Trim();
 
@@ -305,18 +332,27 @@
             return;
         }
 
-        if (ProtectedRoleNames.Contains(role.Name!, StringComparer.OrdinalIgnoreCase))
+        if (role.Category == "system"
+            || ProtectedRoleNames.Contains(role.Name!, StringComparer.OrdinalIgnoreCase))
         {
             SetStatus("Systémovou roli nelze smazat.", true);
             confirmDeleteId = null;
             return;
         }
 
-        // Remove all users from the role first
+        // Remove all users from the role first, checking each result
         var usersInRole = await UserManager.GetUsersInRoleAsync(role.Name!);
         foreach (var user in usersInRole)
         {
-            await UserManager.RemoveFromRoleAsync(user, role.Name!);
+            var removeResult = await UserManager.RemoveFromRoleAsync(user, role.Name!);
+            if (!removeResult.Succeeded)
+            {
+                SetStatus($"Chyba při odebírání uživatele \"{user.Email}\" z role: " +
+                    $"{string.Join("; ", removeResult.Errors.Select(e => e.Description))}", true);
+                confirmDeleteId = null;
+                await LoadRolesAsync();
+                return;
+            }
         }
 
         var result = await RoleManager.DeleteAsync(role);

--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/UserManagement.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/UserManagement.razor
@@ -113,6 +113,11 @@
                                             <td>@FormatLastLogin(user.LastLoginAtUtc)</td>
                                             <td class="text-end">
                                                 <div class="d-flex flex-wrap justify-content-end gap-1">
+                                                    <a href="@($"/admin/users/{user.Id}/roles")"
+                                                       class="btn btn-sm btn-outline-info"
+                                                       data-testid="@($"manage-roles-{user.Id}")">
+                                                        Role
+                                                    </a>
                                                     <form method="post" action="/admin/organizatori/@user.Id/organizator">
                                                         <AntiforgeryToken />
                                                         <button type="submit"
@@ -193,6 +198,11 @@
                                             <td>@FormatLastLogin(user.LastLoginAtUtc)</td>
                                             <td class="text-end">
                                                 <div class="d-flex flex-wrap justify-content-end gap-1">
+                                                    <a href="@($"/admin/users/{user.Id}/roles")"
+                                                       class="btn btn-sm btn-outline-info"
+                                                       data-testid="@($"manage-roles-{user.Id}")">
+                                                        Role
+                                                    </a>
                                                     <form method="post" action="/admin/organizatori/@user.Id/organizator">
                                                         <AntiforgeryToken />
                                                         <button type="submit"

--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/UserRoles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/UserRoles.razor
@@ -50,20 +50,23 @@
 
                     @if (roleGroups is not null)
                     {
-                        @foreach (var group in roleGroups)
+                        @for (var gi = 0; gi < roleGroups.Count; gi++)
                         {
+                            var group = roleGroups[gi];
                             <h3 class="h5 mt-3 mb-2">@group.Label</h3>
                             <div class="row g-2 mb-3">
-                                @foreach (var role in group.Roles)
+                                @for (var ri = 0; ri < group.Roles.Count; ri++)
                                 {
+                                    var role = group.Roles[ri];
+                                    var checkboxId = $"role-{gi}-{ri}";
                                     <div class="col-md-4 col-lg-3">
                                         <div class="form-check">
                                             <input class="form-check-input"
                                                    type="checkbox"
-                                                   id="@($"role-{role.Name}")"
+                                                   id="@checkboxId"
                                                    checked="@role.IsAssigned"
                                                    @onchange="(e) => ToggleRole(role, (bool)e.Value!)" />
-                                            <label class="form-check-label" for="@($"role-{role.Name}")">
+                                            <label class="form-check-label" for="@checkboxId">
                                                 @role.Name
                                             </label>
                                         </div>
@@ -177,6 +180,18 @@
             {
                 SetStatus("Nebyly provedeny žádné změny.", false);
                 return;
+            }
+
+            // Last admin safeguard: if removing Admin role, ensure another active admin exists
+            if (toRemove.Contains(RoleNames.Admin, StringComparer.OrdinalIgnoreCase))
+            {
+                var admins = await UserManager.GetUsersInRoleAsync(RoleNames.Admin);
+                var otherActiveAdmins = admins.Count(u => u.IsActive && u.Id != user.Id);
+                if (otherActiveAdmins == 0)
+                {
+                    SetStatus("Posledního aktivního správce nelze odebrat. Nejprve přidejte jiného správce.", true);
+                    return;
+                }
             }
 
             if (toRemove.Count > 0)

--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/UserRoles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/UserRoles.razor
@@ -1,0 +1,234 @@
+@page "/admin/users/{UserId}/roles"
+@attribute [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
+@rendermode InteractiveServer
+
+@inject RoleManager<ApplicationRole> RoleManager
+@inject UserManager<ApplicationUser> UserManager
+@inject NavigationManager Navigation
+
+<PageTitle>Role uživatele</PageTitle>
+
+<div class="row g-4">
+    <div class="col-12">
+        <section class="card shadow-sm">
+            <div class="card-body p-4">
+                @if (user is null)
+                {
+                    @if (notFound)
+                    {
+                        <div class="alert alert-danger">Uživatel nebyl nalezen.</div>
+                        <a href="/admin/organizatori" class="btn btn-outline-secondary">
+                            <i class="bi bi-arrow-left me-1"></i>Zpět na seznam
+                        </a>
+                    }
+                    else
+                    {
+                        <p class="text-secondary">Načítám...</p>
+                    }
+                }
+                else
+                {
+                    <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 mb-4">
+                        <div>
+                            <h1 class="h3 mb-1">Role uživatele: @userDisplayName</h1>
+                            <p class="text-secondary mb-0">@user.Email</p>
+                        </div>
+                        <div>
+                            <a href="/admin/organizatori" class="btn btn-outline-secondary">
+                                <i class="bi bi-arrow-left me-1"></i>Zpět na seznam
+                            </a>
+                        </div>
+                    </div>
+
+                    @if (!string.IsNullOrEmpty(statusMessage))
+                    {
+                        <div class="alert @(isError ? "alert-danger" : "alert-success") alert-dismissible fade show" role="alert">
+                            @statusMessage
+                            <button type="button" class="btn-close" @onclick="ClearStatus"></button>
+                        </div>
+                    }
+
+                    @if (roleGroups is not null)
+                    {
+                        @foreach (var group in roleGroups)
+                        {
+                            <h3 class="h5 mt-3 mb-2">@group.Label</h3>
+                            <div class="row g-2 mb-3">
+                                @foreach (var role in group.Roles)
+                                {
+                                    <div class="col-md-4 col-lg-3">
+                                        <div class="form-check">
+                                            <input class="form-check-input"
+                                                   type="checkbox"
+                                                   id="@($"role-{role.Name}")"
+                                                   checked="@role.IsAssigned"
+                                                   @onchange="(e) => ToggleRole(role, (bool)e.Value!)" />
+                                            <label class="form-check-label" for="@($"role-{role.Name}")">
+                                                @role.Name
+                                            </label>
+                                        </div>
+                                    </div>
+                                }
+                            </div>
+                        }
+
+                        <hr class="my-3" />
+                        <div class="d-flex gap-2">
+                            <button class="btn btn-primary" @onclick="SaveChangesAsync" disabled="@saving">
+                                @if (saving)
+                                {
+                                    <span class="spinner-border spinner-border-sm me-1" role="status"></span>
+                                }
+                                Uložit změny
+                            </button>
+                            <a href="/admin/organizatori" class="btn btn-outline-secondary">Zrušit</a>
+                        </div>
+                    }
+                }
+            </div>
+        </section>
+    </div>
+</div>
+
+@code {
+    private static readonly (string Key, string Label)[] CategoryOrder =
+    [
+        ("system", "Systémové role"),
+        ("game", "Herní role"),
+        ("staff", "Organizační role"),
+    ];
+
+    [Parameter]
+    public string UserId { get; set; } = "";
+
+    private ApplicationUser? user;
+    private string userDisplayName = "";
+    private bool notFound;
+    private bool saving;
+
+    private List<RoleGroupViewModel>? roleGroups;
+    private HashSet<string> originalRoles = [];
+    private HashSet<string> selectedRoles = [];
+
+    // Status
+    private string? statusMessage;
+    private bool isError;
+
+    protected override async Task OnInitializedAsync()
+    {
+        user = await UserManager.FindByIdAsync(UserId);
+        if (user is null)
+        {
+            notFound = true;
+            return;
+        }
+
+        userDisplayName = !string.IsNullOrWhiteSpace(user.DisplayName)
+            ? user.DisplayName
+            : user.Email ?? user.UserName ?? UserId;
+
+        var userRoles = await UserManager.GetRolesAsync(user);
+        originalRoles = new HashSet<string>(userRoles, StringComparer.OrdinalIgnoreCase);
+        selectedRoles = new HashSet<string>(userRoles, StringComparer.OrdinalIgnoreCase);
+
+        var allRoles = RoleManager.Roles.ToList();
+
+        roleGroups = CategoryOrder
+            .Select(cat => new RoleGroupViewModel
+            {
+                Label = cat.Label,
+                Roles = allRoles
+                    .Where(r => r.Category == cat.Key)
+                    .OrderBy(r => r.Name)
+                    .Select(r => new RoleViewModel
+                    {
+                        Name = r.Name!,
+                        IsAssigned = selectedRoles.Contains(r.Name!),
+                    })
+                    .ToList(),
+            })
+            .Where(g => g.Roles.Count > 0)
+            .ToList();
+    }
+
+    private void ToggleRole(RoleViewModel role, bool isChecked)
+    {
+        role.IsAssigned = isChecked;
+
+        if (isChecked)
+            selectedRoles.Add(role.Name);
+        else
+            selectedRoles.Remove(role.Name);
+    }
+
+    private async Task SaveChangesAsync()
+    {
+        if (user is null) return;
+
+        saving = true;
+        ClearStatus();
+
+        try
+        {
+            var toAdd = selectedRoles.Except(originalRoles, StringComparer.OrdinalIgnoreCase).ToList();
+            var toRemove = originalRoles.Except(selectedRoles, StringComparer.OrdinalIgnoreCase).ToList();
+
+            if (toAdd.Count == 0 && toRemove.Count == 0)
+            {
+                SetStatus("Nebyly provedeny žádné změny.", false);
+                return;
+            }
+
+            if (toRemove.Count > 0)
+            {
+                var removeResult = await UserManager.RemoveFromRolesAsync(user, toRemove);
+                if (!removeResult.Succeeded)
+                {
+                    SetStatus($"Chyba při odebírání rolí: {string.Join("; ", removeResult.Errors.Select(e => e.Description))}", true);
+                    return;
+                }
+            }
+
+            if (toAdd.Count > 0)
+            {
+                var addResult = await UserManager.AddToRolesAsync(user, toAdd);
+                if (!addResult.Succeeded)
+                {
+                    SetStatus($"Chyba při přidávání rolí: {string.Join("; ", addResult.Errors.Select(e => e.Description))}", true);
+                    return;
+                }
+            }
+
+            // Update baseline so subsequent saves diff correctly
+            originalRoles = new HashSet<string>(selectedRoles, StringComparer.OrdinalIgnoreCase);
+            SetStatus("Role byly aktualizovány.", false);
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private void SetStatus(string message, bool error)
+    {
+        statusMessage = message;
+        isError = error;
+    }
+
+    private void ClearStatus()
+    {
+        statusMessage = null;
+    }
+
+    private sealed class RoleGroupViewModel
+    {
+        public required string Label { get; init; }
+        public required List<RoleViewModel> Roles { get; init; }
+    }
+
+    private sealed class RoleViewModel
+    {
+        public required string Name { get; init; }
+        public bool IsAssigned { get; set; }
+    }
+}

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.7.9</Version>
+    <Version>0.8.0</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
- **Role list** (`/admin/roles`): roles grouped by category (system/game/staff), create/edit/delete for non-system roles, user count per role
- **User role assignment** (`/admin/users/{id}/roles`): checkboxes grouped by category, diff-based save
- "Role" button on each user row in user management
- Admin nav link added
- Version 0.8.0

## Test plan
- [ ] CI passes
- [ ] /admin/roles shows roles grouped by category
- [ ] Can create/edit/delete game and staff roles
- [ ] System roles show as protected (no edit/delete)
- [ ] /admin/users/{id}/roles shows checkboxes, save works
- [ ] "Role" button on user management navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)