### PR TITLE
feat(auth): persistent OIDC signing keys for production

### DIFF
--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -197,8 +197,16 @@ public class Program
                 options.SetAccessTokenLifetime(TimeSpan.FromMinutes(30));
                 options.SetRefreshTokenLifetime(TimeSpan.FromDays(30));
 
-                options.AddEphemeralEncryptionKey()
-                    .AddEphemeralSigningKey();
+                if (builder.Environment.IsDevelopment() || builder.Environment.IsEnvironment("Testing"))
+                {
+                    options.AddEphemeralEncryptionKey()
+                        .AddEphemeralSigningKey();
+                }
+                else
+                {
+                    // Persistent keys via Data Protection — survives app restarts
+                    options.UseDataProtection();
+                }
 
                 options.UseAspNetCore()
                     .EnableAuthorizationEndpointPassthrough()


### PR DESCRIPTION
## Summary
- Production uses Data Protection for OIDC token signing/encryption (keys persisted in DB)
- Dev/Testing keeps ephemeral keys
- Tokens now survive app restarts in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)