### PR TITLE
fix: roles page DbContext concurrency crash

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/Roles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/Roles.razor
@@ -175,27 +175,23 @@
     private async Task LoadRolesAsync()
     {
         var allRoles = RoleManager.Roles.ToList();
+        var entries = new List<RoleEntry>();
 
-        var countTasks = allRoles.Select(async role =>
+        foreach (var role in allRoles)
         {
             var usersInRole = await UserManager.GetUsersInRoleAsync(role.Name!);
-            return (Role: role, Count: usersInRole.Count);
-        });
-
-        var results = await Task.WhenAll(countTasks);
-
-        roleEntries = results
-            .Select(r => new RoleEntry
+            entries.Add(new RoleEntry
             {
-                Id = r.Role.Id,
-                Name = r.Role.Name!,
-                Category = r.Role.Category,
-                UserCount = r.Count,
-                IsProtected = r.Role.Category == "system"
-                    || ProtectedRoleNames.Contains(r.Role.Name!, StringComparer.OrdinalIgnoreCase),
-            })
-            .OrderBy(r => r.Name)
-            .ToList();
+                Id = role.Id,
+                Name = role.Name!,
+                Category = role.Category,
+                UserCount = usersInRole.Count,
+                IsProtected = role.Category == "system"
+                    || ProtectedRoleNames.Contains(role.Name!, StringComparer.OrdinalIgnoreCase),
+            });
+        }
+
+        roleEntries = entries.OrderBy(r => r.Name).ToList();
     }
 
     private static readonly string[] AllowedNewCategories = ["game", "staff"];


### PR DESCRIPTION
## Summary
- Revert Task.WhenAll parallel user count loading to sequential foreach
- GetUsersInRoleAsync shares the scoped DbContext, can't run in parallel

## Test plan
- [ ] CI passes
- [ ] /admin/roles loads without Blazor error

🤖 Generated with [Claude Code](https://claude.com/claude-code)