### PR TITLE
fix: show guest login error detail for diagnosis

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
+++ b/src/RegistraceOvcina.Web/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
@@ -241,7 +241,8 @@ internal static class IdentityComponentsEndpointRouteBuilderExtensions
             catch (Exception ex)
             {
                 logger.LogError(ex, "Failed to create/sign-in guest user '{DisplayName}'", displayName);
-                var errorRedirect = "/Account/GuestLogin?error=create-failed";
+                var detail = Uri.EscapeDataString(ex.Message);
+                var errorRedirect = $"/Account/GuestLogin?error=create-failed&detail={detail}";
                 if (!string.IsNullOrWhiteSpace(returnUrl))
                     errorRedirect += $"&ReturnUrl={Uri.EscapeDataString(returnUrl)}";
                 return Results.Redirect(errorRedirect);

--- a/src/RegistraceOvcina.Web/Components/Account/Pages/GuestLogin.razor
+++ b/src/RegistraceOvcina.Web/Components/Account/Pages/GuestLogin.razor
@@ -34,6 +34,10 @@
             {
                 <div class="alert alert-danger" role="alert">
                     Nepodařilo se vytvořit hostovský účet. Zkuste to prosím znovu.
+                    @if (!string.IsNullOrWhiteSpace(detail))
+                    {
+                        <div class="small mt-1 text-break">@detail</div>
+                    }
                 </div>
             }
 
@@ -75,4 +79,7 @@
 
     [SupplyParameterFromQuery(Name = "error")]
     private string? error { get; set; }
+
+    [SupplyParameterFromQuery(Name = "detail")]
+    private string? detail { get; set; }
 }


### PR DESCRIPTION
## Summary
- Pass exception message as `detail` query param on guest login failure
- Display it in the error alert on the GuestLogin page
- Needed to diagnose production create-failed error

## Test plan
- [ ] CI passes
- [ ] Try guest login — see actual error message instead of generic "create failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)