### PR TITLE
fix: guest login crash on empty returnUrl

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
+++ b/src/RegistraceOvcina.Web/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
@@ -236,7 +236,7 @@ internal static class IdentityComponentsEndpointRouteBuilderExtensions
                 logger.LogInformation("Guest user '{DisplayName}' signed in (UserId={UserId})",
                     user.DisplayName, user.Id);
 
-                return Results.LocalRedirect(returnUrl ?? "~/");
+                return Results.LocalRedirect(string.IsNullOrWhiteSpace(returnUrl) ? "~/" : returnUrl);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- `returnUrl` was empty string, `?? "~/"` didn't catch it, `Results.LocalRedirect("")` threw
- Use `string.IsNullOrWhiteSpace(returnUrl) ? "~/" : returnUrl`

## Test plan
- [ ] CI passes
- [ ] Guest login with PIN works — redirects to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)