### PR TITLE
[v0.8.1] feat: game statistics dashboard

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Layout/MainLayout.razor
+++ b/src/RegistraceOvcina.Web/Components/Layout/MainLayout.razor
@@ -33,6 +33,7 @@
                             <a class="nav-link" href="/organizace/role">Role</a>
                             <a class="nav-link" href="/organizace/strava">Strava</a>
                             <a class="nav-link" href="/organizace/posta">Pošta</a>
+                            <a class="nav-link" href="/organizace/statistiky">Statistiky</a>
                             <span class="nav-divider"></span>
                             <a class="nav-link" href="/organizace/osoby">Osoby</a>
                         </Authorized>

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameStatsPage.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameStatsPage.razor
@@ -1,0 +1,352 @@
+@page "/organizace/hry/{gameId:int}/statistiky"
+@attribute [Authorize(Policy = AuthorizationPolicies.StaffOnly)]
+
+@using RegistraceOvcina.Web.Features.Stats
+
+@inject GameStatsService StatsService
+
+<PageTitle>Statistiky — @(stats?.GameName ?? "Načítání…")</PageTitle>
+
+@if (stats is null)
+{
+    <div class="text-center py-5">
+        <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Načítání…</span>
+        </div>
+    </div>
+}
+else
+{
+    <h2 class="mb-1">@stats.GameName</h2>
+    <p class="text-secondary mb-4">Statistiky registrací</p>
+
+    @* ────────── Hero KPI Cards ────────── *@
+    <div class="row g-3 mb-4">
+        @{ var attendeePercent = stats.PlayerCount > 0 && stats.SubmittedCount > 0 ? 100 : 0; }
+        <div class="col-md-3">
+            <div class="card shadow-sm border-start border-4 border-primary">
+                <div class="card-body">
+                    <h2 class="mb-0">@stats.TotalAttendees</h2>
+                    <span class="text-secondary">účastníků</span>
+                    <div class="small text-muted mt-1">@stats.SubmittedCount odeslaných přihlášek</div>
+                </div>
+            </div>
+        </div>
+
+        @{
+            var paymentPercent = stats.ExpectedTotal > 0 ? (int)Math.Round((double)stats.PaidTotal / (double)stats.ExpectedTotal * 100) : 0;
+            var paymentBorder = paymentPercent >= 90 ? "border-success" : paymentPercent >= 50 ? "border-warning" : "border-danger";
+        }
+        <div class="col-md-3">
+            <div class="card shadow-sm border-start border-4 @paymentBorder">
+                <div class="card-body">
+                    <h2 class="mb-0">@paymentPercent %</h2>
+                    <span class="text-secondary">zaplaceno</span>
+                    <div class="small text-muted mt-1">@stats.PaidTotal.ToString("N0") / @stats.ExpectedTotal.ToString("N0") Kč</div>
+                </div>
+            </div>
+        </div>
+
+        @{
+            var indoorTotal = stats.LodgingIndoor;
+            var indoorHoused = stats.RoomsAssigned;
+            var indoorPercent = indoorTotal > 0 ? (int)Math.Round((double)indoorHoused / indoorTotal * 100) : 0;
+            var indoorBorder = indoorPercent >= 90 ? "border-success" : indoorPercent >= 50 ? "border-warning" : "border-danger";
+        }
+        <div class="col-md-3">
+            <div class="card shadow-sm border-start border-4 @indoorBorder">
+                <div class="card-body">
+                    <h2 class="mb-0">@indoorHoused / @indoorTotal</h2>
+                    <span class="text-secondary">ubytovaných uvnitř</span>
+                    <div class="small text-muted mt-1">kapacita pokojů: @stats.RoomsTotal</div>
+                </div>
+            </div>
+        </div>
+
+        @{
+            var kingdomTotal = stats.PlayerCount;
+            var kingdomAssigned = kingdomTotal - stats.KingdomUnassigned;
+            var kingdomPercent = kingdomTotal > 0 ? (int)Math.Round((double)kingdomAssigned / kingdomTotal * 100) : 0;
+            var kingdomBorder = kingdomPercent >= 90 ? "border-success" : kingdomPercent >= 50 ? "border-warning" : "border-danger";
+        }
+        <div class="col-md-3">
+            <div class="card shadow-sm border-start border-4 @kingdomBorder">
+                <div class="card-body">
+                    <h2 class="mb-0">@kingdomAssigned / @kingdomTotal</h2>
+                    <span class="text-secondary">hráčů v království</span>
+                    <div class="small text-muted mt-1">@stats.KingdomUnassigned nepřiřazených</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @* ────────── Action Items ────────── *@
+    @if (stats.UnpaidSubmissionCount > 0 || stats.PlayersWithoutKingdom > 0 || stats.IndoorWithoutRoom > 0)
+    {
+        <div class="mb-4">
+            @if (stats.UnpaidSubmissionCount > 0)
+            {
+                <div class="alert alert-danger d-flex align-items-center mb-2">
+                    <strong class="me-2">@stats.UnpaidSubmissionCount</strong> přihlášek bez plné platby
+                    <a href="/organizace/platby" class="ms-auto btn btn-sm btn-outline-danger">Platby</a>
+                </div>
+            }
+            @if (stats.PlayersWithoutKingdom > 0)
+            {
+                <div class="alert alert-warning d-flex align-items-center mb-2">
+                    <strong class="me-2">@stats.PlayersWithoutKingdom</strong> hráčů bez království
+                    <a href="/organizace/rozdeleni" class="ms-auto btn btn-sm btn-outline-warning">Rozdělení</a>
+                </div>
+            }
+            @if (stats.IndoorWithoutRoom > 0)
+            {
+                <div class="alert alert-warning d-flex align-items-center mb-2">
+                    <strong class="me-2">@stats.IndoorWithoutRoom</strong> ubytovaných uvnitř bez pokoje
+                    <a href="/organizace/ubytovani" class="ms-auto btn btn-sm btn-outline-warning">Ubytování</a>
+                </div>
+            }
+        </div>
+    }
+
+    <div class="row g-4">
+        @* ────────── Demographics ────────── *@
+        <div class="col-lg-6">
+            <div class="card shadow-sm border-start border-4 border-info mb-4">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Demografie hráčů</h5>
+                    <div class="d-flex gap-3 mb-3">
+                        <span class="badge bg-info text-dark fs-6">Průměrný věk: @stats.AveragePlayerAge</span>
+                        <span class="badge bg-secondary fs-6">Průměrná velikost skupiny: @stats.AverageGroupSize</span>
+                    </div>
+                    @foreach (var bracket in stats.AgeBrackets)
+                    {
+                        var pct = bracket.MaxCount > 0 ? (int)Math.Round((double)bracket.Count / bracket.MaxCount * 100) : 0;
+                        <div class="row align-items-center mb-2">
+                            <div class="col-2 text-end fw-semibold small">@bracket.Label</div>
+                            <div class="col-10">
+                                <div class="progress" style="height: 22px;">
+                                    <div class="progress-bar bg-info" role="progressbar"
+                                         style="width: @(pct)%;" aria-valuenow="@bracket.Count"
+                                         aria-valuemin="0" aria-valuemax="@bracket.MaxCount">
+                                        @bracket.Count
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+
+        @* ────────── Attendee Breakdown ────────── *@
+        <div class="col-lg-6">
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Rozdělení účastníků</h5>
+
+                    <h6 class="text-muted mb-2">Hráči (@stats.PlayerCount)</h6>
+                    <div class="d-flex flex-wrap gap-2 mb-3">
+                        <span class="badge bg-primary">PvP: @stats.PlayerPvp</span>
+                        <span class="badge bg-primary">Samostatní: @stats.PlayerIndependent</span>
+                        <span class="badge bg-primary">S hraničárem: @stats.PlayerWithRanger</span>
+                        <span class="badge bg-primary">S rodičem: @stats.PlayerWithParent</span>
+                    </div>
+
+                    <h6 class="text-muted mb-2">Dospělí (@(stats.AdultNpc + stats.AdultMonster + stats.AdultHelper))</h6>
+                    <div class="d-flex flex-wrap gap-2 mb-3">
+                        <span class="badge bg-secondary">NPC / příšery: @stats.AdultNpc</span>
+                        <span class="badge bg-secondary">Přihlížející: @stats.AdultMonster</span>
+                        <span class="badge bg-secondary">Pomocníci / hraničáři: @stats.AdultHelper</span>
+                    </div>
+
+                    <h6 class="text-muted mb-2">Přihlášky</h6>
+                    <div class="d-flex flex-wrap gap-2">
+                        <span class="badge bg-success">Odeslané: @stats.SubmittedCount</span>
+                        <span class="badge bg-warning text-dark">Koncepty: @stats.DraftCount</span>
+                        <span class="badge bg-danger">Zrušené: @stats.CancelledCount</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        @* ────────── Lodging ────────── *@
+        <div class="col-lg-6">
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Ubytování</h5>
+                    <div class="d-flex flex-wrap gap-2 mb-3">
+                        <span class="badge bg-primary">Uvnitř: @stats.LodgingIndoor</span>
+                        <span class="badge bg-success">Stan: @stats.LodgingTent</span>
+                        <span class="badge bg-info text-dark">Venku: @stats.LodgingOutdoor</span>
+                        <span class="badge bg-secondary">Nespí: @stats.LodgingNotStaying</span>
+                    </div>
+
+                    @if (stats.RoomOccupancies.Count > 0)
+                    {
+                        <h6 class="text-muted mb-2">Pokoje</h6>
+                        @foreach (var room in stats.RoomOccupancies)
+                        {
+                            var roomPct = room.Capacity > 0 ? (int)Math.Round((double)room.Assigned / room.Capacity * 100) : 0;
+                            var roomColor = roomPct >= 100 ? "bg-danger" : roomPct >= 70 ? "bg-warning" : "bg-success";
+                            <div class="d-flex align-items-center mb-2">
+                                <span class="me-2 small fw-semibold" style="min-width: 120px;">@room.RoomName</span>
+                                <div class="progress flex-grow-1" style="height: 18px;">
+                                    <div class="progress-bar @roomColor" role="progressbar"
+                                         style="width: @(Math.Min(roomPct, 100))%;">
+                                    </div>
+                                </div>
+                                <span class="ms-2 small text-muted">@room.Assigned / @room.Capacity</span>
+                            </div>
+                        }
+                    }
+                </div>
+            </div>
+        </div>
+
+        @* ────────── Kingdoms ────────── *@
+        <div class="col-lg-6">
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Království</h5>
+                    @if (stats.Kingdoms.Count > 0)
+                    {
+                        <table class="table table-sm mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Království</th>
+                                    <th style="width:40%;">Obsazení</th>
+                                    <th class="text-end">Počet</th>
+                                    <th class="text-end">Prům. věk</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var k in stats.Kingdoms)
+                                {
+                                    var kPct = k.Target > 0 ? (int)Math.Round((double)k.Assigned / k.Target * 100) : 0;
+                                    <tr>
+                                        <td>
+                                            @if (!string.IsNullOrEmpty(k.Color))
+                                            {
+                                                <span class="d-inline-block rounded-circle me-1" style="width:12px;height:12px;background:@k.Color;"></span>
+                                            }
+                                            @k.Name
+                                        </td>
+                                        <td>
+                                            <div class="progress" style="height: 16px;">
+                                                <div class="progress-bar bg-primary" role="progressbar"
+                                                     style="width: @(Math.Min(kPct, 100))%;">
+                                                </div>
+                                            </div>
+                                        </td>
+                                        <td class="text-end">@k.Assigned / @k.Target</td>
+                                        <td class="text-end">@(k.AverageAge > 0 ? k.AverageAge.ToString("F1") : "—")</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                    else
+                    {
+                        <p class="text-muted mb-0">Žádná království nejsou nastavena.</p>
+                    }
+                </div>
+            </div>
+        </div>
+
+        @* ────────── Financial ────────── *@
+        <div class="col-lg-6">
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Finance</h5>
+                    @{
+                        var finPct = stats.ExpectedTotal > 0 ? (int)Math.Round((double)stats.PaidTotal / (double)stats.ExpectedTotal * 100) : 0;
+                        var finColor = finPct >= 90 ? "bg-success" : finPct >= 50 ? "bg-warning" : "bg-danger";
+                    }
+                    <div class="progress mb-3" style="height: 24px;">
+                        <div class="progress-bar @finColor" role="progressbar"
+                             style="width: @(Math.Min(finPct, 100))%;">
+                            @finPct %
+                        </div>
+                    </div>
+                    <table class="table table-sm mb-0">
+                        <tbody>
+                            <tr>
+                                <td>Očekávaná částka</td>
+                                <td class="text-end fw-semibold">@stats.ExpectedTotal.ToString("N0") Kč</td>
+                            </tr>
+                            <tr>
+                                <td>Zaplaceno</td>
+                                <td class="text-end fw-semibold text-success">@stats.PaidTotal.ToString("N0") Kč</td>
+                            </tr>
+                            <tr>
+                                <td>Zbývá</td>
+                                <td class="text-end fw-semibold text-danger">@((stats.ExpectedTotal - stats.PaidTotal).ToString("N0")) Kč</td>
+                            </tr>
+                            <tr>
+                                <td>Dobrovolné příspěvky</td>
+                                <td class="text-end">@stats.DonationTotal.ToString("N0") Kč</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        @* ────────── Food ────────── *@
+        <div class="col-lg-6">
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <h5 class="card-title mb-3">Stravování</h5>
+                    @if (stats.Meals.Count > 0)
+                    {
+                        var mealsByDay = stats.Meals.GroupBy(m => m.Day).ToList();
+                        <div class="row">
+                            @foreach (var dayGroup in mealsByDay)
+                            {
+                                <div class="col-md-6 mb-3">
+                                    <h6 class="text-muted">@dayGroup.Key</h6>
+                                    <table class="table table-sm mb-0">
+                                        <thead>
+                                            <tr>
+                                                <th>Jídlo</th>
+                                                <th class="text-end">Děti</th>
+                                                <th class="text-end">Dospělí</th>
+                                                <th class="text-end">Celkem</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            @foreach (var meal in dayGroup)
+                                            {
+                                                <tr>
+                                                    <td>@meal.MealName</td>
+                                                    <td class="text-end">@meal.ChildCount</td>
+                                                    <td class="text-end">@meal.AdultCount</td>
+                                                    <td class="text-end fw-semibold">@(meal.ChildCount + meal.AdultCount)</td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="text-muted mb-0">Žádné objednávky jídla.</p>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public int GameId { get; set; }
+
+    private GameStats? stats;
+
+    protected override async Task OnInitializedAsync()
+    {
+        stats = await StatsService.GetGameStatsAsync(GameId);
+    }
+}

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/StatsShortcut.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/StatsShortcut.razor
@@ -1,0 +1,27 @@
+@page "/organizace/statistiky"
+@attribute [Authorize(Policy = AuthorizationPolicies.StaffOnly)]
+
+@inject GameService GameService
+@inject NavigationManager NavigationManager
+
+<PageTitle>Statistiky</PageTitle>
+
+@if (latestGameId is null)
+{
+    <div class="empty-state">Žádná hra není k dispozici.</div>
+}
+
+@code {
+    private int? latestGameId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var games = await GameService.GetAdminGamesAsync();
+        var latest = games.FirstOrDefault();
+        if (latest is not null)
+        {
+            latestGameId = latest.Id;
+            NavigationManager.NavigateTo($"/organizace/hry/{latest.Id}/statistiky", replace: true);
+        }
+    }
+}

--- a/src/RegistraceOvcina.Web/Components/_Imports.razor
+++ b/src/RegistraceOvcina.Web/Components/_Imports.razor
@@ -22,6 +22,7 @@
 @using RegistraceOvcina.Web.Features.Email
 @using RegistraceOvcina.Web.Features.Invitations
 @using RegistraceOvcina.Web.Features.Roles
+@using RegistraceOvcina.Web.Features.Stats
 @using RegistraceOvcina.Web.Security
 @using Microsoft.Extensions.Options
 @using static Microsoft.AspNetCore.Components.Web.RenderMode

--- a/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
+++ b/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
@@ -1,0 +1,307 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Features.Stats;
+
+public sealed class GameStatsService(IDbContextFactory<ApplicationDbContext> dbContextFactory)
+{
+    public async Task<GameStats?> GetGameStatsAsync(int gameId, CancellationToken cancellationToken = default)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var game = await db.Games
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == gameId, cancellationToken);
+
+        if (game is null)
+        {
+            return null;
+        }
+
+        var currentYear = DateTime.UtcNow.Year;
+
+        // --- Submission counts (all statuses, directly from submissions) ---
+        var allSubmissions = await db.RegistrationSubmissions
+            .AsNoTracking()
+            .Where(x => x.GameId == gameId)
+            .Select(x => new { x.Id, x.Status, x.ExpectedTotalAmount, x.VoluntaryDonation })
+            .ToListAsync(cancellationToken);
+
+        var submittedCount = allSubmissions.Count(x => x.Status == SubmissionStatus.Submitted);
+        var draftCount = allSubmissions.Count(x => x.Status == SubmissionStatus.Draft);
+        var cancelledCount = allSubmissions.Count(x => x.Status == SubmissionStatus.Cancelled);
+
+        // --- Active registrations from submitted submissions ---
+        var registrations = await db.Registrations
+            .AsNoTracking()
+            .Include(x => x.Person)
+            .Include(x => x.Submission)
+            .Include(x => x.FoodOrders).ThenInclude(fo => fo.MealOption)
+            .Where(x => x.Submission.GameId == gameId
+                && x.Submission.Status == SubmissionStatus.Submitted
+                && x.Status == RegistrationStatus.Active)
+            .ToListAsync(cancellationToken);
+
+        var totalAttendees = registrations.Count;
+
+        // --- Players by sub-type ---
+        var players = registrations.Where(x => x.AttendeeType == AttendeeType.Player).ToList();
+        var playerCount = players.Count;
+        var playerPvp = players.Count(x => x.PlayerSubType == PlayerSubType.Pvp);
+        var playerIndependent = players.Count(x => x.PlayerSubType == PlayerSubType.Independent);
+        var playerWithRanger = players.Count(x => x.PlayerSubType == PlayerSubType.WithRanger);
+        var playerWithParent = players.Count(x => x.PlayerSubType == PlayerSubType.WithParent);
+
+        // --- Adults by role ---
+        var adults = registrations.Where(x => x.AttendeeType == AttendeeType.Adult).ToList();
+        var adultNpc = adults.Count(x => x.AdultRoles.HasFlag(AdultRoleFlags.PlayMonster));
+        var adultHelper = adults.Count(x =>
+            x.AdultRoles.HasFlag(AdultRoleFlags.OrganizationHelper)
+            || x.AdultRoles.HasFlag(AdultRoleFlags.TechSupport)
+            || x.AdultRoles.HasFlag(AdultRoleFlags.RangerLeader));
+        var adultMonster = adults.Count(x => x.AdultRoles.HasFlag(AdultRoleFlags.Spectator));
+
+        // --- Demographics ---
+        var playerAges = players.Select(x => currentYear - x.Person.BirthYear).ToList();
+        var averagePlayerAge = playerAges.Count > 0 ? playerAges.Average() : 0;
+
+        var submittedSubmissionIds = allSubmissions
+            .Where(x => x.Status == SubmissionStatus.Submitted)
+            .Select(x => x.Id)
+            .ToHashSet();
+
+        var groupSizes = registrations
+            .Where(x => submittedSubmissionIds.Contains(x.SubmissionId))
+            .GroupBy(x => x.SubmissionId)
+            .Select(g => g.Count())
+            .ToList();
+        var averageGroupSize = groupSizes.Count > 0 ? groupSizes.Average() : 0;
+
+        // --- Age brackets ---
+        var ageBrackets = BuildAgeBrackets(playerAges);
+
+        // --- Lodging ---
+        var lodgingIndoor = registrations.Count(x => x.LodgingPreference == LodgingPreference.Indoor);
+        var lodgingTent = registrations.Count(x => x.LodgingPreference == LodgingPreference.OwnTent);
+        var lodgingOutdoor = registrations.Count(x => x.LodgingPreference == LodgingPreference.CampOutdoor);
+        var lodgingNotStaying = registrations.Count(x => x.LodgingPreference == LodgingPreference.NotStaying);
+
+        // --- Room occupancy ---
+        var gameRooms = await db.GameRooms
+            .AsNoTracking()
+            .Include(x => x.Room)
+            .Where(x => x.GameId == gameId)
+            .OrderBy(x => x.Room.Name)
+            .ToListAsync(cancellationToken);
+
+        var roomAssignments = registrations
+            .Where(x => x.AssignedGameRoomId.HasValue)
+            .GroupBy(x => x.AssignedGameRoomId!.Value)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var roomOccupancies = gameRooms.Select(gr => new RoomOccupancy(
+            gr.Room.Name,
+            roomAssignments.GetValueOrDefault(gr.Id),
+            gr.Capacity)).ToList();
+
+        var roomsAssigned = roomAssignments.Values.Sum();
+        var roomsTotal = gameRooms.Sum(x => x.Capacity);
+
+        // --- Kingdoms ---
+        var kingdomTargets = await db.GameKingdomTargets
+            .AsNoTracking()
+            .Include(x => x.Kingdom)
+            .Where(x => x.GameId == gameId)
+            .OrderBy(x => x.Kingdom.Name)
+            .ToListAsync(cancellationToken);
+
+        var appearances = await db.CharacterAppearances
+            .AsNoTracking()
+            .Include(x => x.Registration!).ThenInclude(r => r.Person)
+            .Where(x => x.GameId == gameId
+                && x.RegistrationId != null
+                && x.AssignedKingdomId != null)
+            .ToListAsync(cancellationToken);
+
+        var assignmentsByKingdom = appearances
+            .Where(x => x.Registration is not null)
+            .GroupBy(x => x.AssignedKingdomId!.Value)
+            .ToDictionary(
+                g => g.Key,
+                g => g.ToList());
+
+        var kingdoms = kingdomTargets.Select(kt =>
+        {
+            var assigned = assignmentsByKingdom.GetValueOrDefault(kt.KingdomId, []);
+            var ages = assigned
+                .Where(a => a.Registration?.Person is not null)
+                .Select(a => currentYear - a.Registration!.Person.BirthYear)
+                .ToList();
+            return new KingdomStat(
+                kt.Kingdom.DisplayName,
+                kt.Kingdom.Color,
+                assigned.Count,
+                kt.TargetPlayerCount,
+                ages.Count > 0 ? Math.Round(ages.Average(), 1) : 0);
+        }).ToList();
+
+        var totalAssignedPlayers = appearances.Count;
+        var kingdomUnassigned = playerCount - totalAssignedPlayers;
+
+        // --- Financial ---
+        var submittedSubmissions = await db.RegistrationSubmissions
+            .AsNoTracking()
+            .Include(x => x.Payments)
+            .Where(x => x.GameId == gameId && x.Status == SubmissionStatus.Submitted)
+            .ToListAsync(cancellationToken);
+
+        var expectedTotal = submittedSubmissions.Sum(x => x.ExpectedTotalAmount);
+        var paidTotal = submittedSubmissions.Sum(x => x.Payments.Sum(p => p.Amount));
+        var donationTotal = submittedSubmissions.Sum(x => x.VoluntaryDonation);
+        var unpaidSubmissionCount = submittedSubmissions
+            .Count(x => x.Payments.Sum(p => p.Amount) < x.ExpectedTotalAmount && x.ExpectedTotalAmount > 0);
+
+        // --- Food / Meals ---
+        var allFoodOrders = registrations.SelectMany(x => x.FoodOrders).ToList();
+        var meals = allFoodOrders
+            .GroupBy(fo => new { Day = fo.MealDayUtc.Date, MealName = fo.MealOption.Name })
+            .OrderBy(g => g.Key.Day).ThenBy(g => g.Key.MealName)
+            .Select(g =>
+            {
+                var childCount = g.Count(fo =>
+                    registrations.First(r => r.Id == fo.RegistrationId).AttendeeType == AttendeeType.Player);
+                var adultCount = g.Count() - childCount;
+                return new MealStat(
+                    g.Key.Day.ToString("dd.MM. dddd"),
+                    g.Key.MealName,
+                    childCount,
+                    adultCount);
+            })
+            .ToList();
+
+        // --- Action items ---
+        var indoorWithoutRoom = registrations
+            .Count(x => x.LodgingPreference == LodgingPreference.Indoor && !x.AssignedGameRoomId.HasValue);
+        var playersWithoutKingdom = Math.Max(0, kingdomUnassigned);
+
+        return new GameStats
+        {
+            GameName = game.Name,
+            SubmittedCount = submittedCount,
+            DraftCount = draftCount,
+            CancelledCount = cancelledCount,
+            TotalAttendees = totalAttendees,
+            PlayerCount = playerCount,
+            PlayerPvp = playerPvp,
+            PlayerIndependent = playerIndependent,
+            PlayerWithRanger = playerWithRanger,
+            PlayerWithParent = playerWithParent,
+            AdultNpc = adultNpc,
+            AdultMonster = adultMonster,
+            AdultHelper = adultHelper,
+            AgeBrackets = ageBrackets,
+            AveragePlayerAge = Math.Round(averagePlayerAge, 1),
+            AverageGroupSize = Math.Round(averageGroupSize, 1),
+            LodgingIndoor = lodgingIndoor,
+            LodgingTent = lodgingTent,
+            LodgingOutdoor = lodgingOutdoor,
+            LodgingNotStaying = lodgingNotStaying,
+            RoomsAssigned = roomsAssigned,
+            RoomsTotal = roomsTotal,
+            RoomOccupancies = roomOccupancies,
+            Kingdoms = kingdoms,
+            KingdomUnassigned = playersWithoutKingdom,
+            ExpectedTotal = expectedTotal,
+            PaidTotal = paidTotal,
+            DonationTotal = donationTotal,
+            UnpaidSubmissionCount = unpaidSubmissionCount,
+            Meals = meals,
+            IndoorWithoutRoom = indoorWithoutRoom,
+            PlayersWithoutKingdom = playersWithoutKingdom
+        };
+    }
+
+    private static List<AgeBracket> BuildAgeBrackets(List<int> ages)
+    {
+        var brackets = new (string Label, Func<int, bool> Predicate)[]
+        {
+            ("6–9", a => a >= 6 && a <= 9),
+            ("10–12", a => a >= 10 && a <= 12),
+            ("13–15", a => a >= 13 && a <= 15),
+            ("16–17", a => a >= 16 && a <= 17),
+            ("18+", a => a >= 18)
+        };
+
+        var counts = brackets
+            .Select(b => new { b.Label, Count = ages.Count(b.Predicate) })
+            .ToList();
+
+        var maxCount = counts.Max(x => x.Count);
+        if (maxCount == 0) maxCount = 1; // avoid division by zero
+
+        return counts
+            .Select(x => new AgeBracket(x.Label, x.Count, maxCount))
+            .ToList();
+    }
+}
+
+// --- DTOs ---
+
+public sealed class GameStats
+{
+    public string GameName { get; set; } = "";
+
+    // Registration overview
+    public int SubmittedCount { get; set; }
+    public int DraftCount { get; set; }
+    public int CancelledCount { get; set; }
+    public int TotalAttendees { get; set; }
+
+    // Players by sub-type
+    public int PlayerCount { get; set; }
+    public int PlayerPvp { get; set; }
+    public int PlayerIndependent { get; set; }
+    public int PlayerWithRanger { get; set; }
+    public int PlayerWithParent { get; set; }
+
+    // Adults by type
+    public int AdultNpc { get; set; }
+    public int AdultMonster { get; set; }
+    public int AdultHelper { get; set; }
+
+    // Demographics
+    public List<AgeBracket> AgeBrackets { get; set; } = [];
+    public double AveragePlayerAge { get; set; }
+    public double AverageGroupSize { get; set; }
+
+    // Lodging
+    public int LodgingIndoor { get; set; }
+    public int LodgingTent { get; set; }
+    public int LodgingOutdoor { get; set; }
+    public int LodgingNotStaying { get; set; }
+    public int RoomsAssigned { get; set; }
+    public int RoomsTotal { get; set; }
+    public List<RoomOccupancy> RoomOccupancies { get; set; } = [];
+
+    // Kingdoms
+    public List<KingdomStat> Kingdoms { get; set; } = [];
+    public int KingdomUnassigned { get; set; }
+
+    // Financial
+    public decimal ExpectedTotal { get; set; }
+    public decimal PaidTotal { get; set; }
+    public decimal DonationTotal { get; set; }
+    public int UnpaidSubmissionCount { get; set; }
+
+    // Food
+    public List<MealStat> Meals { get; set; } = [];
+
+    // Action items
+    public int IndoorWithoutRoom { get; set; }
+    public int PlayersWithoutKingdom { get; set; }
+}
+
+public sealed record AgeBracket(string Label, int Count, int MaxCount);
+public sealed record RoomOccupancy(string RoomName, int Assigned, int Capacity);
+public sealed record KingdomStat(string Name, string? Color, int Assigned, int Target, double AverageAge);
+public sealed record MealStat(string Day, string MealName, int ChildCount, int AdultCount);

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -27,6 +27,7 @@ using RegistraceOvcina.Web.Features.Roles;
 using RegistraceOvcina.Web.Features.Announcements;
 using RegistraceOvcina.Web.Features.Auth;
 using RegistraceOvcina.Web.Features.ExternalContacts;
+using RegistraceOvcina.Web.Features.Stats;
 using RegistraceOvcina.Web.Features.Users;
 using RegistraceOvcina.Web.Endpoints;
 using RegistraceOvcina.Web.Security;
@@ -251,6 +252,7 @@ public class Program
         builder.Services.AddScoped<UserAdministrationService>();
         builder.Services.AddScoped<GameRoleService>();
         builder.Services.AddScoped<AnnouncementService>();
+        builder.Services.AddScoped<GameStatsService>();
         builder.Services.Configure<IntegrationApiOptions>(
             builder.Configuration.GetSection(IntegrationApiOptions.SectionName));
 


### PR DESCRIPTION
## Summary
- **Hero cards**: attendees, payment %, rooms, kingdoms — color-coded by status
- **Demographics**: age bracket bar chart, averages
- **Attendee breakdown**: players by sub-type, adults by role
- **Lodging**: counts + per-room progress bars
- **Kingdoms**: table with progress bars + avg age
- **Action items**: unpaid, unassigned players/rooms — clickable links
- **Financial**: expected/paid/remaining with progress bar
- **Food**: meal counts by day, child vs adult
- "Statistiky" in organizer nav

## Test plan
- [ ] CI passes
- [ ] Stats page loads with real data, all sections render
- [ ] Progress bars reflect actual data
- [ ] Action item links navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)