### PR TITLE
fix: baca redirect URI /api/auth/callback

### DIFF
--- a/src/RegistraceOvcina.Web/Data/DatabaseInitializer.cs
+++ b/src/RegistraceOvcina.Web/Data/DatabaseInitializer.cs
@@ -381,8 +381,8 @@ public static class DatabaseInitializer
             ClientType = OpenIddictConstants.ClientTypes.Confidential,
             RedirectUris =
             {
-                new Uri("https://baca.ovcina.cz/auth/callback"),
-                new Uri("http://localhost:3000/auth/callback"),
+                new Uri("https://baca.ovcina.cz/api/auth/callback"),
+                new Uri("http://localhost:3000/api/auth/callback"),
             },
             PostLogoutRedirectUris =
             {


### PR DESCRIPTION
Baca callback must go through /api to reach the backend behind the frontend proxy.