### PR TITLE
fix: revert ephemeral OIDC keys — production crash

### DIFF
--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -199,16 +199,9 @@ public class Program
                 options.SetAccessTokenLifetime(TimeSpan.FromMinutes(30));
                 options.SetRefreshTokenLifetime(TimeSpan.FromDays(30));
 
-                if (builder.Environment.IsDevelopment() || builder.Environment.IsEnvironment("Testing"))
-                {
-                    options.AddEphemeralEncryptionKey()
-                        .AddEphemeralSigningKey();
-                }
-                else
-                {
-                    // Persistent keys via Data Protection — survives app restarts
-                    options.UseDataProtection();
-                }
+                // TODO: replace with persistent keys (needs OpenIddict.Server.DataProtection package)
+                options.AddEphemeralEncryptionKey()
+                    .AddEphemeralSigningKey();
 
                 // Disable access token encryption — client apps validate via JWKS
                 options.DisableAccessTokenEncryption();


### PR DESCRIPTION
## Summary
- **HOTFIX** — production is down with `InvalidOperationException: At least one encryption key must be registered`
- `UseDataProtection()` requires `OpenIddict.Server.DataProtection` package which was not installed
- Reverts to ephemeral signing/encryption keys (pre-PR #118 behavior)

## Root cause
PR #118 switched production to `options.UseDataProtection()` but the `OpenIddict.Server.DataProtection` NuGet package was never added. The method compiled (extension exists in core package) but doesn't actually register keys at runtime.

## Test plan
- [ ] CI passes
- [ ] Production responds 200 after deploy
- [ ] OIDC login flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)