### PR TITLE
[v0.8.2] feat: multi-email linking and user admin page

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Account/Pages/ExternalLogin.razor
+++ b/src/RegistraceOvcina.Web/Components/Account/Pages/ExternalLogin.razor
@@ -177,18 +177,22 @@
                 }
             }
 
-            // Check alternate emails — require confirmation before linking
-            var userEmailService = HttpContext.RequestServices.GetRequiredService<UserEmailService>();
-            var alternateUserId = await userEmailService.ResolveUserIdByEmailAsync(email);
-            if (alternateUserId is not null)
+            // Check alternate emails — require confirmation before linking.
+            // Only when no primary-email user was found, because
+            // ResolveUserIdByEmailAsync also resolves primary emails.
+            if (existingUser is null)
             {
-                // Make sure we didn't already find this user via primary email
-                var alternateUser = await UserManager.FindByIdAsync(alternateUserId);
-                if (alternateUser is not null)
+                var userEmailService = HttpContext.RequestServices.GetRequiredService<UserEmailService>();
+                var alternateUserId = await userEmailService.ResolveUserIdByEmailAsync(email);
+                if (alternateUserId is not null)
                 {
-                    pendingLinkUser = alternateUser;
-                    pendingLinkEmail = email;
-                    return; // Razor will render the confirmation section
+                    var alternateUser = await UserManager.FindByIdAsync(alternateUserId);
+                    if (alternateUser is not null)
+                    {
+                        pendingLinkUser = alternateUser;
+                        pendingLinkEmail = email;
+                        return; // Razor will render the confirmation section
+                    }
                 }
             }
 
@@ -220,6 +224,8 @@
 
     private async Task OnDenyLinkAsync()
     {
+        // Prefill registration form with the provider email before clearing
+        Input.Email = pendingLinkEmail ?? "";
         pendingLinkUser = null;
         pendingLinkEmail = null;
         // Falls through to show normal registration form

--- a/src/RegistraceOvcina.Web/Components/Account/Pages/ExternalLogin.razor
+++ b/src/RegistraceOvcina.Web/Components/Account/Pages/ExternalLogin.razor
@@ -7,6 +7,7 @@
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
 @using RegistraceOvcina.Web.Data
+@using RegistraceOvcina.Web.Features.Users
 @using RegistraceOvcina.Web.Security
 
 @inject SignInManager<ApplicationUser> SignInManager
@@ -30,6 +31,28 @@
     logging in.
 </div>
 
+@if (pendingLinkUser is not null)
+{
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <h4 class="card-title">Nalezen existující účet</h4>
+            <p>Našli jsme účet <strong>@pendingLinkUser.DisplayName</strong> propojený
+               s e-mailovou adresou <strong>@pendingLinkEmail</strong>.</p>
+            <p>Je to váš účet?</p>
+            <div class="d-flex gap-2">
+                <form @formname="confirm-link" @onsubmit="OnConfirmLinkAsync" method="post">
+                    <AntiforgeryToken />
+                    <button type="submit" class="btn btn-primary">Ano, to jsem já</button>
+                </form>
+                <form @formname="deny-link" @onsubmit="OnDenyLinkAsync" method="post">
+                    <AntiforgeryToken />
+                    <button type="submit" class="btn btn-outline-secondary">Ne, vytvořit nový účet</button>
+                </form>
+            </div>
+        </div>
+    </div>
+}
+
 <div class="row">
     <div class="col-md-4">
         <EditForm Model="Input" OnValidSubmit="OnValidSubmitAsync" FormName="confirmation" method="post">
@@ -50,6 +73,8 @@
 
     private string? message;
     private ExternalLoginInfo? externalLoginInfo;
+    private ApplicationUser? pendingLinkUser;
+    private string? pendingLinkEmail;
 
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
@@ -152,12 +177,52 @@
                 }
             }
 
+            // Check alternate emails — require confirmation before linking
+            var userEmailService = HttpContext.RequestServices.GetRequiredService<UserEmailService>();
+            var alternateUserId = await userEmailService.ResolveUserIdByEmailAsync(email);
+            if (alternateUserId is not null)
+            {
+                // Make sure we didn't already find this user via primary email
+                var alternateUser = await UserManager.FindByIdAsync(alternateUserId);
+                if (alternateUser is not null)
+                {
+                    pendingLinkUser = alternateUser;
+                    pendingLinkEmail = email;
+                    return; // Razor will render the confirmation section
+                }
+            }
+
             Input.Email = email;
         }
         else if (externalLoginInfo.Principal.HasClaim(c => c.Type == ClaimTypes.Email))
         {
             Input.Email = externalLoginInfo.Principal.FindFirstValue(ClaimTypes.Email) ?? "";
         }
+    }
+
+    private async Task OnConfirmLinkAsync()
+    {
+        if (pendingLinkUser is not null && externalLoginInfo is not null)
+        {
+            var result = await UserManager.AddLoginAsync(pendingLinkUser, externalLoginInfo);
+            if (result.Succeeded)
+            {
+                Logger.LogInformation("Linked {Provider} to existing account {Email} via alternate email.",
+                    externalLoginInfo.LoginProvider, pendingLinkUser.Email);
+                await SignInManager.SignInAsync(pendingLinkUser, isPersistent: false);
+                RedirectManager.RedirectTo(ReturnUrl);
+                return;
+            }
+        }
+        RedirectManager.RedirectToWithStatus("Account/Login",
+            "Nepodařilo se propojit účet. Zkuste to znovu.", HttpContext);
+    }
+
+    private async Task OnDenyLinkAsync()
+    {
+        pendingLinkUser = null;
+        pendingLinkEmail = null;
+        // Falls through to show normal registration form
     }
 
     private async Task OnValidSubmitAsync()

--- a/src/RegistraceOvcina.Web/Data/ApplicationDbContext.cs
+++ b/src/RegistraceOvcina.Web/Data/ApplicationDbContext.cs
@@ -34,6 +34,7 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
     public DbSet<Announcement> Announcements => Set<Announcement>();
     public DbSet<AnnouncementDismissal> AnnouncementDismissals => Set<AnnouncementDismissal>();
     public DbSet<ExternalContact> ExternalContacts => Set<ExternalContact>();
+    public DbSet<UserEmail> UserEmails => Set<UserEmail>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -426,6 +427,18 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
             entity.HasKey(x => x.Id);
             entity.Property(x => x.Email).HasMaxLength(320).IsRequired();
             entity.HasIndex(x => x.Email).IsUnique();
+        });
+
+        builder.Entity<UserEmail>(entity =>
+        {
+            entity.HasIndex(x => x.NormalizedEmail).IsUnique();
+            entity.HasIndex(x => x.UserId);
+            entity.Property(x => x.Email).HasMaxLength(256).IsRequired();
+            entity.Property(x => x.NormalizedEmail).HasMaxLength(256).IsRequired();
+            entity.HasOne(x => x.User)
+                .WithMany(x => x.AlternateEmails)
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
     }
 }

--- a/src/RegistraceOvcina.Web/Data/ApplicationModels.cs
+++ b/src/RegistraceOvcina.Web/Data/ApplicationModels.cs
@@ -436,3 +436,13 @@ public sealed class GameRoom
     public Game Game { get; set; } = default!;
     public Room Room { get; set; } = default!;
 }
+
+public sealed class UserEmail
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = "";
+    public string Email { get; set; } = "";
+    public string NormalizedEmail { get; set; } = "";
+    public DateTime CreatedAtUtc { get; set; }
+    public ApplicationUser User { get; set; } = default!;
+}

--- a/src/RegistraceOvcina.Web/Data/ApplicationUser.cs
+++ b/src/RegistraceOvcina.Web/Data/ApplicationUser.cs
@@ -15,4 +15,6 @@ public sealed class ApplicationUser : IdentityUser
     public DateTime? LastLoginAtUtc { get; set; }
 
     public DateTime CreatedAtUtc { get; set; }
+
+    public List<UserEmail> AlternateEmails { get; set; } = [];
 }

--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using RegistraceOvcina.Web.Data;
 using RegistraceOvcina.Web.Features.Roles;
+using RegistraceOvcina.Web.Features.Users;
 
 namespace RegistraceOvcina.Web.Features.Integration;
 
@@ -75,6 +76,7 @@ public static class IntegrationApiEndpoints
         group.MapGet("/users/by-email", async (
             string email,
             IDbContextFactory<ApplicationDbContext> dbFactory,
+            UserEmailService userEmailService,
             CancellationToken ct) =>
         {
             if (string.IsNullOrWhiteSpace(email))
@@ -82,12 +84,15 @@ public static class IntegrationApiEndpoints
 
             await using var db = await dbFactory.CreateDbContextAsync(ct);
 
-            var normalizedEmail = email.Trim().ToUpperInvariant();
+            var userId = await userEmailService.ResolveUserIdByEmailAsync(email, ct);
+
+            if (userId is null)
+                return Results.Ok(new { Exists = false, DisplayName = (string?)null, Roles = (List<string>?)null });
 
             var user = await db.Users
                 .AsNoTracking()
-                .Where(u => u.NormalizedEmail == normalizedEmail)
-                .Select(u => new { u.Id, u.DisplayName, u.IsActive })
+                .Where(u => u.Id == userId)
+                .Select(u => new { u.DisplayName, u.IsActive })
                 .FirstOrDefaultAsync(ct);
 
             if (user is null || !user.IsActive)
@@ -95,7 +100,7 @@ public static class IntegrationApiEndpoints
 
             var roles = await db.UserRoles
                 .AsNoTracking()
-                .Where(ur => ur.UserId == user.Id)
+                .Where(ur => ur.UserId == userId)
                 .Join(db.Roles, ur => ur.RoleId, r => r.Id, (ur, r) => r.Name!)
                 .ToListAsync(ct);
 
@@ -107,6 +112,7 @@ public static class IntegrationApiEndpoints
             string email,
             int gameId,
             IDbContextFactory<ApplicationDbContext> dbFactory,
+            UserEmailService userEmailService,
             CancellationToken ct) =>
         {
             if (string.IsNullOrWhiteSpace(email))
@@ -126,6 +132,33 @@ public static class IntegrationApiEndpoints
                     r.Person.Email != null &&
                     r.Person.Email.ToUpper() == normalizedEmail,
                     ct);
+
+            if (!isRegistered)
+            {
+                // Fallback: resolve user by primary + alternate emails, then check by PersonId
+                var userId = await userEmailService.ResolveUserIdByEmailAsync(email, ct);
+                if (userId is not null)
+                {
+                    var personId = await db.Users
+                        .AsNoTracking()
+                        .Where(u => u.Id == userId)
+                        .Select(u => u.PersonId)
+                        .FirstOrDefaultAsync(ct);
+
+                    if (personId.HasValue)
+                    {
+                        isRegistered = await db.Registrations
+                            .AsNoTracking()
+                            .AnyAsync(r =>
+                                r.Submission.GameId == gameId &&
+                                r.Submission.Status == SubmissionStatus.Submitted &&
+                                r.Status == RegistrationStatus.Active &&
+                                !r.Submission.IsDeleted &&
+                                r.PersonId == personId.Value,
+                                ct);
+                    }
+                }
+            }
 
             return Results.Ok(new PresenceCheckDto(isRegistered));
         }).AllowAnonymous();

--- a/src/RegistraceOvcina.Web/Features/Roles/GameRoleService.cs
+++ b/src/RegistraceOvcina.Web/Features/Roles/GameRoleService.cs
@@ -11,9 +11,21 @@ public sealed class GameRoleService(IDbContextFactory<ApplicationDbContext> dbFa
         await using var db = await dbFactory.CreateDbContextAsync();
         var normalizedEmail = email.Trim().ToUpperInvariant();
 
+        var userId = await db.Users.AsNoTracking()
+            .Where(u => u.NormalizedEmail == normalizedEmail)
+            .Select(u => u.Id)
+            .FirstOrDefaultAsync();
+
+        userId ??= await db.UserEmails.AsNoTracking()
+            .Where(ue => ue.NormalizedEmail == normalizedEmail)
+            .Select(ue => ue.UserId)
+            .FirstOrDefaultAsync();
+
+        if (userId is null) return [];
+
         return await db.GameRoles
             .AsNoTracking()
-            .Where(gr => gr.User.NormalizedEmail == normalizedEmail && gr.GameId == gameId)
+            .Where(gr => gr.UserId == userId && gr.GameId == gameId)
             .Select(gr => gr.RoleName)
             .ToListAsync();
     }
@@ -24,10 +36,22 @@ public sealed class GameRoleService(IDbContextFactory<ApplicationDbContext> dbFa
         var normalizedEmail = email.Trim().ToUpperInvariant();
         var normalizedRole = roleName.Trim().ToLowerInvariant();
 
+        var userId = await db.Users.AsNoTracking()
+            .Where(u => u.NormalizedEmail == normalizedEmail)
+            .Select(u => u.Id)
+            .FirstOrDefaultAsync();
+
+        userId ??= await db.UserEmails.AsNoTracking()
+            .Where(ue => ue.NormalizedEmail == normalizedEmail)
+            .Select(ue => ue.UserId)
+            .FirstOrDefaultAsync();
+
+        if (userId is null) return false;
+
         return await db.GameRoles
             .AsNoTracking()
             .AnyAsync(gr =>
-                gr.User.NormalizedEmail == normalizedEmail &&
+                gr.UserId == userId &&
                 gr.GameId == gameId &&
                 gr.RoleName == normalizedRole);
     }

--- a/src/RegistraceOvcina.Web/Features/Users/UserEmailService.cs
+++ b/src/RegistraceOvcina.Web/Features/Users/UserEmailService.cs
@@ -1,0 +1,107 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Features.Users;
+
+public sealed class UserEmailService(IDbContextFactory<ApplicationDbContext> dbFactory, TimeProvider timeProvider)
+{
+    public const int MaxAlternateEmails = 4;
+
+    public async Task<List<UserEmail>> GetAlternateEmailsAsync(string userId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        return await db.UserEmails
+            .AsNoTracking()
+            .Where(x => x.UserId == userId)
+            .OrderBy(x => x.CreatedAtUtc)
+            .ToListAsync(ct);
+    }
+
+    public async Task AddAlternateEmailAsync(string userId, string email, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            throw new ValidationException("E-mail je povinný.");
+        }
+
+        var normalizedEmail = email.Trim().ToUpperInvariant();
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var user = await db.Users.SingleOrDefaultAsync(x => x.Id == userId, ct)
+            ?? throw new ValidationException("Uživatel nenalezen.");
+
+        if (user.NormalizedEmail == normalizedEmail)
+        {
+            throw new ValidationException("Alternativní e-mail nesmí být stejný jako primární.");
+        }
+
+        var currentCount = await db.UserEmails.CountAsync(x => x.UserId == userId, ct);
+        if (currentCount >= MaxAlternateEmails)
+        {
+            throw new ValidationException("Uživatel může mít maximálně 4 alternativní e-maily.");
+        }
+
+        var existsInUsers = await db.Users.AnyAsync(x => x.NormalizedEmail == normalizedEmail, ct);
+        if (existsInUsers)
+        {
+            throw new ValidationException("Tento e-mail je již přiřazen jinému účtu.");
+        }
+
+        var existsInUserEmails = await db.UserEmails.AnyAsync(x => x.NormalizedEmail == normalizedEmail, ct);
+        if (existsInUserEmails)
+        {
+            throw new ValidationException("Tento e-mail je již přiřazen jinému účtu.");
+        }
+
+        db.UserEmails.Add(new UserEmail
+        {
+            UserId = userId,
+            Email = email.Trim(),
+            NormalizedEmail = normalizedEmail,
+            CreatedAtUtc = timeProvider.GetUtcNow().UtcDateTime
+        });
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task RemoveAlternateEmailAsync(string userId, int emailId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var entity = await db.UserEmails
+            .SingleOrDefaultAsync(x => x.Id == emailId && x.UserId == userId, ct);
+
+        if (entity is null)
+        {
+            return;
+        }
+
+        db.UserEmails.Remove(entity);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<string?> ResolveUserIdByEmailAsync(string email, CancellationToken ct = default)
+    {
+        var normalizedEmail = email.Trim().ToUpperInvariant();
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var primaryUserId = await db.Users
+            .Where(x => x.NormalizedEmail == normalizedEmail)
+            .Select(x => x.Id)
+            .SingleOrDefaultAsync(ct);
+
+        if (primaryUserId is not null)
+        {
+            return primaryUserId;
+        }
+
+        return await db.UserEmails
+            .Where(x => x.NormalizedEmail == normalizedEmail)
+            .Select(x => x.UserId)
+            .SingleOrDefaultAsync(ct);
+    }
+}

--- a/src/RegistraceOvcina.Web/Migrations/20260411160527_AddUserEmails.Designer.cs
+++ b/src/RegistraceOvcina.Web/Migrations/20260411160527_AddUserEmails.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RegistraceOvcina.Web.Data;
@@ -11,9 +12,11 @@ using RegistraceOvcina.Web.Data;
 namespace RegistraceOvcina.Web.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411160527_AddUserEmails")]
+    partial class AddUserEmails
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/RegistraceOvcina.Web/Migrations/20260411160527_AddUserEmails.cs
+++ b/src/RegistraceOvcina.Web/Migrations/20260411160527_AddUserEmails.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace RegistraceOvcina.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserEmails : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserEmails",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    Email = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    NormalizedEmail = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserEmails", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserEmails_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserEmails_NormalizedEmail",
+                table: "UserEmails",
+                column: "NormalizedEmail",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserEmails_UserId",
+                table: "UserEmails",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserEmails");
+        }
+    }
+}

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -254,6 +254,7 @@ public class Program
             builder.Configuration.GetSection(GuestAuthOptions.SectionName));
         builder.Services.AddScoped<GuestAuthService>();
         builder.Services.AddScoped<UserAdministrationService>();
+        builder.Services.AddScoped<UserEmailService>();
         builder.Services.AddScoped<GameRoleService>();
         builder.Services.AddScoped<AnnouncementService>();
         builder.Services.AddScoped<GameStatsService>();

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.8.1</Version>
+    <Version>0.8.2</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/UserEmailServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/UserEmailServiceTests.cs
@@ -1,0 +1,289 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.Users;
+
+namespace RegistraceOvcina.Web.Tests;
+
+public sealed class UserEmailServiceTests
+{
+    [Fact]
+    public async Task AddAlternateEmail_Succeeds()
+    {
+        var options = CreateOptions();
+        var user = CreateUser("user-1", "Alice", "alice@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserEmailService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        await service.AddAlternateEmailAsync("user-1", "alice-alt@example.cz");
+
+        await using var verificationDb = new ApplicationDbContext(options);
+        var saved = await verificationDb.UserEmails.SingleAsync();
+
+        Assert.Equal("user-1", saved.UserId);
+        Assert.Equal("alice-alt@example.cz", saved.Email);
+        Assert.Equal("ALICE-ALT@EXAMPLE.CZ", saved.NormalizedEmail);
+    }
+
+    [Fact]
+    public async Task AddAlternateEmail_RejectsDuplicate_InUsers()
+    {
+        var options = CreateOptions();
+        var user1 = CreateUser("user-1", "Alice", "alice@example.cz", true);
+        var user2 = CreateUser("user-2", "Bob", "bob@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.AddRange(user1, user2);
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserEmailService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(() =>
+            service.AddAlternateEmailAsync("user-1", "bob@example.cz"));
+
+        Assert.Equal("Tento e-mail je již přiřazen jinému účtu.", ex.Message);
+    }
+
+    [Fact]
+    public async Task AddAlternateEmail_RejectsDuplicate_InUserEmails()
+    {
+        var options = CreateOptions();
+        var user1 = CreateUser("user-1", "Alice", "alice@example.cz", true);
+        var user2 = CreateUser("user-2", "Bob", "bob@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.AddRange(user1, user2);
+            db.UserEmails.Add(new UserEmail
+            {
+                UserId = "user-2",
+                Email = "shared@example.cz",
+                NormalizedEmail = "SHARED@EXAMPLE.CZ",
+                CreatedAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserEmailService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(() =>
+            service.AddAlternateEmailAsync("user-1", "shared@example.cz"));
+
+        Assert.Equal("Tento e-mail je již přiřazen jinému účtu.", ex.Message);
+    }
+
+    [Fact]
+    public async Task AddAlternateEmail_RejectsSameAsPrimary()
+    {
+        var options = CreateOptions();
+        var user = CreateUser("user-1", "Alice", "alice@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserEmailService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(() =>
+            service.AddAlternateEmailAsync("user-1", "alice@example.cz"));
+
+        Assert.Equal("Alternativní e-mail nesmí být stejný jako primární.", ex.Message);
+    }
+
+    [Fact]
+    public async Task AddAlternateEmail_RejectsOverLimit()
+    {
+        var options = CreateOptions();
+        var user = CreateUser("user-1", "Alice", "alice@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(user);
+
+            for (var i = 1; i <= 4; i++)
+            {
+                db.UserEmails.Add(new UserEmail
+                {
+                    UserId = "user-1",
+                    Email = $"alt{i}@example.cz",
+                    NormalizedEmail = $"ALT{i}@EXAMPLE.CZ",
+                    CreatedAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                });
+            }
+
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserEmailService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(() =>
+            service.AddAlternateEmailAsync("user-1", "alt5@example.cz"));
+
+        Assert.Equal("Uživatel může mít maximálně 4 alternativní e-maily.", ex.Message);
+    }
+
+    [Fact]
+    public async Task RemoveAlternateEmail_Succeeds()
+    {
+        var options = CreateOptions();
+        var user = CreateUser("user-1", "Alice", "alice@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(user);
+            db.UserEmails.Add(new UserEmail
+            {
+                Id = 42,
+                UserId = "user-1",
+                Email = "alt@example.cz",
+                NormalizedEmail = "ALT@EXAMPLE.CZ",
+                CreatedAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserEmailService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        await service.RemoveAlternateEmailAsync("user-1", 42);
+
+        await using var verificationDb = new ApplicationDbContext(options);
+        Assert.Empty(await verificationDb.UserEmails.ToListAsync());
+    }
+
+    [Fact]
+    public async Task RemoveAlternateEmail_WrongUser_DoesNothing()
+    {
+        var options = CreateOptions();
+        var user1 = CreateUser("user-1", "Alice", "alice@example.cz", true);
+        var user2 = CreateUser("user-2", "Bob", "bob@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.AddRange(user1, user2);
+            db.UserEmails.Add(new UserEmail
+            {
+                Id = 42,
+                UserId = "user-2",
+                Email = "alt@example.cz",
+                NormalizedEmail = "ALT@EXAMPLE.CZ",
+                CreatedAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserEmailService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        await service.RemoveAlternateEmailAsync("user-1", 42);
+
+        await using var verificationDb = new ApplicationDbContext(options);
+        Assert.Single(await verificationDb.UserEmails.ToListAsync());
+    }
+
+    [Fact]
+    public async Task ResolveUserIdByEmail_FindsPrimary()
+    {
+        var options = CreateOptions();
+        var user = CreateUser("user-1", "Alice", "alice@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserEmailService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        var result = await service.ResolveUserIdByEmailAsync("alice@example.cz");
+
+        Assert.Equal("user-1", result);
+    }
+
+    [Fact]
+    public async Task ResolveUserIdByEmail_FindsAlternate()
+    {
+        var options = CreateOptions();
+        var user = CreateUser("user-1", "Alice", "alice@example.cz", true);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(user);
+            db.UserEmails.Add(new UserEmail
+            {
+                UserId = "user-1",
+                Email = "alice-alt@example.cz",
+                NormalizedEmail = "ALICE-ALT@EXAMPLE.CZ",
+                CreatedAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new UserEmailService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        var result = await service.ResolveUserIdByEmailAsync("alice-alt@example.cz");
+
+        Assert.Equal("user-1", result);
+    }
+
+    [Fact]
+    public async Task ResolveUserIdByEmail_ReturnsNull_WhenNotFound()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            await db.Database.EnsureCreatedAsync();
+        }
+
+        var service = new UserEmailService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        var result = await service.ResolveUserIdByEmailAsync("nobody@example.cz");
+
+        Assert.Null(result);
+    }
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static ApplicationUser CreateUser(string id, string displayName, string email, bool isActive) =>
+        new()
+        {
+            Id = id,
+            DisplayName = displayName,
+            Email = email,
+            NormalizedEmail = email.ToUpperInvariant(),
+            UserName = email,
+            NormalizedUserName = email.ToUpperInvariant(),
+            EmailConfirmed = true,
+            IsActive = isActive,
+            SecurityStamp = "initial-stamp",
+            CreatedAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now = new(new DateTime(2026, 4, 5, 12, 0, 0, DateTimeKind.Utc));
+
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}


### PR DESCRIPTION
## Summary
- **UserEmail** entity — links up to 4 alternate emails per user (unique index, cascade delete)
- **UserEmailService** — CRUD + validation (Czech messages) + email resolution (primary → alternate fallback)
- **Integration API** — all endpoints (`/users/by-email`, `/registrations/check`, `/users/{email}/roles`, `/users/{email}/has-role`) now resolve via alternate emails
- **GameRoleService** — `GetRolesForUserAsync` and `HasRoleAsync` resolve via alternate emails
- **User admin page** (`/admin/uzivatele`) — quick email lookup showing user profile, identity roles, game roles, alternate email management (add/remove)
- **External login** — when provider email matches an alternate email, shows confirmation prompt before linking accounts

## Test plan
- [ ] CI passes (68 unit tests, 0 warnings)
- [ ] Admin can search by any email on `/admin/uzivatele`
- [ ] Admin can add/remove alternate emails (max 4, validation works)
- [ ] Integration API returns correct data for alternate emails
- [ ] External login with alternate email shows confirmation prompt
- [ ] Existing login flows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)