### PR TITLE
[v0.8.3] feat: manual person merge via search

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/PersonDetail.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/PersonDetail.razor
@@ -188,6 +188,95 @@ else
         <section class="card shadow-sm border-0">
             <div class="card-body d-flex flex-column gap-3">
                 <div>
+                    <h2 class="h5 mb-1">Ruční vyhledání osoby ke sloučení</h2>
+                    <p class="text-secondary mb-0">Hledat osobu ke sloučení — jméno, e-mail nebo telefon</p>
+                </div>
+
+                <form method="get" action="/organizace/osoby/@PersonId" class="d-flex gap-2" data-testid="manual-merge-search-form">
+                    <input type="search"
+                           class="form-control"
+                           name="searchMerge"
+                           value="@SearchMerge"
+                           placeholder="Jméno, e-mail nebo telefon" />
+                    <button type="submit" class="btn btn-primary">Hledat</button>
+                </form>
+
+                @if (searchResults is not null)
+                {
+                    @if (searchResults.Count == 0)
+                    {
+                        <div class="alert alert-light border mb-0">Nenalezli jsme žádnou osobu pro zadaný filtr.</div>
+                    }
+                    else
+                    {
+                        <div class="d-flex flex-column gap-3">
+                            @foreach (var result in searchResults)
+                            {
+                                @if (confirmingMergePersonId == result.Id)
+                                {
+                                    <div class="border border-danger rounded p-3 d-flex flex-column gap-3" data-testid="merge-confirm-card">
+                                        <div class="fw-semibold text-danger">
+                                            Sloučit <strong>@result.FullName</strong> (ročník @result.BirthYear, @result.RegistrationCount účast/í)
+                                            do <strong>@model.FullName</strong> (ročník @model.BirthYear, @model.RegistrationHistory.Count účast/í)?
+                                        </div>
+                                        <p class="text-secondary mb-0">
+                                            Registrace, postavy a kontaktní údaje budou převedeny. Tato akce nelze vrátit.
+                                        </p>
+                                        <div class="d-flex gap-2">
+                                            <form method="post" action="/organizace/osoby/@PersonId/sloucit" class="d-inline">
+                                                <AntiforgeryToken />
+                                                <input type="hidden" name="duplicatePersonId" value="@result.Id" />
+                                                <button type="submit" class="btn btn-danger btn-sm">Potvrdit sloučení</button>
+                                            </form>
+                                            <a href="/organizace/osoby/@PersonId?searchMerge=@Uri.EscapeDataString(SearchMerge ?? "")" class="btn btn-outline-secondary btn-sm">Zrušit</a>
+                                        </div>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="border rounded p-3 d-flex flex-column gap-3" data-testid="merge-search-result">
+                                        <div class="d-flex flex-column flex-lg-row justify-content-between gap-3">
+                                            <div>
+                                                <div class="fw-semibold">@result.FullName</div>
+                                                <div class="text-secondary small">
+                                                    Ročník @result.BirthYear
+                                                    @if (!string.IsNullOrWhiteSpace(result.Email))
+                                                    {
+                                                        <span> · @result.Email</span>
+                                                    }
+                                                    @if (!string.IsNullOrWhiteSpace(result.Phone))
+                                                    {
+                                                        <span> · @result.Phone</span>
+                                                    }
+                                                </div>
+                                            </div>
+                                            <a class="btn btn-outline-secondary btn-sm align-self-start" href="/organizace/osoby/@result.Id">Otevřít detail</a>
+                                        </div>
+
+                                        <div class="text-secondary small">
+                                            @result.RegistrationCount × účast
+                                            @if (result.LastSeenAtUtc is not null)
+                                            {
+                                                <span> · naposledy @result.LastSeenGameName (@CzechTime.Format(result.LastSeenAtUtc.Value))</span>
+                                            }
+                                        </div>
+
+                                        <div>
+                                            <a href="/organizace/osoby/@PersonId?searchMerge=@Uri.EscapeDataString(SearchMerge ?? "")&confirmMerge=@result.Id"
+                                               class="btn btn-outline-danger btn-sm">Sloučit</a>
+                                        </div>
+                                    </div>
+                                }
+                            }
+                        </div>
+                    }
+                }
+            </div>
+        </section>
+
+        <section class="card shadow-sm border-0">
+            <div class="card-body d-flex flex-column gap-3">
+                <div>
                     <h2 class="h5 mb-1">Historie registrací</h2>
                     <p class="text-secondary mb-0">Přehled účastí a rolí napříč hrami.</p>
                 </div>
@@ -343,10 +432,18 @@ else
     [SupplyParameterFromQuery(Name = "error")]
     private string? Error { get; set; }
 
+    [SupplyParameterFromQuery(Name = "searchMerge")]
+    private string? SearchMerge { get; set; }
+
+    [SupplyParameterFromQuery(Name = "confirmMerge")]
+    private int? ConfirmMerge { get; set; }
+
     private PersonReviewDetailPageModel? model;
     private string? statusMessage;
     private string? errorMessage;
     private bool isLoaded;
+    private List<PersonSearchResultItem>? searchResults;
+    private int? confirmingMergePersonId;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -361,6 +458,13 @@ else
                 : Merged == 1
                     ? "Duplicitní osoba byla sloučena."
                     : null;
+
+        if (!string.IsNullOrWhiteSpace(SearchMerge))
+        {
+            searchResults = await PeopleReviewService.SearchPersonsAsync(SearchMerge, PersonId);
+            confirmingMergePersonId = ConfirmMerge;
+        }
+
         isLoaded = true;
     }
 

--- a/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
+++ b/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
@@ -465,6 +465,74 @@ public sealed class PeopleReviewService(
         await db.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task<List<PersonSearchResultItem>> SearchPersonsAsync(
+        string query,
+        int excludePersonId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return [];
+        }
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var trimmed = query.Trim();
+
+        // Coarse SQL filter first (case-insensitive via DB collation)
+        var candidates = await db.People
+            .AsNoTracking()
+            .Where(x => x.Id != excludePersonId)
+            .Where(x =>
+                (x.FirstName + " " + x.LastName).Contains(trimmed)
+                || (x.Email != null && x.Email.Contains(trimmed))
+                || (x.Phone != null && x.Phone.Contains(trimmed)))
+            .Select(x => new PersonSearchProjection(
+                x.Id,
+                x.FirstName,
+                x.LastName,
+                x.BirthYear,
+                x.Email,
+                x.Phone,
+                x.Registrations.Count,
+                x.Registrations
+                    .OrderByDescending(r => r.Submission.Game.StartsAtUtc)
+                    .Select(r => (DateTime?)r.Submission.Game.StartsAtUtc)
+                    .FirstOrDefault(),
+                x.Registrations
+                    .OrderByDescending(r => r.Submission.Game.StartsAtUtc)
+                    .Select(r => r.Submission.Game.Name)
+                    .FirstOrDefault()))
+            .ToListAsync(cancellationToken);
+
+        // Refine in-memory with diacritic/phone normalization
+        var normalizedQuery = PersonIdentityNormalizer.NormalizeComparisonText(query);
+        var normalizedPhone = PersonIdentityNormalizer.NormalizePhone(query);
+
+        return candidates
+            .Where(x =>
+                PersonIdentityNormalizer.NormalizeComparisonText($"{x.FirstName} {x.LastName}")
+                    .Contains(normalizedQuery, StringComparison.Ordinal)
+                || PersonIdentityNormalizer.NormalizeEmail(x.Email)
+                    .Contains(trimmed, StringComparison.OrdinalIgnoreCase)
+                || (!string.IsNullOrWhiteSpace(normalizedPhone)
+                    && PersonIdentityNormalizer.NormalizePhone(x.Phone)
+                        .Contains(normalizedPhone, StringComparison.Ordinal)))
+            .OrderBy(x => x.LastName, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(x => x.FirstName, StringComparer.CurrentCultureIgnoreCase)
+            .Take(10)
+            .Select(x => new PersonSearchResultItem(
+                x.Id,
+                $"{x.FirstName} {x.LastName}",
+                x.BirthYear,
+                x.Email,
+                x.Phone,
+                x.RegistrationCount,
+                x.LastSeenAtUtc,
+                x.LastSeenGameName))
+            .ToList();
+    }
+
     private async Task<List<LinkableAccountItem>> GetLinkableAccountsAsync(
         ApplicationDbContext db,
         Person person,
@@ -609,6 +677,17 @@ public sealed class PeopleReviewService(
         DateTime? LastSeenAtUtc,
         string? LastSeenGameName);
 
+    private sealed record PersonSearchProjection(
+        int Id,
+        string FirstName,
+        string LastName,
+        int BirthYear,
+        string? Email,
+        string? Phone,
+        int RegistrationCount,
+        DateTime? LastSeenAtUtc,
+        string? LastSeenGameName);
+
     private sealed record PersonCandidateProjection(
         int Id,
         string FirstName,
@@ -700,3 +779,13 @@ public sealed record PersonOrganizerNoteItem(
     string Note,
     DateTime CreatedAtUtc,
     string AuthorLabel);
+
+public sealed record PersonSearchResultItem(
+    int Id,
+    string FullName,
+    int BirthYear,
+    string? Email,
+    string? Phone,
+    int RegistrationCount,
+    DateTime? LastSeenAtUtc,
+    string? LastSeenGameName);

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.8.2</Version>
+    <Version>0.8.3</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
- Search box on person detail page to find and merge any person by name, email, or phone
- Confirmation step before merge with details of both persons
- Reuses existing `PeopleReviewService.MergeAsync` — no new merge logic
- Added `SearchPersonsAsync` method for diacritic-insensitive search

## Test plan
- [ ] CI passes
- [ ] Search finds persons by name, email, phone
- [ ] Search excludes current person and deleted persons
- [ ] Confirmation shows correct details for both persons
- [ ] Merge works and page refreshes with success message
- [ ] Existing auto-candidate merge still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)