### PR TITLE
[v0.8.4] feat: expand role rows to show users

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/Roles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/Roles.razor
@@ -97,28 +97,7 @@
                                             </tr>
                                             @if (expandedRoleId == entry.Id && expandedRoleUsers is not null)
                                             {
-                                                <tr>
-                                                    <td colspan="4" class="p-0">
-                                                        <div class="bg-light border-top px-4 py-2">
-                                                            @if (expandedRoleUsers.Count == 0)
-                                                            {
-                                                                <span class="text-muted small">Žádní uživatelé v této roli.</span>
-                                                            }
-                                                            else
-                                                            {
-                                                                <ul class="list-unstyled mb-0 small">
-                                                                    @foreach (var user in expandedRoleUsers)
-                                                                    {
-                                                                        <li class="py-1 border-bottom border-light-subtle">
-                                                                            <strong>@user.DisplayName</strong>
-                                                                            <span class="text-muted ms-2">@user.Email</span>
-                                                                        </li>
-                                                                    }
-                                                                </ul>
-                                                            }
-                                                        </div>
-                                                    </td>
-                                                </tr>
+                                                @ExpandedUsersRow
                                             }
                                         }
                                         else
@@ -158,28 +137,7 @@
                                             </tr>
                                             @if (expandedRoleId == entry.Id && expandedRoleUsers is not null)
                                             {
-                                                <tr>
-                                                    <td colspan="4" class="p-0">
-                                                        <div class="bg-light border-top px-4 py-2">
-                                                            @if (expandedRoleUsers.Count == 0)
-                                                            {
-                                                                <span class="text-muted small">Žádní uživatelé v této roli.</span>
-                                                            }
-                                                            else
-                                                            {
-                                                                <ul class="list-unstyled mb-0 small">
-                                                                    @foreach (var user in expandedRoleUsers)
-                                                                    {
-                                                                        <li class="py-1 border-bottom border-light-subtle">
-                                                                            <strong>@user.DisplayName</strong>
-                                                                            <span class="text-muted ms-2">@user.Email</span>
-                                                                        </li>
-                                                                    }
-                                                                </ul>
-                                                            }
-                                                        </div>
-                                                    </td>
-                                                </tr>
+                                                @ExpandedUsersRow
                                             }
                                         }
                                     }
@@ -238,6 +196,9 @@
 
     private async Task LoadRolesAsync()
     {
+        expandedRoleId = null;
+        expandedRoleUsers = null;
+
         var allRoles = RoleManager.Roles.ToList();
         var entries = new List<RoleEntry>();
 
@@ -449,8 +410,13 @@
             return;
         }
 
-        expandedRoleId = entry.Id;
+        var targetId = entry.Id;
+        expandedRoleId = targetId;
         var usersInRole = await UserManager.GetUsersInRoleAsync(entry.Name);
+
+        // Guard against race: if user clicked another role while awaiting, discard stale result
+        if (expandedRoleId != targetId) return;
+
         expandedRoleUsers = usersInRole
             .OrderBy(u => u.DisplayName)
             .Select(u => new RoleUserInfo(u.DisplayName, u.Email ?? ""))
@@ -463,6 +429,32 @@
         "game" => "Herní",
         "staff" => "Organizační",
         _ => category,
+    };
+
+    private RenderFragment ExpandedUsersRow => __builder =>
+    {
+        <tr>
+            <td colspan="4" class="p-0">
+                <div class="bg-light border-top px-4 py-2">
+                    @if (expandedRoleUsers!.Count == 0)
+                    {
+                        <span class="text-muted small">Žádní uživatelé v této roli.</span>
+                    }
+                    else
+                    {
+                        <ul class="list-unstyled mb-0 small">
+                            @foreach (var user in expandedRoleUsers)
+                            {
+                                <li class="py-1 border-bottom border-light-subtle">
+                                    <strong>@user.DisplayName</strong>
+                                    <span class="text-muted ms-2">@user.Email</span>
+                                </li>
+                            }
+                        </ul>
+                    }
+                </div>
+            </td>
+        </tr>
     };
 
     private static string CategoryBadgeClass(string category) => category switch

--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/Roles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/Roles.razor
@@ -82,7 +82,12 @@
                                                         <option value="staff">Organizační role</option>
                                                     </select>
                                                 </td>
-                                                <td>@entry.UserCount</td>
+                                                <td>
+                                                    <button class="btn btn-sm btn-link p-0 text-decoration-none" @onclick="() => ToggleExpandAsync(entry)">
+                                                        @entry.UserCount
+                                                        <i class="bi @(expandedRoleId == entry.Id ? "bi-chevron-up" : "bi-chevron-down") ms-1 small"></i>
+                                                    </button>
+                                                </td>
                                                 <td>
                                                     <div class="d-flex gap-1">
                                                         <button class="btn btn-sm btn-primary" @onclick="SaveEditAsync">Uložit</button>
@@ -90,6 +95,31 @@
                                                     </div>
                                                 </td>
                                             </tr>
+                                            @if (expandedRoleId == entry.Id && expandedRoleUsers is not null)
+                                            {
+                                                <tr>
+                                                    <td colspan="4" class="p-0">
+                                                        <div class="bg-light border-top px-4 py-2">
+                                                            @if (expandedRoleUsers.Count == 0)
+                                                            {
+                                                                <span class="text-muted small">Žádní uživatelé v této roli.</span>
+                                                            }
+                                                            else
+                                                            {
+                                                                <ul class="list-unstyled mb-0 small">
+                                                                    @foreach (var user in expandedRoleUsers)
+                                                                    {
+                                                                        <li class="py-1 border-bottom border-light-subtle">
+                                                                            <strong>@user.DisplayName</strong>
+                                                                            <span class="text-muted ms-2">@user.Email</span>
+                                                                        </li>
+                                                                    }
+                                                                </ul>
+                                                            }
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            }
                                         }
                                         else
                                         {
@@ -98,7 +128,12 @@
                                                 <td>
                                                     <span class="badge @CategoryBadgeClass(entry.Category)">@CategoryLabel(entry.Category)</span>
                                                 </td>
-                                                <td>@entry.UserCount</td>
+                                                <td>
+                                                    <button class="btn btn-sm btn-link p-0 text-decoration-none" @onclick="() => ToggleExpandAsync(entry)">
+                                                        @entry.UserCount
+                                                        <i class="bi @(expandedRoleId == entry.Id ? "bi-chevron-up" : "bi-chevron-down") ms-1 small"></i>
+                                                    </button>
+                                                </td>
                                                 <td>
                                                     @if (!entry.IsProtected)
                                                     {
@@ -121,6 +156,31 @@
                                                     }
                                                 </td>
                                             </tr>
+                                            @if (expandedRoleId == entry.Id && expandedRoleUsers is not null)
+                                            {
+                                                <tr>
+                                                    <td colspan="4" class="p-0">
+                                                        <div class="bg-light border-top px-4 py-2">
+                                                            @if (expandedRoleUsers.Count == 0)
+                                                            {
+                                                                <span class="text-muted small">Žádní uživatelé v této roli.</span>
+                                                            }
+                                                            else
+                                                            {
+                                                                <ul class="list-unstyled mb-0 small">
+                                                                    @foreach (var user in expandedRoleUsers)
+                                                                    {
+                                                                        <li class="py-1 border-bottom border-light-subtle">
+                                                                            <strong>@user.DisplayName</strong>
+                                                                            <span class="text-muted ms-2">@user.Email</span>
+                                                                        </li>
+                                                                    }
+                                                                </ul>
+                                                            }
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            }
                                         }
                                     }
                                 </tbody>
@@ -162,6 +222,10 @@
 
     // Delete confirmation
     private string? confirmDeleteId;
+
+    // Expand user list
+    private string? expandedRoleId;
+    private List<RoleUserInfo>? expandedRoleUsers;
 
     // Status
     private string? statusMessage;
@@ -376,6 +440,23 @@
         statusMessage = null;
     }
 
+    private async Task ToggleExpandAsync(RoleEntry entry)
+    {
+        if (expandedRoleId == entry.Id)
+        {
+            expandedRoleId = null;
+            expandedRoleUsers = null;
+            return;
+        }
+
+        expandedRoleId = entry.Id;
+        var usersInRole = await UserManager.GetUsersInRoleAsync(entry.Name);
+        expandedRoleUsers = usersInRole
+            .OrderBy(u => u.DisplayName)
+            .Select(u => new RoleUserInfo(u.DisplayName, u.Email ?? ""))
+            .ToList();
+    }
+
     private static string CategoryLabel(string category) => category switch
     {
         "system" => "Systémová",
@@ -400,4 +481,6 @@
         public required int UserCount { get; init; }
         public required bool IsProtected { get; init; }
     }
+
+    private sealed record RoleUserInfo(string DisplayName, string Email);
 }

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.8.3</Version>
+    <Version>0.8.4</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
- Click user count on roles page to expand inline list of users with that role
- Shows display name + email, sorted alphabetically
- Click again to collapse
- Uses existing `UserManager.GetUsersInRoleAsync()`

## Test plan
- [ ] CI passes
- [ ] Clicking user count expands/collapses user list
- [ ] Empty roles show "Žádní uživatelé v této roli"
- [ ] Existing role CRUD unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)