### PR TITLE
fix: user admin page missing service method + nav link

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Layout/MainLayout.razor
+++ b/src/RegistraceOvcina.Web/Components/Layout/MainLayout.razor
@@ -43,6 +43,7 @@
                             <a class="nav-link" href="/admin/hry">Hry</a>
                             <a class="nav-link" href="/admin/kralovstvi">Správa království</a>
                             <a class="nav-link" href="/admin/organizatori">Organizátoři</a>
+                            <a class="nav-link" href="/admin/uzivatele">Uživatelé</a>
                             <a class="nav-link" href="/admin/oznameni">Oznámení</a>
                             <a class="nav-link" href="/admin/osloveni">Oslovení</a>
                             <a class="nav-link" href="/admin/roles">Role</a>

--- a/src/RegistraceOvcina.Web/Features/Users/UserAdministrationService.cs
+++ b/src/RegistraceOvcina.Web/Features/Users/UserAdministrationService.cs
@@ -232,6 +232,51 @@ public sealed class UserAdministrationService(IDbContextFactory<ApplicationDbCon
             RoleNames.Admin => granted ? "admin-added" : "admin-removed",
             _ => throw new InvalidOperationException($"Unsupported role '{roleName}'.")
         };
+
+    public async Task<UserLookupResult?> LookupByEmailAsync(string email, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(email)) return null;
+        var normalizedEmail = email.Trim().ToUpperInvariant();
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
+        // Find user by primary or alternate email
+        var userId = await db.Users.AsNoTracking()
+            .Where(u => u.NormalizedEmail == normalizedEmail)
+            .Select(u => u.Id)
+            .FirstOrDefaultAsync(ct);
+
+        userId ??= await db.UserEmails.AsNoTracking()
+            .Where(ue => ue.NormalizedEmail == normalizedEmail)
+            .Select(ue => ue.UserId)
+            .FirstOrDefaultAsync(ct);
+
+        if (userId is null) return null;
+
+        var user = await db.Users.AsNoTracking()
+            .Where(u => u.Id == userId)
+            .Select(u => new { u.Id, u.DisplayName, u.Email, u.IsActive, u.LastLoginAtUtc, u.CreatedAtUtc })
+            .SingleAsync(ct);
+
+        var identityRoles = await db.UserRoles.AsNoTracking()
+            .Where(ur => ur.UserId == userId)
+            .Join(db.Roles, ur => ur.RoleId, r => r.Id, (ur, r) => r.Name!)
+            .ToListAsync(ct);
+
+        var alternateEmails = await db.UserEmails.AsNoTracking()
+            .Where(ue => ue.UserId == userId)
+            .OrderBy(ue => ue.Email)
+            .ToListAsync(ct);
+
+        var gameRoles = await db.GameRoles.AsNoTracking()
+            .Where(gr => gr.UserId == userId)
+            .Join(db.Games, gr => gr.GameId, g => g.Id, (gr, g) => new GameRoleSummary(g.Id, g.Name, gr.RoleName))
+            .ToListAsync(ct);
+
+        return new UserLookupResult(
+            user.Id, user.DisplayName, user.Email ?? "",
+            user.IsActive, user.LastLoginAtUtc, user.CreatedAtUtc,
+            identityRoles, alternateEmails, gameRoles);
+    }
 }
 
 public sealed record UserAdministrationPage(
@@ -258,3 +303,11 @@ public sealed record ManagedUserSummary(
 }
 
 public sealed record UserManagementChangeResult(string StatusCode);
+
+public sealed record UserLookupResult(
+    string Id, string DisplayName, string PrimaryEmail,
+    bool IsActive, DateTime? LastLoginAtUtc, DateTime CreatedAtUtc,
+    List<string> IdentityRoles, List<UserEmail> AlternateEmails,
+    List<GameRoleSummary> GameRoles);
+
+public sealed record GameRoleSummary(int GameId, string GameName, string RoleName);


### PR DESCRIPTION
## Summary
- `UserAdmin.razor` was deployed but `LookupByEmailAsync` method and nav link were missing from the squash merge
- Page returned 404 because Blazor couldn't compile it at runtime

## Test plan
- [ ] `/admin/uzivatele` loads
- [ ] Search works

🤖 Generated with [Claude Code](https://claude.com/claude-code)