### PR TITLE
[v0.8.6] feat: user admin — partial search, rename, merge, user list

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/UserAdmin.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/UserAdmin.razor
@@ -16,14 +16,14 @@
         <section class="card shadow-sm">
             <div class="card-body p-4">
                 <h1 class="h3 mb-2">Správa uživatelů</h1>
-                <p class="text-secondary mb-3">Vyhledejte uživatele podle e-mailu a spravujte alternativní e-maily.</p>
+                <p class="text-secondary mb-3">Vyhledejte uživatele podle jména nebo e-mailu.</p>
 
                 <div class="d-flex gap-2 mb-3">
-                    <input type="email"
+                    <input type="text"
                            class="form-control"
                            style="max-width: 400px;"
-                           placeholder="E-mail uživatele"
-                           @bind="searchEmail"
+                           placeholder="Jméno nebo e-mail"
+                           @bind="searchQuery"
                            @bind:event="oninput"
                            @onkeydown="HandleKeyDown" />
                     <button class="btn btn-primary" @onclick="SearchAsync" disabled="@isSearching">
@@ -36,9 +36,31 @@
                     <div class="alert alert-danger" role="alert">@errorMessage</div>
                 }
 
-                @if (hasSearched && lookupResult is null && string.IsNullOrWhiteSpace(errorMessage))
+                @if (hasSearched && searchResults is not null && searchResults.Count == 0 && string.IsNullOrWhiteSpace(errorMessage))
                 {
-                    <div class="alert alert-warning" role="alert">Uživatel s tímto e-mailem nebyl nalezen.</div>
+                    <div class="alert alert-warning" role="alert">Žádný uživatel nenalezen.</div>
+                }
+
+                @if (searchResults is not null && searchResults.Count > 1 && lookupResult is null)
+                {
+                    <div class="list-group">
+                        @foreach (var result in searchResults)
+                        {
+                            <button class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
+                                    @onclick="() => SelectUserAsync(result.Id)">
+                                <div>
+                                    <span class="fw-semibold">@result.DisplayName</span>
+                                    <span class="text-secondary ms-2">@result.Email</span>
+                                </div>
+                                <div class="d-flex align-items-center gap-2">
+                                    <span class="badge @(result.IsActive ? "text-bg-success" : "text-bg-secondary")">
+                                        @(result.IsActive ? "Aktivní" : "Deaktivovaný")
+                                    </span>
+                                    <span class="btn btn-sm btn-outline-primary">Vybrat</span>
+                                </div>
+                            </button>
+                        }
+                    </div>
                 }
             </div>
         </section>
@@ -46,12 +68,37 @@
 
     @if (lookupResult is not null)
     {
+        @* User detail card *@
         <div class="col-12">
             <section class="card shadow-sm">
                 <div class="card-body p-4">
                     <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 mb-4">
                         <div>
-                            <h2 class="h4 mb-1">@lookupResult.DisplayName</h2>
+                            @if (isEditingName)
+                            {
+                                <div class="d-flex align-items-center gap-2 mb-1">
+                                    <input type="text"
+                                           class="form-control form-control-sm"
+                                           style="max-width: 300px;"
+                                           @bind="editDisplayName"
+                                           @bind:event="oninput" />
+                                    <button class="btn btn-sm btn-success" @onclick="SaveRenameAsync" disabled="@isRenaming">
+                                        Uložit
+                                    </button>
+                                    <button class="btn btn-sm btn-outline-secondary" @onclick="CancelRename">
+                                        Zrušit
+                                    </button>
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="d-flex align-items-center gap-2 mb-1">
+                                    <h2 class="h4 mb-0">@lookupResult.DisplayName</h2>
+                                    <button class="btn btn-sm btn-outline-secondary" @onclick="StartRename" title="Přejmenovat">
+                                        Upravit
+                                    </button>
+                                </div>
+                            }
                             <div class="text-secondary">@lookupResult.PrimaryEmail</div>
                         </div>
                         <div class="d-flex align-items-center gap-2">
@@ -60,6 +107,11 @@
                             </span>
                         </div>
                     </div>
+
+                    @if (!string.IsNullOrWhiteSpace(renameMessage))
+                    {
+                        <div class="alert @(renameIsError ? "alert-danger" : "alert-success") mb-3" role="alert">@renameMessage</div>
+                    }
 
                     <div class="row g-3">
                         <div class="col-md-6">
@@ -176,19 +228,156 @@
                 </div>
             </section>
         </div>
+
+        @* Merge users *@
+        <div class="col-12">
+            <section class="card shadow-sm">
+                <div class="card-body p-4">
+                    <h3 class="h5 mb-3">Sloučit s jiným účtem</h3>
+                    <p class="text-secondary mb-3">Vyhledejte duplicitní účet, jehož data se převedou do tohoto uživatele.</p>
+
+                    <div class="d-flex gap-2 mb-3">
+                        <input type="text"
+                               class="form-control"
+                               style="max-width: 400px;"
+                               placeholder="Jméno nebo e-mail duplicitního účtu"
+                               @bind="mergeSearchQuery"
+                               @bind:event="oninput"
+                               @onkeydown="HandleMergeKeyDown" />
+                        <button class="btn btn-outline-primary" @onclick="SearchMergeAsync" disabled="@isMergeSearching">
+                            @(isMergeSearching ? "Hledám..." : "Hledat")
+                        </button>
+                    </div>
+
+                    @if (!string.IsNullOrWhiteSpace(mergeError))
+                    {
+                        <div class="alert alert-danger" role="alert">@mergeError</div>
+                    }
+
+                    @if (!string.IsNullOrWhiteSpace(mergeSuccess))
+                    {
+                        <div class="alert alert-success" role="alert">@mergeSuccess</div>
+                    }
+
+                    @if (mergeSearchResults is not null && mergeSearchResults.Count > 0 && mergeTarget is null)
+                    {
+                        <div class="list-group mb-3">
+                            @foreach (var result in mergeSearchResults)
+                            {
+                                <button class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
+                                        @onclick="() => SelectMergeTargetAsync(result.Id)">
+                                    <div>
+                                        <span class="fw-semibold">@result.DisplayName</span>
+                                        <span class="text-secondary ms-2">@result.Email</span>
+                                    </div>
+                                    <div class="d-flex align-items-center gap-2">
+                                        <span class="badge @(result.IsActive ? "text-bg-success" : "text-bg-secondary")">
+                                            @(result.IsActive ? "Aktivní" : "Deaktivovaný")
+                                        </span>
+                                        <span class="btn btn-sm btn-outline-primary">Vybrat</span>
+                                    </div>
+                                </button>
+                            }
+                        </div>
+                    }
+
+                    @if (mergeSearchResults is not null && mergeSearchResults.Count == 0)
+                    {
+                        <div class="alert alert-warning" role="alert">Žádný uživatel nenalezen.</div>
+                    }
+
+                    @if (mergeTarget is not null)
+                    {
+                        <div class="card border-warning mb-3">
+                            <div class="card-body">
+                                <h4 class="h6 mb-2">Duplicitní účet k sloučení</h4>
+                                <div class="mb-1"><strong>Jméno:</strong> @mergeTarget.DisplayName</div>
+                                <div class="mb-1"><strong>E-mail:</strong> @mergeTarget.PrimaryEmail</div>
+                                <div class="mb-1">
+                                    <strong>Role:</strong>
+                                    @if (mergeTarget.IdentityRoles.Count > 0)
+                                    {
+                                        @string.Join(", ", mergeTarget.IdentityRoles)
+                                    }
+                                    else
+                                    {
+                                        <span class="text-secondary">Žádné</span>
+                                    }
+                                </div>
+                                <div class="mb-3">
+                                    <strong>Stav:</strong>
+                                    <span class="badge @(mergeTarget.IsActive ? "text-bg-success" : "text-bg-secondary")">
+                                        @(mergeTarget.IsActive ? "Aktivní" : "Deaktivovaný")
+                                    </span>
+                                </div>
+
+                                @if (!mergeConfirmationShown)
+                                {
+                                    <div class="d-flex gap-2">
+                                        <button class="btn btn-warning" @onclick="ShowMergeConfirmation">
+                                            Sloučit do aktuálního účtu
+                                        </button>
+                                        <button class="btn btn-outline-secondary" @onclick="CancelMerge">
+                                            Zrušit
+                                        </button>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="alert alert-danger mb-3">
+                                        Sloučit účet <strong>@mergeTarget.DisplayName</strong> (@mergeTarget.PrimaryEmail) do
+                                        <strong>@lookupResult.DisplayName</strong> (@lookupResult.PrimaryEmail)?
+                                        Role a přihlášení budou převedeny. Tato akce nelze vrátit.
+                                    </div>
+                                    <div class="d-flex gap-2">
+                                        <button class="btn btn-danger" @onclick="ExecuteMergeAsync" disabled="@isMerging">
+                                            @(isMerging ? "Slučuji..." : "Potvrdit sloučení")
+                                        </button>
+                                        <button class="btn btn-outline-secondary" @onclick="CancelMerge" disabled="@isMerging">
+                                            Zrušit
+                                        </button>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            </section>
+        </div>
     }
 </div>
 
 @code {
-    private string searchEmail = "";
-    private string newAlternateEmail = "";
+    // Search state
+    private string searchQuery = "";
     private string? errorMessage;
-    private string? emailError;
-    private string? emailSuccess;
     private bool hasSearched;
     private bool isSearching;
-    private bool isAddingEmail;
+    private List<UserSearchResult>? searchResults;
     private UserLookupResult? lookupResult;
+
+    // Alternate email state
+    private string newAlternateEmail = "";
+    private string? emailError;
+    private string? emailSuccess;
+    private bool isAddingEmail;
+
+    // Rename state
+    private bool isEditingName;
+    private bool isRenaming;
+    private string editDisplayName = "";
+    private string? renameMessage;
+    private bool renameIsError;
+
+    // Merge state
+    private string mergeSearchQuery = "";
+    private bool isMergeSearching;
+    private List<UserSearchResult>? mergeSearchResults;
+    private UserLookupResult? mergeTarget;
+    private bool mergeConfirmationShown;
+    private bool isMerging;
+    private string? mergeError;
+    private string? mergeSuccess;
 
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
@@ -204,18 +393,26 @@
         emailError = null;
         emailSuccess = null;
         lookupResult = null;
+        searchResults = null;
         hasSearched = true;
+        ClearRenameState();
+        ClearMergeState();
 
-        if (string.IsNullOrWhiteSpace(searchEmail))
+        if (string.IsNullOrWhiteSpace(searchQuery))
         {
-            errorMessage = "Zadejte e-mail.";
+            errorMessage = "Zadejte hledaný výraz.";
             return;
         }
 
         isSearching = true;
         try
         {
-            lookupResult = await UserAdministrationService.LookupByEmailAsync(searchEmail);
+            searchResults = await UserAdministrationService.SearchUsersAsync(searchQuery);
+
+            if (searchResults.Count == 1)
+            {
+                lookupResult = await UserAdministrationService.LookupByIdAsync(searchResults[0].Id);
+            }
         }
         catch (Exception ex)
         {
@@ -226,6 +423,73 @@
             isSearching = false;
         }
     }
+
+    private async Task SelectUserAsync(string userId)
+    {
+        errorMessage = null;
+        ClearRenameState();
+        ClearMergeState();
+
+        try
+        {
+            lookupResult = await UserAdministrationService.LookupByIdAsync(userId);
+        }
+        catch (Exception ex)
+        {
+            errorMessage = ex.Message;
+        }
+    }
+
+    // --- Rename ---
+
+    private void StartRename()
+    {
+        editDisplayName = lookupResult?.DisplayName ?? "";
+        isEditingName = true;
+        renameMessage = null;
+    }
+
+    private void CancelRename()
+    {
+        isEditingName = false;
+        renameMessage = null;
+    }
+
+    private void ClearRenameState()
+    {
+        isEditingName = false;
+        isRenaming = false;
+        editDisplayName = "";
+        renameMessage = null;
+        renameIsError = false;
+    }
+
+    private async Task SaveRenameAsync()
+    {
+        if (lookupResult is null) return;
+
+        renameMessage = null;
+        isRenaming = true;
+        try
+        {
+            await UserAdministrationService.RenameUserAsync(lookupResult.Id, editDisplayName);
+            lookupResult = await UserAdministrationService.LookupByIdAsync(lookupResult.Id);
+            isEditingName = false;
+            renameMessage = "Jméno bylo úspěšně změněno.";
+            renameIsError = false;
+        }
+        catch (ValidationException ex)
+        {
+            renameMessage = ex.Message;
+            renameIsError = true;
+        }
+        finally
+        {
+            isRenaming = false;
+        }
+    }
+
+    // --- Alternate emails ---
 
     private async Task AddAlternateEmailAsync()
     {
@@ -244,7 +508,7 @@
             await UserEmailService.AddAlternateEmailAsync(lookupResult.Id, newAlternateEmail);
             emailSuccess = $"E-mail {newAlternateEmail} byl přidán.";
             newAlternateEmail = "";
-            lookupResult = await UserAdministrationService.LookupByEmailAsync(lookupResult.PrimaryEmail);
+            lookupResult = await UserAdministrationService.LookupByIdAsync(lookupResult.Id);
         }
         catch (ValidationException ex)
         {
@@ -267,11 +531,121 @@
         {
             await UserEmailService.RemoveAlternateEmailAsync(lookupResult.Id, emailId);
             emailSuccess = "E-mail byl odebrán.";
-            lookupResult = await UserAdministrationService.LookupByEmailAsync(lookupResult.PrimaryEmail);
+            lookupResult = await UserAdministrationService.LookupByIdAsync(lookupResult.Id);
         }
         catch (ValidationException ex)
         {
             emailError = ex.Message;
+        }
+    }
+
+    // --- Merge ---
+
+    private async Task HandleMergeKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+        {
+            await SearchMergeAsync();
+        }
+    }
+
+    private void ClearMergeState()
+    {
+        mergeSearchQuery = "";
+        mergeSearchResults = null;
+        mergeTarget = null;
+        mergeConfirmationShown = false;
+        isMerging = false;
+        isMergeSearching = false;
+        mergeError = null;
+        mergeSuccess = null;
+    }
+
+    private async Task SearchMergeAsync()
+    {
+        mergeError = null;
+        mergeSuccess = null;
+        mergeTarget = null;
+        mergeConfirmationShown = false;
+
+        if (string.IsNullOrWhiteSpace(mergeSearchQuery))
+        {
+            mergeError = "Zadejte hledaný výraz.";
+            return;
+        }
+
+        isMergeSearching = true;
+        try
+        {
+            mergeSearchResults = await UserAdministrationService.SearchUsersAsync(mergeSearchQuery);
+            // Filter out the canonical user from merge results
+            mergeSearchResults = mergeSearchResults.Where(r => r.Id != lookupResult?.Id).ToList();
+        }
+        catch (Exception ex)
+        {
+            mergeError = ex.Message;
+        }
+        finally
+        {
+            isMergeSearching = false;
+        }
+    }
+
+    private async Task SelectMergeTargetAsync(string userId)
+    {
+        mergeError = null;
+        try
+        {
+            mergeTarget = await UserAdministrationService.LookupByIdAsync(userId);
+        }
+        catch (Exception ex)
+        {
+            mergeError = ex.Message;
+        }
+    }
+
+    private void ShowMergeConfirmation()
+    {
+        mergeConfirmationShown = true;
+    }
+
+    private void CancelMerge()
+    {
+        mergeTarget = null;
+        mergeSearchResults = null;
+        mergeSearchQuery = "";
+        mergeConfirmationShown = false;
+        mergeError = null;
+    }
+
+    private async Task ExecuteMergeAsync()
+    {
+        if (lookupResult is null || mergeTarget is null) return;
+
+        mergeError = null;
+        isMerging = true;
+        try
+        {
+            await UserAdministrationService.MergeUsersAsync(lookupResult.Id, mergeTarget.Id);
+            mergeSuccess = $"Účet {mergeTarget.DisplayName} ({mergeTarget.PrimaryEmail}) byl sloučen.";
+            mergeTarget = null;
+            mergeSearchResults = null;
+            mergeSearchQuery = "";
+            mergeConfirmationShown = false;
+            // Refresh the canonical user to show updated data
+            lookupResult = await UserAdministrationService.LookupByIdAsync(lookupResult.Id);
+        }
+        catch (ValidationException ex)
+        {
+            mergeError = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            mergeError = $"Chyba při slučování: {ex.Message}";
+        }
+        finally
+        {
+            isMerging = false;
         }
     }
 

--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/UserAdmin.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/UserAdmin.razor
@@ -66,6 +66,53 @@
         </section>
     </div>
 
+    @* All users list *@
+    @if (lookupResult is null && allUsers is not null)
+    {
+        <div class="col-12">
+            <section class="card shadow-sm">
+                <div class="card-body p-4">
+                    <h2 class="h5 mb-3">Všichni uživatelé <span class="badge text-bg-secondary">@allUsers.Count</span></h2>
+                    <div class="table-responsive">
+                        <table class="table table-hover mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Jméno</th>
+                                    <th>E-mail</th>
+                                    <th>Stav</th>
+                                    <th>Poslední přihlášení</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var user in allUsers)
+                                {
+                                    <tr>
+                                        <td>@user.DisplayName</td>
+                                        <td class="text-secondary">@user.Email</td>
+                                        <td>
+                                            <span class="badge @(user.IsActive ? "text-bg-success" : "text-bg-secondary") small">
+                                                @(user.IsActive ? "Aktivní" : "Deaktivovaný")
+                                            </span>
+                                        </td>
+                                        <td class="text-secondary small">
+                                            @(user.LastLoginAtUtc?.ToLocalTime().ToString("d. M. yyyy HH:mm") ?? "Nikdy")
+                                        </td>
+                                        <td>
+                                            <button class="btn btn-sm btn-outline-primary" @onclick="() => SelectUserAsync(user.Id)">
+                                                Otevřít
+                                            </button>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </section>
+        </div>
+    }
+
     @if (lookupResult is not null)
     {
         @* User detail card *@
@@ -348,6 +395,9 @@
 </div>
 
 @code {
+    // All users list
+    private List<UserSearchResult>? allUsers;
+
     // Search state
     private string searchQuery = "";
     private string? errorMessage;
@@ -378,6 +428,19 @@
     private bool isMerging;
     private string? mergeError;
     private string? mergeSuccess;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAllUsersAsync();
+    }
+
+    private async Task LoadAllUsersAsync()
+    {
+        var page = await UserAdministrationService.GetPageAsync();
+        allUsers = page.StaffUsers.Concat(page.OtherUsers)
+            .Select(u => new UserSearchResult(u.Id, u.DisplayName, u.Email, u.IsActive, u.LastLoginAtUtc))
+            .ToList();
+    }
 
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
@@ -477,6 +540,7 @@
             isEditingName = false;
             renameMessage = "Jméno bylo úspěšně změněno.";
             renameIsError = false;
+            await LoadAllUsersAsync();
         }
         catch (ValidationException ex)
         {
@@ -632,8 +696,9 @@
             mergeSearchResults = null;
             mergeSearchQuery = "";
             mergeConfirmationShown = false;
-            // Refresh the canonical user to show updated data
+            // Refresh the canonical user and user list
             lookupResult = await UserAdministrationService.LookupByIdAsync(lookupResult.Id);
+            await LoadAllUsersAsync();
         }
         catch (ValidationException ex)
         {

--- a/src/RegistraceOvcina.Web/Features/Users/UserAdministrationService.cs
+++ b/src/RegistraceOvcina.Web/Features/Users/UserAdministrationService.cs
@@ -252,10 +252,19 @@ public sealed class UserAdministrationService(IDbContextFactory<ApplicationDbCon
 
         if (userId is null) return null;
 
+        return await LookupByIdAsync(userId, ct);
+    }
+
+    public async Task<UserLookupResult?> LookupByIdAsync(string userId, CancellationToken ct = default)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
         var user = await db.Users.AsNoTracking()
             .Where(u => u.Id == userId)
             .Select(u => new { u.Id, u.DisplayName, u.Email, u.IsActive, u.LastLoginAtUtc, u.CreatedAtUtc })
-            .SingleAsync(ct);
+            .SingleOrDefaultAsync(ct);
+
+        if (user is null) return null;
 
         var identityRoles = await db.UserRoles.AsNoTracking()
             .Where(ur => ur.UserId == userId)
@@ -276,6 +285,222 @@ public sealed class UserAdministrationService(IDbContextFactory<ApplicationDbCon
             user.Id, user.DisplayName, user.Email ?? "",
             user.IsActive, user.LastLoginAtUtc, user.CreatedAtUtc,
             identityRoles, alternateEmails, gameRoles);
+    }
+
+    public async Task<List<UserSearchResult>> SearchUsersAsync(string query, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(query) || query.Trim().Length < 2)
+            return [];
+
+        var term = query.Trim().ToUpperInvariant();
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
+        // Find user IDs matching by primary email or display name
+        var primaryMatches = await db.Users.AsNoTracking()
+            .Where(u => u.NormalizedEmail!.Contains(term) || u.DisplayName.ToUpper().Contains(term))
+            .Select(u => u.Id)
+            .Take(10)
+            .ToListAsync(ct);
+
+        // Find user IDs matching by alternate email
+        var alternateMatches = await db.UserEmails.AsNoTracking()
+            .Where(ue => ue.NormalizedEmail.Contains(term))
+            .Select(ue => ue.UserId)
+            .Distinct()
+            .Take(10)
+            .ToListAsync(ct);
+
+        var allUserIds = primaryMatches.Union(alternateMatches).Distinct().ToList();
+        if (allUserIds.Count == 0) return [];
+
+        var results = await db.Users.AsNoTracking()
+            .Where(u => allUserIds.Contains(u.Id))
+            .OrderBy(u => u.DisplayName)
+            .ThenBy(u => u.Email)
+            .Take(10)
+            .Select(u => new UserSearchResult(u.Id, u.DisplayName, u.Email ?? "", u.IsActive, u.LastLoginAtUtc))
+            .ToListAsync(ct);
+
+        return results;
+    }
+
+    public async Task RenameUserAsync(string userId, string newDisplayName, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(newDisplayName))
+            throw new ValidationException("Jméno nesmí být prázdné.");
+
+        newDisplayName = newDisplayName.Trim();
+        if (newDisplayName.Length > 200)
+            throw new ValidationException("Jméno je příliš dlouhé (max 200 znaků).");
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+        var nowUtc = timeProvider.GetUtcNow().UtcDateTime;
+
+        var user = await db.Users.SingleOrDefaultAsync(u => u.Id == userId, ct)
+            ?? throw new ValidationException("Uživatel nebyl nalezen.");
+
+        var oldName = user.DisplayName;
+        user.DisplayName = newDisplayName;
+
+        db.AuditLogs.Add(new AuditLog
+        {
+            EntityType = nameof(ApplicationUser),
+            EntityId = user.Id,
+            Action = "UserRenamed",
+            ActorUserId = userId,
+            CreatedAtUtc = nowUtc,
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                OldDisplayName = oldName,
+                NewDisplayName = newDisplayName,
+                user.Email
+            })
+        });
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task MergeUsersAsync(string canonicalUserId, string duplicateUserId, CancellationToken ct = default)
+    {
+        if (canonicalUserId == duplicateUserId)
+            throw new ValidationException("Nelze sloučit uživatele sám se sebou.");
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+        var nowUtc = timeProvider.GetUtcNow().UtcDateTime;
+
+        var canonical = await db.Users.SingleOrDefaultAsync(u => u.Id == canonicalUserId, ct)
+            ?? throw new ValidationException("Cílový uživatel nebyl nalezen.");
+        var duplicate = await db.Users.SingleOrDefaultAsync(u => u.Id == duplicateUserId, ct)
+            ?? throw new ValidationException("Duplicitní uživatel nebyl nalezen.");
+
+        // 1. Transfer identity roles
+        var canonicalRoleIds = await db.UserRoles.AsNoTracking()
+            .Where(ur => ur.UserId == canonicalUserId)
+            .Select(ur => ur.RoleId)
+            .ToListAsync(ct);
+
+        var duplicateRoles = await db.UserRoles
+            .Where(ur => ur.UserId == duplicateUserId)
+            .ToListAsync(ct);
+
+        foreach (var role in duplicateRoles)
+        {
+            if (!canonicalRoleIds.Contains(role.RoleId))
+            {
+                db.UserRoles.Add(new IdentityUserRole<string>
+                {
+                    UserId = canonicalUserId,
+                    RoleId = role.RoleId
+                });
+            }
+            db.UserRoles.Remove(role);
+        }
+
+        // 2. Transfer game roles
+        var canonicalGameRoles = await db.GameRoles.AsNoTracking()
+            .Where(gr => gr.UserId == canonicalUserId)
+            .Select(gr => new { gr.GameId, gr.RoleName })
+            .ToListAsync(ct);
+
+        var duplicateGameRoles = await db.GameRoles
+            .Where(gr => gr.UserId == duplicateUserId)
+            .ToListAsync(ct);
+
+        foreach (var gr in duplicateGameRoles)
+        {
+            if (!canonicalGameRoles.Any(c => c.GameId == gr.GameId && c.RoleName == gr.RoleName))
+            {
+                gr.UserId = canonicalUserId;
+            }
+            else
+            {
+                db.GameRoles.Remove(gr);
+            }
+        }
+
+        // 3. Transfer external logins
+        var duplicateLogins = await db.UserLogins
+            .Where(ul => ul.UserId == duplicateUserId)
+            .ToListAsync(ct);
+
+        foreach (var login in duplicateLogins)
+        {
+            db.UserLogins.Remove(login);
+            db.UserLogins.Add(new IdentityUserLogin<string>
+            {
+                UserId = canonicalUserId,
+                LoginProvider = login.LoginProvider,
+                ProviderKey = login.ProviderKey,
+                ProviderDisplayName = login.ProviderDisplayName
+            });
+        }
+
+        // 4. Transfer alternate emails
+        var canonicalEmails = await db.UserEmails.AsNoTracking()
+            .Where(ue => ue.UserId == canonicalUserId)
+            .Select(ue => ue.NormalizedEmail)
+            .ToListAsync(ct);
+
+        var duplicateEmails = await db.UserEmails
+            .Where(ue => ue.UserId == duplicateUserId)
+            .ToListAsync(ct);
+
+        foreach (var ue in duplicateEmails)
+        {
+            if (!canonicalEmails.Contains(ue.NormalizedEmail))
+            {
+                ue.UserId = canonicalUserId;
+            }
+            else
+            {
+                db.UserEmails.Remove(ue);
+            }
+        }
+
+        // 5. Copy PersonId if canonical doesn't have one
+        if (canonical.PersonId is null && duplicate.PersonId is not null)
+        {
+            canonical.PersonId = duplicate.PersonId;
+        }
+
+        // 6. Deactivate duplicate
+        duplicate.IsActive = false;
+        duplicate.SecurityStamp = Guid.NewGuid().ToString("N");
+
+        // 7. Add duplicate's primary email as alternate on canonical (if different and not already there)
+        var duplicatePrimaryNormalized = duplicate.Email?.Trim().ToUpperInvariant();
+        var canonicalPrimaryNormalized = canonical.Email?.Trim().ToUpperInvariant();
+        if (!string.IsNullOrWhiteSpace(duplicatePrimaryNormalized)
+            && duplicatePrimaryNormalized != canonicalPrimaryNormalized
+            && !canonicalEmails.Contains(duplicatePrimaryNormalized))
+        {
+            db.UserEmails.Add(new UserEmail
+            {
+                UserId = canonicalUserId,
+                Email = duplicate.Email!.Trim(),
+                NormalizedEmail = duplicatePrimaryNormalized,
+                CreatedAtUtc = nowUtc
+            });
+        }
+
+        db.AuditLogs.Add(new AuditLog
+        {
+            EntityType = nameof(ApplicationUser),
+            EntityId = canonicalUserId,
+            Action = "UserMerged",
+            ActorUserId = canonicalUserId,
+            CreatedAtUtc = nowUtc,
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                CanonicalUserId = canonicalUserId,
+                CanonicalEmail = canonical.Email,
+                DuplicateUserId = duplicateUserId,
+                DuplicateEmail = duplicate.Email,
+                DuplicateDisplayName = duplicate.DisplayName
+            })
+        });
+
+        await db.SaveChangesAsync(ct);
     }
 }
 
@@ -311,3 +536,5 @@ public sealed record UserLookupResult(
     List<GameRoleSummary> GameRoles);
 
 public sealed record GameRoleSummary(int GameId, string GameName, string RoleName);
+
+public sealed record UserSearchResult(string Id, string DisplayName, string Email, bool IsActive, DateTime? LastLoginAtUtc);

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.8.5</Version>
+    <Version>0.8.6</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
- **Partial search** — search by name or email fragment, pick from results
- **Rename user** — edit DisplayName inline (fixes group-name-as-person-name issue)
- **Merge users** — transfer roles, logins, emails from duplicate to canonical, deactivate duplicate
- **User list** — all users shown on page load as a table with Otevřít button
- Version bump to 0.8.6

## Test plan
- [ ] CI passes
- [ ] Search with partial text shows multiple results
- [ ] Clicking user opens detail
- [ ] Rename works + refreshes list
- [ ] Merge works + refreshes list
- [ ] Alternate email add/remove still works
- [ ] User list shows on page load, hides on detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)