### PR TITLE
[v0.8.8] fix: hide deactivated users from search and user list

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/UserAdmin.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/UserAdmin.razor
@@ -438,6 +438,7 @@
     {
         var page = await UserAdministrationService.GetPageAsync();
         allUsers = page.StaffUsers.Concat(page.OtherUsers)
+            .Where(u => u.IsActive)
             .Select(u => new UserSearchResult(u.Id, u.DisplayName, u.Email, u.IsActive, u.LastLoginAtUtc))
             .ToList();
     }

--- a/src/RegistraceOvcina.Web/Features/Users/UserAdministrationService.cs
+++ b/src/RegistraceOvcina.Web/Features/Users/UserAdministrationService.cs
@@ -295,16 +295,16 @@ public sealed class UserAdministrationService(IDbContextFactory<ApplicationDbCon
         var term = query.Trim().ToUpperInvariant();
         await using var db = await dbContextFactory.CreateDbContextAsync(ct);
 
-        // Find user IDs matching by primary email or display name
+        // Find user IDs matching by primary email or display name (active only)
         var primaryMatches = await db.Users.AsNoTracking()
-            .Where(u => u.NormalizedEmail!.Contains(term) || u.DisplayName.ToUpper().Contains(term))
+            .Where(u => u.IsActive && (u.NormalizedEmail!.Contains(term) || u.DisplayName.ToUpper().Contains(term)))
             .Select(u => u.Id)
             .Take(10)
             .ToListAsync(ct);
 
-        // Find user IDs matching by alternate email
+        // Find user IDs matching by alternate email (active users only)
         var alternateMatches = await db.UserEmails.AsNoTracking()
-            .Where(ue => ue.NormalizedEmail.Contains(term))
+            .Where(ue => ue.NormalizedEmail.Contains(term) && ue.User.IsActive)
             .Select(ue => ue.UserId)
             .Distinct()
             .Take(10)

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.8.7</Version>
+    <Version>0.8.8</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
- Search results exclude deactivated users (both primary and alternate email search)
- All-users list on admin page only shows active users

## Test plan
- [ ] CI passes
- [ ] Search doesn't show deactivated accounts
- [ ] User list only shows active users

🤖 Generated with [Claude Code](https://claude.com/claude-code)