### PR TITLE
fix: QR stickers EF Core query translation error

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/QrStickers.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/QrStickers.razor
@@ -100,14 +100,13 @@ else
                 && r.Status == RegistrationStatus.Active
                 && !r.Submission.IsDeleted
                 && !r.Person.IsDeleted)
+            .OrderBy(r => r.Person.LastName)
+            .ThenBy(r => r.Person.FirstName)
             .Select(r => new StickerData(
                 r.Person.Id,
                 r.Person.FirstName,
                 r.Person.LastName,
                 r.CharacterName))
-            .Distinct()
-            .OrderBy(r => r.LastName)
-            .ThenBy(r => r.FirstName)
             .ToListAsync();
     }
 


### PR DESCRIPTION
## Summary
- `Distinct()` on record projection with `OrderBy` can't be translated by EF Core
- Removed `Distinct()` (registrations are already unique per person+game)
- Moved `OrderBy` before `Select` so EF Core can translate it

## Test plan
- [ ] `/organizace/hry/1/qr-stitky` loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)