### PR TITLE
[v0.9.0] feat: adults page — game role assignment, sorting, grouping

### DIFF
--- a/docs/plans/2026-04-12-qr-glejt-character-system-design.md
+++ b/docs/plans/2026-04-12-qr-glejt-character-system-design.md
@@ -1,0 +1,157 @@
+# QR Glejt & Character System — Design
+
+**Date:** 2026-04-12
+**Status:** Approved
+**Deadline:** 2026-05-01 (game day)
+
+## Problem
+
+Ovčina LARP (~120 children) currently tracks character progression with pen and pencil on paper badges (glejty). No digital record of who leveled when, what skills were gained, or event history. Characters exist in registrace as seed data but don't live or evolve anywhere.
+
+## Solution
+
+Add QR codes to glejty (as stickers). Organizers scan with phone camera, land on hra.ovcina.cz, see/edit the character's live game state. Character management lives in hra as a natural extension of the world wiki.
+
+## System Boundaries
+
+### Registrace (registrace.ovcina.cz)
+- **Owns:** Person, Registration, Character seed (name, class, kingdom from sign-up)
+- **New:** QR sticker print page, character seed API endpoint
+- **Does NOT:** track live game state
+
+### OvcinaHra (hra.ovcina.cz)
+- **Currently:** World wiki (locations, monsters, quests, items)
+- **New:** Character entity, CharacterAssignment, event log, scan page
+- **Owns:** Live character state (level, skills, points), cross-game character history
+- **Auth:** OIDC via registrace (already working)
+
+### Integration
+- REST API only. Registrace exposes `GET /api/v1/games/{gameId}/characters` for seed data.
+- Hra calls it once at game setup, creates its own records.
+- No shared DB, no event bus, no file exports.
+
+## Data Model (in Hra)
+
+### Character (persistent world entity)
+```
+Id, Name, Race, Kingdom, BirthYear (in-game lore year)
+Notes, IsPlayedCharacter (vs lore-only NPC)
+IsDeleted, CreatedAtUtc, UpdatedAtUtc
+ParentCharacterId (nullable — in-game family tree)
+ExternalPersonId (nullable — registrace PersonId for played characters)
+```
+
+### CharacterAssignment (character in a game, played by a person)
+```
+Id, CharacterId, GameId, ExternalPersonId
+IsActive (false if character died mid-game)
+StartedAtUtc, EndedAtUtc (nullable)
+```
+
+- One Player (Person) can have multiple Characters over time
+- One Character can participate in multiple Games (cross-game continuity)
+- One Player can have multiple Characters in one Game (if character dies → new one)
+- QR resolves: PersonId → active CharacterAssignment for current game → Character
+
+### CharacterEvent (timestamped log)
+```
+Id, CharacterAssignmentId, Timestamp
+OrganizerId (who logged it), EventType, Data (JSON)
+Location (optional freeform text — which town/station)
+```
+
+Event types: `LevelUp`, `SkillGained`, `PointsChanged`, `Note`
+
+Current character state = replay of events:
+- Level = count of LevelUp events
+- Skills = collected SkillGained events
+- Points = sum of PointsChanged events per category (good/bad/neutral)
+
+## QR Code
+
+**Encodes:** `hra.ovcina.cz/p/{personId}` — simple URL, any phone camera works.
+
+**PersonId** is from registrace, stable across games. Hra resolves which character this person is currently playing.
+
+**Physical format:** Sticker sheet printed from registrace, peel and stick onto existing glejty. Each sticker shows player name + character name + QR.
+
+## Scan Page UX (`/p/{personId}`)
+
+Organizer scans QR → lands on scan page → sees:
+
+**Header:** Character name, kingdom, race, level
+
+**Quick actions (big buttons, mobile-friendly):**
+- "Level up" — one tap
+- "Add points" — pick category + amount
+- "Add note" — freeform text
+
+**Recent events:** last 5 entries with timestamp + organizer name
+
+**No offline-first complexity.** Signal is mostly available, occasional dead spots. Failed writes retry in background. Character data cached in browser after first load (Blazor WASM).
+
+## Registrace Changes
+
+### 1. QR Sticker Print Page
+- Route: `/organizace/hry/{gameId}/qr-stitky`
+- Grid of stickers: player name + character name + QR code
+- CSS print-optimized, cut along lines
+- QRCoder NuGet for SVG generation
+- Can ship independently before hra is ready
+
+### 2. Character Seed API
+- `GET /api/v1/games/{gameId}/characters`
+- Returns all characters for a game with person info, kingdom, class
+- Protected by existing API key filter
+
+## Hra Changes
+
+### 1. Character CRUD
+- Admin pages for character list + edit form
+- Fields: name, race, kingdom, birth year, notes, isPlayed, parent link
+- Basic for May 1 — polish later
+
+### 2. Import from Registrace
+- Game setup action: call registrace API, create Character + CharacterAssignment records
+- Match by ExternalPersonId to avoid duplicates on re-import
+
+### 3. Scan Page
+- `/p/{personId}` — mobile-optimized, organizer-only (OIDC auth required)
+- Resolves active CharacterAssignment for current game
+- Quick actions for level up, points, notes
+- Event log display
+
+### 4. Event Log
+- CharacterEvent entity + EF migration
+- Service for creating events + computing current state
+- API endpoints for the Blazor WASM client
+
+## Build Order (for May 1 deadline)
+
+**Week 1 (Apr 12-18) — Registrace:**
+1. QR sticker print page
+2. Character seed API endpoint
+
+**Week 1-2 (Apr 12-25) — Hra:**
+1. Character + CharacterAssignment + CharacterEvent entities + migrations
+2. Character CRUD pages (basic)
+3. Import from registrace
+4. Scan page + event log
+
+**Week 3 (Apr 25-30) — Polish:**
+1. Test with real data
+2. Print stickers
+3. Bug fixes
+
+**Post-game (after May 1):**
+- Family tree links UI
+- Character history across games
+- Richer skill/progression system
+- Player-facing character profiles
+
+## Non-Goals (for May 1)
+- Offline-first PWA with sync
+- Player-facing profiles (organizer-only)
+- Skill catalog / progression rules
+- Family tree UI (field exists, UI later)
+- Character death / new character flow UI (can be done manually via admin)

--- a/docs/plans/2026-04-12-qr-stickers-seed-api-implementation.md
+++ b/docs/plans/2026-04-12-qr-stickers-seed-api-implementation.md
@@ -1,0 +1,177 @@
+# QR Stickers & Character Seed API — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add QR sticker print page and character seed API endpoint to registrace for the glejt/character system.
+
+**Architecture:** Two additions — a new organizer page that generates printable QR sticker sheets using QRCoder (already installed), and a new integration API endpoint returning character data for a game.
+
+**Tech Stack:** .NET 10, Blazor Server, QRCoder 1.6.0, existing integration API pattern
+
+---
+
+### Task 1: Character Seed API Endpoint
+
+**Files:**
+- Modify: `src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs`
+- Modify: `src/RegistraceOvcina.Web/Features/Integration/IntegrationApiDtos.cs`
+
+**Step 1: Add DTO to IntegrationApiDtos.cs**
+
+```csharp
+/// <summary>Character seed data for hra import.</summary>
+public sealed record CharacterSeedDto(
+    int CharacterId,
+    int PersonId,
+    string PersonFirstName,
+    string PersonLastName,
+    int PersonBirthYear,
+    string CharacterName,
+    string? Race,
+    string? ClassOrType,
+    string? KingdomName,
+    int? KingdomId,
+    int? LevelReached,
+    string ContinuityStatus);
+```
+
+**Step 2: Add endpoint to IntegrationApiEndpoints.cs**
+
+After the existing `/games/{id:int}/registrations` endpoint, add:
+
+```csharp
+// GET /api/v1/games/{id}/characters — character seeds for hra import
+group.MapGet("/games/{id:int}/characters", async (
+    int id,
+    IDbContextFactory<ApplicationDbContext> dbFactory,
+    CancellationToken ct) =>
+{
+    await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+    var characters = await db.CharacterAppearances
+        .AsNoTracking()
+        .Where(ca => ca.GameId == id && !ca.Character.IsDeleted)
+        .Select(ca => new CharacterSeedDto(
+            ca.CharacterId,
+            ca.Character.PersonId,
+            ca.Character.Person.FirstName,
+            ca.Character.Person.LastName,
+            ca.Character.Person.BirthYear,
+            ca.Character.Name,
+            ca.Character.Race,
+            ca.Character.ClassOrType,
+            ca.AssignedKingdom != null ? ca.AssignedKingdom.Name : null,
+            ca.AssignedKingdomId,
+            ca.LevelReached,
+            ca.ContinuityStatus.ToString()))
+        .ToListAsync(ct);
+
+    return Results.Ok(characters);
+});
+```
+
+**Step 3: Commit**
+
+```bash
+git add -A && git commit -m "feat: add character seed API endpoint for hra import"
+```
+
+---
+
+### Task 2: QR Sticker Print Page
+
+**Files:**
+- Create: `src/RegistraceOvcina.Web/Components/Pages/Organizer/QrStickers.razor`
+- Modify: `src/RegistraceOvcina.Web/Components/Layout/MainLayout.razor` (add nav link if game-specific pages have nav)
+
+**Step 1: Create QrStickers.razor**
+
+Route: `@page "/organizace/hry/{gameId:int}/qr-stitky"`
+Authorization: organizer/admin only
+Render mode: static SSR (print page, no interactivity needed)
+
+The page:
+1. Loads all active registrations for the game with their Person + Character data
+2. Generates a QR code for each player encoding `hra.ovcina.cz/p/{personId}`
+3. Renders a printable grid of stickers, each showing:
+   - Player real name (FirstName LastName)
+   - Character name
+   - QR code (SVG inline via QRCoder)
+4. CSS print layout: A4, grid of stickers (3 columns x N rows), cut lines
+5. Print button at top (hidden in print CSS)
+
+**QR generation using QRCoder:**
+```csharp
+using QRCoder;
+
+private string GenerateQrSvg(int personId)
+{
+    var url = $"https://hra.ovcina.cz/p/{personId}";
+    using var generator = new QRCodeGenerator();
+    using var data = generator.CreateQrCode(url, QRCodeGenerator.ECCLevel.M);
+    using var svgQr = new SvgQRCode(data);
+    return svgQr.GetGraphic(3);
+}
+```
+
+**Data loading:**
+```csharp
+var registrations = await db.Registrations
+    .AsNoTracking()
+    .Where(r => r.Submission.GameId == gameId
+        && r.Submission.Status == SubmissionStatus.Submitted
+        && r.Status == RegistrationStatus.Active
+        && !r.Submission.IsDeleted
+        && !r.Person.IsDeleted)
+    .Select(r => new {
+        r.Person.Id,
+        r.Person.FirstName,
+        r.Person.LastName,
+        r.CharacterName
+    })
+    .OrderBy(r => r.LastName)
+    .ThenBy(r => r.FirstName)
+    .ToListAsync();
+```
+
+**Print CSS:**
+```css
+@media print {
+    .no-print { display: none !important; }
+    .sticker-grid { page-break-inside: avoid; }
+    .sticker { 
+        border: 1px dashed #ccc; 
+        padding: 8px; 
+        text-align: center;
+        break-inside: avoid;
+    }
+}
+```
+
+**Step 2: Add navigation link**
+
+On the game detail/management pages, add a link to the QR stickers page. Check where other game-specific organizer links live (like `/organizace/hry/{gameId}/kralovstvi` etc.) and add "QR štítky" link nearby.
+
+**Step 3: Commit**
+
+```bash
+git add -A && git commit -m "feat: QR sticker print page for game badges"
+```
+
+---
+
+### Task 3: Version Bump + PR
+
+**Files:**
+- Modify: `src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj` — bump to 0.8.9
+
+**Step 1: Bump version**
+
+**Step 2: Commit and push**
+
+```bash
+git add -A && git commit -m "[v0.8.9] feat: QR stickers and character seed API"
+git push -u origin feature/qr-stickers-seed-api
+```
+
+**Step 3: Create PR, wait for CI, resolve comments, merge**

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameRoles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameRoles.razor
@@ -1,37 +1,38 @@
 @page "/organizace/role"
+@rendermode InteractiveServer
 @attribute [Authorize(Policy = AuthorizationPolicies.StaffOnly)]
 
-@using RegistraceOvcina.Web.Infrastructure
 @using Microsoft.EntityFrameworkCore
 @inject IDbContextFactory<ApplicationDbContext> DbFactory
 @inject GameService GameService
+@inject GameRoleService GameRoleService
+@inject AuthenticationStateProvider AuthStateProvider
 
-<PageTitle>Role dospělých</PageTitle>
+<PageTitle>Dospělí</PageTitle>
 
 <div class="d-flex justify-content-between align-items-end mb-4">
     <div>
-        <h1 class="h3 mb-1">Role dospělých</h1>
-        <p class="text-secondary mb-0">Přehled dospělých účastníků a jejich rolí pro aktuální hru.</p>
+        <h1 class="h3 mb-1">Dospělí</h1>
+        <p class="text-secondary mb-0">Přehled a správa herních rolí dospělých účastníků.</p>
     </div>
-    <div>
-        <form method="get" class="d-flex align-items-center gap-2">
-            <label class="form-label mb-0 text-nowrap" for="game-filter">Hra</label>
-            <select id="game-filter" name="gameId" class="form-select form-select-sm" style="min-width: 200px;" onchange="this.form.submit()">
-                @if (games is not null)
+    <div class="d-flex align-items-center gap-2">
+        <label class="form-label mb-0 text-nowrap" for="game-filter">Hra</label>
+        <select id="game-filter" class="form-select form-select-sm" style="min-width: 200px;"
+                value="@selectedGameId" @onchange="OnGameChanged">
+            @if (games is not null)
+            {
+                @foreach (var game in games)
                 {
-                    @foreach (var game in games)
-                    {
-                        <option value="@game.Id" selected="@(selectedGameId == game.Id)">@game.Name</option>
-                    }
+                    <option value="@game.Id">@game.Name</option>
                 }
-            </select>
-        </form>
+            }
+        </select>
     </div>
 </div>
 
 @if (adults is null)
 {
-    <p class="text-secondary">Načítám...</p>
+    <p class="text-secondary">Načítám…</p>
 }
 else if (adults.Count == 0)
 {
@@ -39,85 +40,348 @@ else if (adults.Count == 0)
 }
 else
 {
-    <div class="table-responsive">
-        <table class="table align-middle">
-            <thead>
-                <tr>
-                    <th>Jméno</th>
-                    <th>Skupina</th>
-                    <th>Zvolené role</th>
-                    <th>Poznámka</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var adult in adults)
-                {
-                    <tr>
-                        <td class="fw-semibold">@adult.FullName</td>
-                        <td>@adult.GroupName</td>
-                        <td>
-                            @if (adult.Roles.Count > 0)
-                            {
-                                <div class="d-flex flex-wrap gap-1">
-                                    @foreach (var role in adult.Roles)
-                                    {
-                                        <span class="badge text-bg-secondary">@role</span>
-                                    }
-                                </div>
-                            }
-                            else
-                            {
-                                <span class="text-secondary">Bez role</span>
-                            }
-                        </td>
-                        <td class="small text-secondary">@(adult.Note ?? "—")</td>
-                    </tr>
-                }
-            </tbody>
-        </table>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div class="text-secondary small">Celkem: <strong>@adults.Count</strong> dospělých</div>
+        <button class="btn btn-sm @(groupByRole ? "btn-primary" : "btn-outline-secondary")"
+                @onclick="ToggleGrouping">
+            <i class="bi bi-collection me-1"></i>Seskupit podle role
+        </button>
     </div>
 
-    <div class="text-secondary small mt-2">Celkem: <strong>@adults.Count</strong> dospělých</div>
+    @if (groupByRole)
+    {
+        @foreach (var group in GetRoleGroups())
+        {
+            <div class="mb-4">
+                <h5 class="mb-2">@group.RoleName <span class="badge text-bg-secondary">@group.Adults.Count</span></h5>
+                @if (group.Adults.Count == 0)
+                {
+                    <p class="text-secondary small ms-2">Nikdo nemá tuto roli.</p>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th role="button" @onclick="ToggleSort" class="user-select-none">
+                                        Jméno @SortIndicator
+                                    </th>
+                                    <th>Skupina</th>
+                                    <th>E-mail</th>
+                                    <th>Zvolené role</th>
+                                    <th>Přidělené herní role</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var adult in SortAdults(group.Adults))
+                                {
+                                    <tr>
+                                        <td class="fw-semibold">@adult.FullName</td>
+                                        <td>@adult.GroupName</td>
+                                        <td class="small">@(adult.Email ?? "—")</td>
+                                        <td>
+                                            <div class="d-flex flex-wrap gap-1">
+                                                @foreach (var label in GetAdultRoleLabels(adult.AdultRoles))
+                                                {
+                                                    <span class="badge text-bg-light border">@label</span>
+                                                }
+                                            </div>
+                                        </td>
+                                        <td>
+                                            @if (adult.HasAccount)
+                                            {
+                                                <div class="d-flex flex-wrap gap-1 mb-1">
+                                                    @foreach (var role in adult.AssignedGameRoles)
+                                                    {
+                                                        <span class="badge text-bg-primary d-inline-flex align-items-center gap-1">
+                                                            @role
+                                                            <button type="button" class="btn-close btn-close-white" style="font-size: 0.5rem;"
+                                                                    @onclick="() => RevokeRoleAsync(adult, role)"></button>
+                                                        </span>
+                                                    }
+                                                </div>
+                                                <div class="d-flex gap-1">
+                                                    <select class="form-select form-select-sm" style="max-width: 180px;"
+                                                            value="@adult.SelectedRole"
+                                                            @onchange="(e) => adult.SelectedRole = e.Value?.ToString() ?? string.Empty">
+                                                        <option value="">-- Vybrat --</option>
+                                                        @foreach (var r in GetAvailableRolesFor(adult))
+                                                        {
+                                                            <option value="@r">@r</option>
+                                                        }
+                                                    </select>
+                                                    <button class="btn btn-sm btn-outline-primary"
+                                                            disabled="@string.IsNullOrEmpty(adult.SelectedRole)"
+                                                            @onclick="() => AssignRoleAsync(adult)">
+                                                        Přidat
+                                                    </button>
+                                                </div>
+                                            }
+                                            else
+                                            {
+                                                <span class="badge text-bg-warning">Bez účtu</span>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+            </div>
+        }
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table align-middle">
+                <thead>
+                    <tr>
+                        <th role="button" @onclick="ToggleSort" class="user-select-none">
+                            Jméno @SortIndicator
+                        </th>
+                        <th>Skupina</th>
+                        <th>E-mail</th>
+                        <th>Zvolené role</th>
+                        <th>Přidělené herní role</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var adult in SortAdults(adults))
+                    {
+                        <tr>
+                            <td class="fw-semibold">@adult.FullName</td>
+                            <td>@adult.GroupName</td>
+                            <td class="small">@(adult.Email ?? "—")</td>
+                            <td>
+                                <div class="d-flex flex-wrap gap-1">
+                                    @foreach (var label in GetAdultRoleLabels(adult.AdultRoles))
+                                    {
+                                        <span class="badge text-bg-light border">@label</span>
+                                    }
+                                </div>
+                            </td>
+                            <td>
+                                @if (adult.HasAccount)
+                                {
+                                    <div class="d-flex flex-wrap gap-1 mb-1">
+                                        @foreach (var role in adult.AssignedGameRoles)
+                                        {
+                                            <span class="badge text-bg-primary d-inline-flex align-items-center gap-1">
+                                                @role
+                                                <button type="button" class="btn-close btn-close-white" style="font-size: 0.5rem;"
+                                                        @onclick="() => RevokeRoleAsync(adult, role)"></button>
+                                            </span>
+                                        }
+                                    </div>
+                                    <div class="d-flex gap-1">
+                                        <select class="form-select form-select-sm" style="max-width: 180px;"
+                                                value="@adult.SelectedRole"
+                                                @onchange="(e) => adult.SelectedRole = e.Value?.ToString() ?? string.Empty">
+                                            <option value="">-- Vybrat --</option>
+                                            @foreach (var r in GetAvailableRolesFor(adult))
+                                            {
+                                                <option value="@r">@r</option>
+                                            }
+                                        </select>
+                                        <button class="btn btn-sm btn-outline-primary"
+                                                disabled="@string.IsNullOrEmpty(adult.SelectedRole)"
+                                                @onclick="() => AssignRoleAsync(adult)">
+                                            Přidat
+                                        </button>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <span class="badge text-bg-warning">Bez účtu</span>
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
 }
 
 @code {
-    [SupplyParameterFromQuery(Name = "gameId")]
-    private int? selectedGameId { get; set; }
-
+    private int? selectedGameId;
     private IReadOnlyList<GameSummary>? games;
-    private IReadOnlyList<AdultRoleView>? adults;
+    private List<AdultRoleView>? adults;
+    private List<string> availableGameRoles = [];
+    private bool groupByRole;
+    private bool sortDescending;
+    private string currentUserId = "";
+
+    private string SortIndicator => sortDescending ? "▼" : "▲";
 
     protected override async Task OnInitializedAsync()
     {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        currentUserId = authState.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value ?? "";
+
         games = await GameService.GetAdminGamesAsync();
 
-        if (!selectedGameId.HasValue && games.Count > 0)
+        if (games.Count > 0)
         {
             selectedGameId = games[0].Id;
-        }
-
-        if (selectedGameId.HasValue)
-        {
-            await using var db = await DbFactory.CreateDbContextAsync();
-            adults = await db.Registrations
-                .AsNoTracking()
-                .Where(r => r.Submission.GameId == selectedGameId.Value
-                    && r.AttendeeType == AttendeeType.Adult
-                    && r.Status == RegistrationStatus.Active
-                    && !r.Submission.IsDeleted)
-                .OrderBy(r => r.Person.LastName)
-                .ThenBy(r => r.Person.FirstName)
-                .Select(r => new AdultRoleView(
-                    r.Id,
-                    $"{r.Person.FirstName} {r.Person.LastName}",
-                    r.Submission.GroupName,
-                    GetRoleLabels(r.AdultRoles),
-                    r.RegistrantNote))
-                .ToListAsync();
+            await LoadDataAsync();
         }
     }
 
-    private static List<string> GetRoleLabels(AdultRoleFlags flags)
+    private async Task OnGameChanged(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var gameId))
+        {
+            selectedGameId = gameId;
+            await LoadDataAsync();
+        }
+    }
+
+    private async Task LoadDataAsync()
+    {
+        if (!selectedGameId.HasValue) return;
+
+        await using var db = await DbFactory.CreateDbContextAsync();
+
+        // Load available game roles
+        availableGameRoles = await db.Roles.AsNoTracking()
+            .Where(r => r.Category == "game")
+            .OrderBy(r => r.Name)
+            .Select(r => r.Name!)
+            .ToListAsync();
+
+        // Load adults
+        var adultRows = await db.Registrations.AsNoTracking()
+            .Where(r => r.Submission.GameId == selectedGameId.Value
+                && r.AttendeeType == AttendeeType.Adult
+                && r.Status == RegistrationStatus.Active
+                && !r.Submission.IsDeleted)
+            .OrderBy(r => r.Person.LastName)
+            .ThenBy(r => r.Person.FirstName)
+            .Select(r => new
+            {
+                r.Id,
+                FirstName = r.Person.FirstName,
+                LastName = r.Person.LastName,
+                r.Submission.GroupName,
+                Email = r.Person.Email,
+                r.AdultRoles
+            })
+            .ToListAsync();
+
+        // Load all emails that have user accounts
+        var allEmails = adultRows
+            .Where(a => !string.IsNullOrWhiteSpace(a.Email))
+            .Select(a => a.Email!.Trim().ToUpperInvariant())
+            .Distinct()
+            .ToList();
+
+        var emailsWithAccounts = allEmails.Count > 0
+            ? await db.Users.AsNoTracking()
+                .Where(u => allEmails.Contains(u.NormalizedEmail!))
+                .Select(u => u.NormalizedEmail!)
+                .ToListAsync()
+            : [];
+
+        var emailsWithAccountsSet = emailsWithAccounts.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Load assigned game roles for this game
+        var assignedRoles = await db.GameRoles.AsNoTracking()
+            .Where(gr => gr.GameId == selectedGameId.Value)
+            .Select(gr => new { gr.User.Email, gr.RoleName })
+            .ToListAsync();
+
+        var rolesByEmail = assignedRoles
+            .Where(r => r.Email is not null)
+            .GroupBy(r => r.Email!.Trim(), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(r => r.RoleName).OrderBy(r => r).ToList(),
+                StringComparer.OrdinalIgnoreCase);
+
+        adults = adultRows.Select(a =>
+        {
+            var email = a.Email?.Trim();
+            var normalizedEmail = email?.ToUpperInvariant();
+            var hasAccount = normalizedEmail is not null && emailsWithAccountsSet.Contains(normalizedEmail);
+            var assignedRolesList = email is not null && rolesByEmail.TryGetValue(email, out var roles)
+                ? roles
+                : new List<string>();
+
+            return new AdultRoleView
+            {
+                RegistrationId = a.Id,
+                FullName = $"{a.FirstName} {a.LastName}",
+                LastName = a.LastName,
+                FirstName = a.FirstName,
+                GroupName = a.GroupName,
+                Email = email,
+                AdultRoles = a.AdultRoles,
+                HasAccount = hasAccount,
+                AssignedGameRoles = assignedRolesList,
+                SelectedRole = ""
+            };
+        }).ToList();
+    }
+
+    private async Task AssignRoleAsync(AdultRoleView adult)
+    {
+        if (string.IsNullOrEmpty(adult.SelectedRole) || string.IsNullOrEmpty(adult.Email) || !selectedGameId.HasValue)
+            return;
+
+        await GameRoleService.AssignRoleAsync(adult.Email, selectedGameId.Value, adult.SelectedRole, currentUserId);
+
+        // Update local state
+        if (!adult.AssignedGameRoles.Contains(adult.SelectedRole, StringComparer.OrdinalIgnoreCase))
+        {
+            adult.AssignedGameRoles.Add(adult.SelectedRole);
+            adult.AssignedGameRoles.Sort(StringComparer.OrdinalIgnoreCase);
+        }
+        adult.SelectedRole = "";
+    }
+
+    private async Task RevokeRoleAsync(AdultRoleView adult, string roleName)
+    {
+        if (string.IsNullOrEmpty(adult.Email) || !selectedGameId.HasValue)
+            return;
+
+        await GameRoleService.RevokeRoleAsync(adult.Email, selectedGameId.Value, roleName, currentUserId);
+
+        // Update local state
+        adult.AssignedGameRoles.RemoveAll(r => string.Equals(r, roleName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private List<string> GetAvailableRolesFor(AdultRoleView adult)
+    {
+        return availableGameRoles
+            .Where(r => !adult.AssignedGameRoles.Contains(r, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private List<RoleGroup> GetRoleGroups()
+    {
+        if (adults is null) return [];
+
+        return availableGameRoles
+            .Select(roleName => new RoleGroup(
+                roleName,
+                adults.Where(a => a.AssignedGameRoles.Contains(roleName, StringComparer.OrdinalIgnoreCase)).ToList()))
+            .Where(g => g.Adults.Count > 0)
+            .ToList();
+    }
+
+    private void ToggleSort() => sortDescending = !sortDescending;
+
+    private void ToggleGrouping() => groupByRole = !groupByRole;
+
+    private List<AdultRoleView> SortAdults(IEnumerable<AdultRoleView> source) =>
+        sortDescending
+            ? source.OrderByDescending(a => a.LastName).ThenByDescending(a => a.FirstName).ToList()
+            : source.OrderBy(a => a.LastName).ThenBy(a => a.FirstName).ToList();
+
+    private static List<string> GetAdultRoleLabels(AdultRoleFlags flags)
     {
         var labels = new List<string>();
         if (flags.HasFlag(AdultRoleFlags.PlayMonster)) labels.Add("Příšera");
@@ -128,5 +392,19 @@ else
         return labels;
     }
 
-    private sealed record AdultRoleView(int RegistrationId, string FullName, string GroupName, List<string> Roles, string? Note);
+    private sealed class AdultRoleView
+    {
+        public int RegistrationId { get; set; }
+        public string FullName { get; set; } = "";
+        public string LastName { get; set; } = "";
+        public string FirstName { get; set; } = "";
+        public string GroupName { get; set; } = "";
+        public string? Email { get; set; }
+        public AdultRoleFlags AdultRoles { get; set; }
+        public bool HasAccount { get; set; }
+        public List<string> AssignedGameRoles { get; set; } = [];
+        public string SelectedRole { get; set; } = "";
+    }
+
+    private sealed record RoleGroup(string RoleName, List<AdultRoleView> Adults);
 }

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.8.9</Version>
+    <Version>0.9.0</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
- Renamed page to "Dospělí" — overview and management of adult attendee game roles
- **Game role assignment** — assign roles (Gandalf, Příšera, Obchodník, etc.) from dropdown, remove with X badge
- Shows "Zvolené role" (AdultRoleFlags from registration) as read-only info alongside editable game roles
- Adults without user account shown as "Bez účtu"
- **Sorting** by name (clickable header)
- **Grouping** by role toggle
- Replaces the old `/organizace/hry/{gameId}/role` assignment page for adults

## Test plan
- [ ] CI passes
- [ ] Can assign game roles to adults with accounts
- [ ] Can remove game roles
- [ ] Grouping toggle works
- [ ] Sorting works
- [ ] Adults without accounts show "Bez účtu"

🤖 Generated with [Claude Code](https://claude.com/claude-code)