### PR TITLE
fix: stop re-seeding deleted game roles

### DIFF
--- a/src/RegistraceOvcina.Web/Data/DatabaseInitializer.cs
+++ b/src/RegistraceOvcina.Web/Data/DatabaseInitializer.cs
@@ -14,10 +14,7 @@ public static class DatabaseInitializer
         (RoleNames.Organizer, "system"),
         (RoleNames.Registrant, "system"),
         (RoleNames.Guest, "system"),
-        (RoleNames.King, "game"),
-        (RoleNames.Merchant, "game"),
-        (RoleNames.Player, "game"),
-        (RoleNames.Healer, "game"),
+        // Game roles are managed by admins in /admin/roles — no longer seeded
         (RoleNames.StaffRegistration, "staff"),
         (RoleNames.StaffAccounts, "staff"),
         (RoleNames.StaffLogistics, "staff"),

--- a/src/RegistraceOvcina.Web/Security/RoleNames.cs
+++ b/src/RegistraceOvcina.Web/Security/RoleNames.cs
@@ -8,11 +8,7 @@ public static class RoleNames
     public const string Registrant = "Registrant";
     public const string Guest = "Guest";
 
-    // Game roles (world identity)
-    public const string King = "King";
-    public const string Merchant = "Merchant";
-    public const string Player = "Player";
-    public const string Healer = "Healer";
+    // Game roles are managed by admins in /admin/roles — no hardcoded constants
 
     // Staff roles (organizational)
     public const string StaffRegistration = "Staff-Registration";


### PR DESCRIPTION
## Summary
- Removed King, Merchant, Player, Healer from seed data — they were recreated on every deploy
- Game roles are managed by admins in `/admin/roles`
- Cleaned up unused RoleNames constants

## Test plan
- [ ] CI passes
- [ ] Deleted game roles stay deleted after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)