### PR TITLE
fix: QR stickers only for players, not adults

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/QrStickers.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/QrStickers.razor
@@ -98,6 +98,7 @@ else
             .Where(r => r.Submission.GameId == GameId
                 && r.Submission.Status == SubmissionStatus.Submitted
                 && r.Status == RegistrationStatus.Active
+                && r.AttendeeType == AttendeeType.Player
                 && !r.Submission.IsDeleted
                 && !r.Person.IsDeleted)
             .OrderBy(r => r.Person.LastName)


### PR DESCRIPTION
## Summary
- Filter QR sticker generation to `AttendeeType.Player` only
- Adults aren't characters in the game

## Test plan
- [ ] Sticker page shows only children/players
- [ ] Adult count drops as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)