### PR TITLE
fix: character seed API filters by active player registrations [v0.9.1]

### DIFF
--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
@@ -73,6 +73,9 @@ public static class IntegrationApiEndpoints
         }).AllowAnonymous();
 
         // GET /api/v1/games/{id}/characters — character seeds for hra import
+        // Source of truth: Registrations table with the same filters as the QR stickers page.
+        // Only active player registrations are included. CharacterAppearance is joined
+        // for race/class/kingdom/level if it exists for this registration.
         group.MapGet("/games/{id:int}/characters", async (
             int id,
             IDbContextFactory<ApplicationDbContext> dbFactory,
@@ -80,22 +83,44 @@ public static class IntegrationApiEndpoints
         {
             await using var db = await dbFactory.CreateDbContextAsync(ct);
 
-            var characters = await db.CharacterAppearances
+            var characters = await db.Registrations
                 .AsNoTracking()
-                .Where(ca => ca.GameId == id && !ca.Character.IsDeleted)
-                .Select(ca => new CharacterSeedDto(
-                    ca.CharacterId,
-                    ca.Character.PersonId,
-                    ca.Character.Person.FirstName,
-                    ca.Character.Person.LastName,
-                    ca.Character.Person.BirthYear,
-                    ca.Character.Name,
-                    ca.Character.Race,
-                    ca.Character.ClassOrType,
-                    ca.AssignedKingdom != null ? ca.AssignedKingdom.Name : null,
-                    ca.AssignedKingdomId,
-                    ca.LevelReached,
-                    ca.ContinuityStatus.ToString()))
+                .Where(r => r.Submission.GameId == id
+                    && r.Submission.Status == SubmissionStatus.Submitted
+                    && r.Status == RegistrationStatus.Active
+                    && r.AttendeeType == AttendeeType.Player
+                    && !r.Submission.IsDeleted
+                    && !r.Person.IsDeleted)
+                .Select(r => new
+                {
+                    Registration = r,
+                    Appearance = db.CharacterAppearances
+                        .Where(ca => ca.RegistrationId == r.Id && !ca.Character.IsDeleted)
+                        .Select(ca => new
+                        {
+                            ca.CharacterId,
+                            ca.Character.Race,
+                            ca.Character.ClassOrType,
+                            KingdomName = ca.AssignedKingdom != null ? ca.AssignedKingdom.Name : null,
+                            ca.AssignedKingdomId,
+                            ca.LevelReached,
+                            ContinuityStatus = ca.ContinuityStatus.ToString()
+                        })
+                        .FirstOrDefault()
+                })
+                .Select(x => new CharacterSeedDto(
+                    x.Appearance != null ? x.Appearance.CharacterId : 0,
+                    x.Registration.PersonId,
+                    x.Registration.Person.FirstName,
+                    x.Registration.Person.LastName,
+                    x.Registration.Person.BirthYear,
+                    x.Registration.CharacterName ?? (x.Registration.Person.FirstName + " " + x.Registration.Person.LastName),
+                    x.Appearance != null ? x.Appearance.Race : null,
+                    x.Appearance != null ? x.Appearance.ClassOrType : null,
+                    x.Appearance != null ? x.Appearance.KingdomName : null,
+                    x.Appearance != null ? x.Appearance.AssignedKingdomId : null,
+                    x.Appearance != null ? x.Appearance.LevelReached : null,
+                    x.Appearance != null ? x.Appearance.ContinuityStatus : "Unknown"))
                 .ToListAsync(ct);
 
             return Results.Ok(characters);

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.0</Version>
+    <Version>0.9.1</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Problem
The character seed API (used by hra.ovcina.cz to import players) was querying \`CharacterAppearances\` unfiltered. That table contains historical character records tied to game IDs even if the person isn't actually registered for the current year — so the Hra app was getting characters for people who aren't playing.

## Fix
Query \`Registrations\` with the **same filter as the QR stickers page**:
- \`Submission.GameId == id\`
- \`Submission.Status == Submitted\`
- \`Registration.Status == Active\`
- \`AttendeeType == Player\`
- Not soft-deleted (Person or Submission)

\`CharacterAppearance\` is LEFT JOINed via \`RegistrationId\` to get optional race/class/kingdom/level if set.

This makes the QR stickers page and the Hra character import return the **same set of people**.

## Test plan
- [x] Build clean
- [ ] Manual: hit \`/api/v1/games/1/characters\` after deploy, verify it matches QR sticker page count
- [ ] Manual: re-run character import from Hra, verify only active players come through

🤖 Generated with [Claude Code](https://claude.com/claude-code)