### PR TITLE
[v0.9.1] feat: bot API — game info, user game-info, lodging

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/Games.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/Games.razor
@@ -110,6 +110,12 @@
                         </div>
                     </div>
 
+                    <div class="mb-3 mt-3">
+                        <label class="form-label" for="organization-info">Organizační informace (JSON)</label>
+                        <textarea id="organization-info" name="@nameof(CreateGameInput.OrganizationInfo)" rows="10" class="form-control font-monospace" placeholder='{"location":"...","gatheringPoint":"...","whatToBring":[],"schedule":"...","organizerContact":"..."}'>@input.OrganizationInfo</textarea>
+                        <div class="form-text">Volný JSON blob pro bot integraci (místo konání, sraz, co s sebou, program, kontakt). Musí být platný JSON nebo prázdné.</div>
+                    </div>
+
                     <button type="submit" class="btn btn-primary mt-4 w-100" data-testid="create-game-submit">
                         @(editGameId.HasValue ? "Uložit změny" : "Uložit hru")
                     </button>

--- a/src/RegistraceOvcina.Web/Data/Models/Game.cs
+++ b/src/RegistraceOvcina.Web/Data/Models/Game.cs
@@ -22,6 +22,12 @@ public sealed class Game
     public VariableSymbolStrategy VariableSymbolStrategy { get; set; }
     public int TargetPlayerCountTotal { get; set; }
     public bool IsPublished { get; set; }
+
+    /// <summary>
+    /// Free-form JSON blob with organizational info (location, gathering point, what to bring,
+    /// schedule outline, organizer contact). Parsed by API endpoints into structured response.
+    /// </summary>
+    public string? OrganizationInfo { get; set; }
     public DateTime CreatedAtUtc { get; set; }
     public DateTime UpdatedAtUtc { get; set; }
     public List<GameKingdomTarget> KingdomTargets { get; set; } = [];

--- a/src/RegistraceOvcina.Web/Features/Games/CreateGameInput.cs
+++ b/src/RegistraceOvcina.Web/Features/Games/CreateGameInput.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
+using System.Text.Json;
 using RegistraceOvcina.Web.Data;
 using RegistraceOvcina.Web.Infrastructure;
 
@@ -59,6 +60,9 @@ public sealed class CreateGameInput : IValidatableObject
     public int TargetPlayerCountTotal { get; set; } = 50;
 
     public bool IsPublished { get; set; } = true;
+
+    /// <summary>Free-form JSON blob exposing org info via API (parsed by bot).</summary>
+    public string? OrganizationInfo { get; set; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
@@ -151,6 +155,26 @@ public sealed class CreateGameInput : IValidatableObject
                 "Uzávěrka jídel musí být nejpozději v okamžiku startu.",
                 [nameof(MealOrderingClosesAtLocalText)]);
         }
+
+        if (!string.IsNullOrWhiteSpace(OrganizationInfo) && !IsValidJson(OrganizationInfo))
+        {
+            yield return new ValidationResult(
+                "Organizační informace musí být platný JSON.",
+                [nameof(OrganizationInfo)]);
+        }
+    }
+
+    private static bool IsValidJson(string value)
+    {
+        try
+        {
+            using var _ = JsonDocument.Parse(value);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
     public CreateGameCommand ToCommand() => new(
@@ -171,7 +195,8 @@ public sealed class CreateGameInput : IValidatableObject
         BankAccount,
         BankAccountName,
         TargetPlayerCountTotal,
-        IsPublished);
+        IsPublished,
+        OrganizationInfo);
 
     public static CreateGameInput FromGame(Game game)
     {
@@ -196,7 +221,8 @@ public sealed class CreateGameInput : IValidatableObject
             BankAccount = game.BankAccount,
             BankAccountName = game.BankAccountName,
             TargetPlayerCountTotal = game.TargetPlayerCountTotal,
-            IsPublished = game.IsPublished
+            IsPublished = game.IsPublished,
+            OrganizationInfo = game.OrganizationInfo
         };
     }
 

--- a/src/RegistraceOvcina.Web/Features/Games/GameService.cs
+++ b/src/RegistraceOvcina.Web/Features/Games/GameService.cs
@@ -114,6 +114,7 @@ public sealed class GameService(IDbContextFactory<ApplicationDbContext> dbContex
             VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
             TargetPlayerCountTotal = command.TargetPlayerCountTotal,
             IsPublished = command.IsPublished,
+            OrganizationInfo = string.IsNullOrWhiteSpace(command.OrganizationInfo) ? null : command.OrganizationInfo,
             CreatedAtUtc = nowUtc,
             UpdatedAtUtc = nowUtc
         };
@@ -176,6 +177,7 @@ public sealed class GameService(IDbContextFactory<ApplicationDbContext> dbContex
         game.BankAccountName = command.BankAccountName.Trim();
         game.TargetPlayerCountTotal = command.TargetPlayerCountTotal;
         game.IsPublished = command.IsPublished;
+        game.OrganizationInfo = string.IsNullOrWhiteSpace(command.OrganizationInfo) ? null : command.OrganizationInfo;
         game.UpdatedAtUtc = nowUtc;
 
         await db.SaveChangesAsync(ct);
@@ -235,7 +237,8 @@ public sealed record CreateGameCommand(
     string BankAccount,
     string BankAccountName,
     int TargetPlayerCountTotal,
-    bool IsPublished);
+    bool IsPublished,
+    string? OrganizationInfo = null);
 
 public sealed record GameSummary(
     int Id,

--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiDtos.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiDtos.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace RegistraceOvcina.Web.Features.Integration;
 
 /// <summary>Publicly safe game info — excludes payment/pricing fields.</summary>
@@ -33,6 +35,50 @@ public sealed record HasRoleDto(bool HasRole);
 
 /// <summary>Role assignment request body.</summary>
 public sealed record AssignRoleRequest(int GameId, string RoleName);
+
+/// <summary>Full game info including parsed organization metadata.</summary>
+public sealed record GameInfoDto(
+    int Id,
+    string Name,
+    string? Description,
+    DateTime StartsAtUtc,
+    DateTime EndsAtUtc,
+    DateTime RegistrationClosesAtUtc,
+    int TargetPlayerCountTotal,
+    int TotalRegistered,
+    bool IsPublished,
+    JsonElement? OrganizationInfo);
+
+/// <summary>Attendee (registration) entry for a user's game info response.</summary>
+public sealed record UserAttendeeDto(
+    int PersonId,
+    string FirstName,
+    string LastName,
+    int BirthYear,
+    string AttendeeType,
+    string? CharacterName,
+    int? PreferredKingdomId);
+
+/// <summary>Lodging assignment details for a user in a game.</summary>
+public sealed record UserLodgingDto(
+    string LodgingType,
+    string? RoomName,
+    int? RoomCapacity,
+    List<string> Roommates);
+
+/// <summary>Full user-in-game info: registration, payments, attendees, lodging, roles.</summary>
+public sealed record UserGameInfoDto(
+    string Email,
+    int GameId,
+    bool Registered,
+    string? GroupName,
+    DateTime? RegistrationDate,
+    string PaymentStatus,
+    decimal? ExpectedAmount,
+    decimal? PaidAmount,
+    List<UserAttendeeDto> Attendees,
+    UserLodgingDto? Lodging,
+    List<string> GameRoles);
 
 /// <summary>Character seed data for hra import.</summary>
 public sealed record CharacterSeedDto(

--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -38,6 +39,85 @@ public static class IntegrationApiEndpoints
 
             return Results.Ok(games);
         }).AllowAnonymous();
+
+        // GET /api/v1/games/{id}/info — full game info with parsed organization metadata
+        group.MapGet("/games/{id:int}/info", async (
+            int id,
+            IDbContextFactory<ApplicationDbContext> dbFactory,
+            CancellationToken ct) =>
+        {
+            await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+            var game = await db.Games.AsNoTracking()
+                .Where(g => g.Id == id && g.IsPublished)
+                .FirstOrDefaultAsync(ct);
+
+            if (game is null)
+                return Results.NotFound();
+
+            // Parse OrganizationInfo JSON if present
+            JsonElement? orgInfo = null;
+            if (!string.IsNullOrWhiteSpace(game.OrganizationInfo))
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(game.OrganizationInfo);
+                    orgInfo = doc.RootElement.Clone();
+                }
+                catch (JsonException)
+                {
+                    // Malformed JSON — return null
+                }
+            }
+
+            var totalRegistered = await db.Registrations.AsNoTracking()
+                .CountAsync(r => r.Submission.GameId == id
+                    && r.Submission.Status == SubmissionStatus.Submitted
+                    && r.Status == RegistrationStatus.Active
+                    && !r.Submission.IsDeleted, ct);
+
+            return Results.Ok(new GameInfoDto(
+                game.Id,
+                game.Name,
+                game.Description,
+                game.StartsAtUtc,
+                game.EndsAtUtc,
+                game.RegistrationClosesAtUtc,
+                game.TargetPlayerCountTotal,
+                totalRegistered,
+                game.IsPublished,
+                orgInfo));
+        }).AllowAnonymous();
+
+        // GET /api/v1/users/{email}/game-info?gameId=... — comprehensive user-in-game info
+        group.MapGet("/users/{email}/game-info", async (
+            string email,
+            int gameId,
+            IDbContextFactory<ApplicationDbContext> dbFactory,
+            UserEmailService userEmailService,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(email))
+                return Results.BadRequest("email is required.");
+
+            var info = await LoadUserGameInfoAsync(email, gameId, dbFactory, userEmailService, ct);
+            return Results.Ok(info);
+        });
+
+        // GET /api/v1/users/{email}/lodging?gameId=... — lodging slice only
+        group.MapGet("/users/{email}/lodging", async (
+            string email,
+            int gameId,
+            IDbContextFactory<ApplicationDbContext> dbFactory,
+            UserEmailService userEmailService,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(email))
+                return Results.BadRequest("email is required.");
+
+            var info = await LoadUserGameInfoAsync(email, gameId, dbFactory, userEmailService, ct);
+            return Results.Ok(info.Lodging);
+        });
 
         // GET /api/v1/games/{id}/registrations — active registrations for a game
         group.MapGet("/games/{id:int}/registrations", async (
@@ -262,6 +342,123 @@ public static class IntegrationApiEndpoints
         });
 
         return app;
+    }
+
+    private static async Task<UserGameInfoDto> LoadUserGameInfoAsync(
+        string email,
+        int gameId,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        UserEmailService userEmailService,
+        CancellationToken ct)
+    {
+        var userId = await userEmailService.ResolveUserIdByEmailAsync(email, ct);
+        if (userId is null)
+        {
+            return new UserGameInfoDto(email, gameId, false, null, null, "unpaid", null, null, [], null, []);
+        }
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var submission = await db.RegistrationSubmissions.AsNoTracking()
+            .Where(s => s.RegistrantUserId == userId && s.GameId == gameId && !s.IsDeleted)
+            .OrderByDescending(s => s.SubmittedAtUtc ?? s.LastEditedAtUtc)
+            .FirstOrDefaultAsync(ct);
+
+        if (submission is null)
+        {
+            return new UserGameInfoDto(email, gameId, false, null, null, "unpaid", null, null, [], null, []);
+        }
+
+        // Load attendees with associated person + kingdom + room data
+        var attendees = await db.Registrations.AsNoTracking()
+            .Where(r => r.SubmissionId == submission.Id && r.Status == RegistrationStatus.Active)
+            .OrderBy(r => r.Person.LastName).ThenBy(r => r.Person.FirstName)
+            .Select(r => new
+            {
+                RegistrationId = r.Id,
+                r.PersonId,
+                r.Person.FirstName,
+                r.Person.LastName,
+                r.Person.BirthYear,
+                r.AttendeeType,
+                r.CharacterName,
+                r.PreferredKingdomId,
+                r.AssignedGameRoomId
+            })
+            .ToListAsync(ct);
+
+        var attendeeDtos = attendees.Select(a => new UserAttendeeDto(
+            a.PersonId,
+            a.FirstName,
+            a.LastName,
+            a.BirthYear,
+            a.AttendeeType.ToString(),
+            a.CharacterName,
+            a.PreferredKingdomId
+        )).ToList();
+
+        // Compute payment totals + status
+        var paid = await db.Payments.AsNoTracking()
+            .Where(p => p.SubmissionId == submission.Id)
+            .SumAsync(p => (decimal?)p.Amount, ct) ?? 0m;
+
+        var expected = submission.ExpectedTotalAmount;
+        string paymentStatus = expected > 0 && paid >= expected ? "paid"
+            : paid > 0 ? "partial"
+            : "unpaid";
+
+        // Resolve the registrant's own attendee record (by user's PersonId link)
+        var user = await db.Users.AsNoTracking()
+            .Where(u => u.Id == userId)
+            .Select(u => new { u.PersonId })
+            .FirstOrDefaultAsync(ct);
+        var selfPersonId = user?.PersonId;
+
+        var selfReg = attendees.FirstOrDefault(a => selfPersonId.HasValue && a.PersonId == selfPersonId.Value)
+            ?? attendees.FirstOrDefault(a => a.AttendeeType == AttendeeType.Adult)
+            ?? attendees.FirstOrDefault();
+
+        UserLodgingDto? lodging = null;
+        if (selfReg?.AssignedGameRoomId is int roomId)
+        {
+            var room = await db.GameRooms.AsNoTracking()
+                .Where(gr => gr.Id == roomId)
+                .Select(gr => new { gr.Id, RoomName = gr.Room.Name, gr.Capacity })
+                .FirstOrDefaultAsync(ct);
+
+            if (room is not null)
+            {
+                var roommates = await db.Registrations.AsNoTracking()
+                    .Where(r => r.AssignedGameRoomId == room.Id
+                        && r.Submission.GameId == gameId
+                        && r.Status == RegistrationStatus.Active
+                        && !r.Submission.IsDeleted
+                        && r.PersonId != selfReg.PersonId)
+                    .Select(r => r.Person.FirstName + " " + r.Person.LastName)
+                    .ToListAsync(ct);
+
+                lodging = new UserLodgingDto("Indoor", room.RoomName, room.Capacity, roommates);
+            }
+        }
+
+        // Game roles for this user in this game
+        var gameRoles = await db.GameRoles.AsNoTracking()
+            .Where(gr => gr.UserId == userId && gr.GameId == gameId)
+            .Select(gr => gr.RoleName)
+            .ToListAsync(ct);
+
+        return new UserGameInfoDto(
+            email,
+            gameId,
+            true,
+            submission.GroupName,
+            submission.SubmittedAtUtc,
+            paymentStatus,
+            expected,
+            paid,
+            attendeeDtos,
+            lodging,
+            gameRoles);
     }
 }
 

--- a/src/RegistraceOvcina.Web/Migrations/20260413054545_AddGameOrganizationInfo.Designer.cs
+++ b/src/RegistraceOvcina.Web/Migrations/20260413054545_AddGameOrganizationInfo.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RegistraceOvcina.Web.Data;
@@ -11,9 +12,11 @@ using RegistraceOvcina.Web.Data;
 namespace RegistraceOvcina.Web.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413054545_AddGameOrganizationInfo")]
+    partial class AddGameOrganizationInfo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/RegistraceOvcina.Web/Migrations/20260413054545_AddGameOrganizationInfo.cs
+++ b/src/RegistraceOvcina.Web/Migrations/20260413054545_AddGameOrganizationInfo.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RegistraceOvcina.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameOrganizationInfo : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OrganizationInfo",
+                table: "Games",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OrganizationInfo",
+                table: "Games");
+        }
+    }
+}

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.0</Version>
+    <Version>0.9.1</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
Three new integration API endpoints for the Ovčina Bot:

- **`GET /api/v1/games/{id}/info`** — full game with parsed OrganizationInfo JSON blob (location, schedule, what to bring, etc.)
- **`GET /api/v1/users/{email}/game-info?gameId=Y`** — everything for a user in a game: registration, attendees, lodging, payment status, game roles
- **`GET /api/v1/users/{email}/lodging?gameId=Y`** — lodging shortcut

Also:
- New `OrganizationInfo` field on Game (single nullable text column for free-form JSON)
- Admin UI textarea on game edit page with JSON validation
- EF migration `AddGameOrganizationInfo`

## Test plan
- [ ] CI passes
- [ ] Game edit page accepts JSON in OrganizationInfo
- [ ] `/games/{id}/info` parses and returns the JSON
- [ ] `/users/{email}/game-info` returns attendees, payment, lodging, roles
- [ ] Roommates list correctly excludes self

🤖 Generated with [Claude Code](https://claude.com/claude-code)