### PR TITLE
fix: user merge transfers registration submissions

### DIFF
--- a/src/RegistraceOvcina.Web/Features/Users/UserAdministrationService.cs
+++ b/src/RegistraceOvcina.Web/Features/Users/UserAdministrationService.cs
@@ -457,7 +457,12 @@ public sealed class UserAdministrationService(IDbContextFactory<ApplicationDbCon
             }
         }
 
-        // 5. Copy PersonId if canonical doesn't have one
+        // 5. Transfer registration submissions
+        await db.RegistrationSubmissions
+            .Where(s => s.RegistrantUserId == duplicateUserId)
+            .ExecuteUpdateAsync(s => s.SetProperty(x => x.RegistrantUserId, canonicalUserId), ct);
+
+        // 6. Copy PersonId if canonical doesn't have one
         if (canonical.PersonId is null && duplicate.PersonId is not null)
         {
             canonical.PersonId = duplicate.PersonId;


### PR DESCRIPTION
## Summary
- User merge now transfers RegistrationSubmissions from duplicate to canonical account
- Previously, submissions stayed orphaned on the deactivated account
- Real case: Lumír Kvita couldn't see his Kvitovi registration after merging lumirius@gmail.com into noir1@seznam.cz

## Test plan
- [ ] CI passes
- [ ] User merge transfers all submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)