### PR TITLE
[v0.9.2] feat: friendly registration-closed message with stand-in contact

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Home.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Home.razor
@@ -1,6 +1,7 @@
 ﻿@page "/"
 @inject GameService GameService
 @inject NavigationManager NavigationManager
+@inject TimeProvider TimeProvider
 
 <PageTitle>Ovčina registrace</PageTitle>
 
@@ -91,6 +92,13 @@
                                 <dt class="col-sm-5 text-secondary">Volná místa pro hráče</dt>
                                 <dd class="col-sm-7 fw-semibold">@game.RemainingPlayerSpots / @game.TargetPlayerCountTotal</dd>
                             </dl>
+
+                            @if (IsRegistrationClosed(game))
+                            {
+                                <div class="alert alert-warning mb-0" role="alert" data-testid="@($"landing-game-{game.Id}-closed")">
+                                    Registrace na tuto hru je již uzavřena — jsme za kapacitou. Pokud se chcete přihlásit jako náhradník, napište nám na <a href="mailto:ovcina@ovcina.cz">ovcina@ovcina.cz</a> nebo zavolejte.
+                                </div>
+                            }
                         </div>
                     </article>
                 </div>
@@ -111,4 +119,7 @@
 
     private static string GetGameDateRange(GameSummary game) =>
         $"{CzechTime.Format(game.StartsAtUtc)} - {CzechTime.Format(game.EndsAtUtc)}";
+
+    private bool IsRegistrationClosed(GameSummary game) =>
+        game.RegistrationClosesAtUtc < TimeProvider.GetUtcNow().UtcDateTime;
 }

--- a/src/RegistraceOvcina.Web/Features/Submissions/SubmissionService.cs
+++ b/src/RegistraceOvcina.Web/Features/Submissions/SubmissionService.cs
@@ -73,7 +73,7 @@ public sealed class SubmissionService(
 
         if (game.RegistrationClosesAtUtc < nowUtc)
         {
-            throw new ValidationException("Registrace pro tuto hru už byla uzavřena.");
+            throw new ValidationException("Registrace pro tuto hru je již uzavřena. Jsme za kapacitou — pokud se chcete přihlásit jako náhradník, napište nám na ovcina@ovcina.cz.");
         }
 
         var submission = new RegistrationSubmission
@@ -918,7 +918,7 @@ public sealed class SubmissionService(
             throw new ValidationException("Tuto hru zatím nelze přihlašovat.");
 
         if (game.RegistrationClosesAtUtc < nowUtc)
-            throw new ValidationException("Registrace pro tuto hru už byla uzavřena.");
+            throw new ValidationException("Registrace pro tuto hru je již uzavřena. Jsme za kapacitou — pokud se chcete přihlásit jako náhradník, napište nám na ovcina@ovcina.cz.");
 
         var existingDraft = await db.RegistrationSubmissions
             .Where(x => x.GameId == targetGameId && x.RegistrantUserId == user.Id && !x.IsDeleted)

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
- Registration deadline rejection now mentions over-capacity + stand-in option
- Home page shows "Registrace uzavřena" banner with mailto link when game's registration deadline has passed
- Direction: people who still want to come can email ovcina@ovcina.cz to register as stand-in (náhradník)

## Test plan
- [ ] CI passes
- [ ] Closed games show the banner on home page
- [ ] Submitting a registration after deadline shows the new message

🤖 Generated with [Claude Code](https://claude.com/claude-code)