### PR TITLE
Fix merge crash when canonical has duplicate normalized character names

### DIFF
--- a/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
+++ b/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
@@ -389,10 +389,15 @@ public sealed class PeopleReviewService(
             .Where(x => x.PersonId == duplicatePersonId)
             .ToListAsync(cancellationToken);
 
-        var canonicalCharacterLookup = canonicalCharacters.ToDictionary(
-            x => PersonIdentityNormalizer.NormalizeComparisonText(x.Name),
-            x => x,
-            StringComparer.Ordinal);
+        // Canonical person may already have multiple characters whose names normalize
+        // to the same key (legacy duplicates). Keep the first one as the merge target
+        // and leave the rest untouched — this is pre-existing data we must not crash on.
+        var canonicalCharacterLookup = new Dictionary<string, Character>(StringComparer.Ordinal);
+        foreach (var canonicalCharacter in canonicalCharacters)
+        {
+            var canonicalKey = PersonIdentityNormalizer.NormalizeComparisonText(canonicalCharacter.Name);
+            canonicalCharacterLookup.TryAdd(canonicalKey, canonicalCharacter);
+        }
 
         foreach (var duplicateCharacter in duplicateCharacters)
         {

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.3</Version>
+    <Version>0.9.4</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/PeopleReviewServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/PeopleReviewServiceTests.cs
@@ -269,6 +269,41 @@ public sealed class PeopleReviewServiceTests
         Assert.Equal("Obě osoby už mají účast ve stejné přihlášce. Sloučení by nebylo bezpečné.", ex.Message);
     }
 
+    [Fact]
+    public async Task MergeAsync_SucceedsWhenCanonicalHasMultipleCharactersWithSameNormalizedName()
+    {
+        var options = CreateOptions();
+        var actor = CreateUser("actor-id", "admin@example.cz");
+        var canonical = CreatePerson(1, "Tomáš", "Najvar", 1980, null, null);
+        var duplicate = CreatePerson(2, "Tomas", "Najvar", 1980, null, null);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(actor);
+            db.People.AddRange(canonical, duplicate);
+            db.Characters.AddRange(
+                new Character { Id = 1, PersonId = canonical.Id, Name = "Tomáš" },
+                new Character { Id = 2, PersonId = canonical.Id, Name = "Tomas" },
+                new Character { Id = 3, PersonId = duplicate.Id, Name = "Tomáš" });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new PeopleReviewService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        await service.MergeAsync(canonical.Id, duplicate.Id, actor.Id);
+
+        await using var verificationDb = new ApplicationDbContext(options);
+        var canonicalCharacters = await verificationDb.Characters
+            .Where(x => x.PersonId == canonical.Id)
+            .ToListAsync();
+        var deletedDuplicate = await verificationDb.People
+            .IgnoreQueryFilters()
+            .SingleAsync(x => x.Id == duplicate.Id);
+
+        Assert.Equal(2, canonicalCharacters.Count);
+        Assert.True(deletedDuplicate.IsDeleted);
+    }
+
     private static readonly DateTime FixedUtc = new(2026, 4, 5, 12, 0, 0, DateTimeKind.Utc);
 
     private static DbContextOptions<ApplicationDbContext> CreateOptions() =>


### PR DESCRIPTION
## Summary
- `MergeAsync` crashed with `ArgumentException: An item with the same key has already been added. Key: tomas` whenever the canonical person already had two Characters whose names collapsed to the same key after `NormalizeComparisonText` (e.g. "Tomáš" and "Tomas"). Reproduced on prod while merging Person 193 (`/organizace/osoby/193/sloucit`).
- Replaced `canonicalCharacters.ToDictionary(...)` with a manual loop using `TryAdd`, so the first character wins per normalized key and pre-existing duplicates on the canonical side are left untouched.
- Bumped version `0.9.3 → 0.9.4`.

## Test plan
- [x] `dotnet test --filter PeopleReviewServiceTests` — 7/7 passing, including new regression `MergeAsync_SucceedsWhenCanonicalHasMultipleCharactersWithSameNormalizedName`
- [ ] After merge, retry merge on `/organizace/osoby/193/sloucit` in production
- [ ] Confirm audit log entry `PersonMerged` is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)