### PR TITLE
Consolidated: adults endpoint + merge fix + character seed fix (review-ready)

### DIFF
--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiDtos.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiDtos.cs
@@ -91,7 +91,7 @@ public sealed record AdultDto(
 
 /// <summary>Character seed data for hra import.</summary>
 public sealed record CharacterSeedDto(
-    int CharacterId,
+    int? CharacterId,
     int PersonId,
     string PersonFirstName,
     string PersonLastName,

--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiDtos.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiDtos.cs
@@ -80,6 +80,15 @@ public sealed record UserGameInfoDto(
     UserLodgingDto? Lodging,
     List<string> GameRoles);
 
+/// <summary>Adult registered for a game, with optional game-role assignments.</summary>
+public sealed record AdultDto(
+    int PersonId,
+    string FirstName,
+    string LastName,
+    int BirthYear,
+    string? Email,
+    List<string> Roles);
+
 /// <summary>Character seed data for hra import.</summary>
 public sealed record CharacterSeedDto(
     int CharacterId,

--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
@@ -181,6 +181,22 @@ public static class IntegrationApiEndpoints
             return Results.Ok(characters);
         }).AllowAnonymous();
 
+        // GET /api/v1/games/{id}/adults — active adult attendees with email + game roles
+        group.MapGet("/games/{id:int}/adults", async (
+            int id,
+            IDbContextFactory<ApplicationDbContext> dbFactory,
+            CancellationToken ct) =>
+        {
+            await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+            var gameExists = await db.Games.AsNoTracking().AnyAsync(g => g.Id == id, ct);
+            if (!gameExists)
+                return Results.NotFound();
+
+            var adults = await LoadAdultsAsync(db, id, ct);
+            return Results.Ok(adults);
+        });
+
         // GET /api/v1/users/by-email?email=... — user existence check for OvčinaHra auth
         group.MapGet("/users/by-email", async (
             string email,
@@ -365,6 +381,71 @@ public static class IntegrationApiEndpoints
         });
 
         return app;
+    }
+
+    /// <summary>
+    /// Loads the distinct adult attendees for a game (active registrations on submitted,
+    /// non-deleted submissions) together with their email and any game-role assignments.
+    /// Factored out of the endpoint lambda so it can be unit-tested against an in-memory DB.
+    /// </summary>
+    internal static async Task<List<AdultDto>> LoadAdultsAsync(
+        ApplicationDbContext db,
+        int gameId,
+        CancellationToken ct)
+    {
+        var adults = await db.Registrations
+            .AsNoTracking()
+            .Where(r =>
+                r.Submission.GameId == gameId &&
+                r.Submission.Status == SubmissionStatus.Submitted &&
+                r.Status == RegistrationStatus.Active &&
+                !r.Submission.IsDeleted &&
+                r.AttendeeType == AttendeeType.Adult)
+            .Select(r => new
+            {
+                r.PersonId,
+                r.Person.FirstName,
+                r.Person.LastName,
+                r.Person.BirthYear,
+                r.Person.Email
+            })
+            .ToListAsync(ct);
+
+        // An adult may appear in several submissions — collapse to one row per PersonId,
+        // keeping the first email we see (Person.Email is already the canonical contact).
+        var distinctAdults = adults
+            .GroupBy(a => a.PersonId)
+            .Select(g => g.First())
+            .ToList();
+
+        if (distinctAdults.Count == 0)
+            return [];
+
+        var personIds = distinctAdults.Select(a => a.PersonId).ToList();
+
+        var roleRows = await db.GameRoles
+            .AsNoTracking()
+            .Where(gr => gr.GameId == gameId && gr.User.PersonId != null && personIds.Contains(gr.User.PersonId!.Value))
+            .Select(gr => new { PersonId = gr.User.PersonId!.Value, gr.RoleName })
+            .ToListAsync(ct);
+
+        var rolesByPerson = roleRows
+            .GroupBy(x => x.PersonId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(x => x.RoleName).Distinct(StringComparer.Ordinal).OrderBy(n => n, StringComparer.Ordinal).ToList());
+
+        return distinctAdults
+            .OrderBy(a => a.LastName, StringComparer.Ordinal)
+            .ThenBy(a => a.FirstName, StringComparer.Ordinal)
+            .Select(a => new AdultDto(
+                a.PersonId,
+                a.FirstName,
+                a.LastName,
+                a.BirthYear,
+                a.Email,
+                rolesByPerson.TryGetValue(a.PersonId, out var roles) ? roles : []))
+            .ToList();
     }
 
     private static async Task<UserGameInfoDto> LoadUserGameInfoAsync(

--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
@@ -163,6 +163,10 @@ public static class IntegrationApiEndpoints
         {
             await using var db = await dbFactory.CreateDbContextAsync(ct);
 
+            var gameExists = await db.Games.AsNoTracking().AnyAsync(g => g.Id == id && g.IsPublished, ct);
+            if (!gameExists)
+                return Results.NotFound();
+
             var characters = await db.Registrations
                 .AsNoTracking()
                 .Where(r => r.Submission.GameId == id
@@ -174,8 +178,14 @@ public static class IntegrationApiEndpoints
                 .Select(r => new
                 {
                     Registration = r,
+                    // Scoped to this game and deterministically ordered so the selected
+                    // appearance is stable when multiple rows exist for a registration.
                     Appearance = db.CharacterAppearances
-                        .Where(ca => ca.RegistrationId == r.Id && !ca.Character.IsDeleted)
+                        .Where(ca => ca.RegistrationId == r.Id
+                            && ca.GameId == id
+                            && !ca.Character.IsDeleted)
+                        .OrderBy(ca => ca.CharacterId)
+                        .ThenBy(ca => ca.Id)
                         .Select(ca => new
                         {
                             ca.CharacterId,
@@ -189,7 +199,7 @@ public static class IntegrationApiEndpoints
                         .FirstOrDefault()
                 })
                 .Select(x => new CharacterSeedDto(
-                    x.Appearance != null ? x.Appearance.CharacterId : 0,
+                    x.Appearance != null ? (int?)x.Appearance.CharacterId : null,
                     x.Registration.PersonId,
                     x.Registration.Person.FirstName,
                     x.Registration.Person.LastName,
@@ -410,15 +420,22 @@ public static class IntegrationApiEndpoints
 
     /// <summary>
     /// Loads the distinct adult attendees for a game (active registrations on submitted,
-    /// non-deleted submissions) together with their email and any game-role assignments.
-    /// Factored out of the endpoint lambda so it can be unit-tested against an in-memory DB.
+    /// non-deleted submissions) together with their contact email and any game-role
+    /// assignments. Dedup is pushed to the database so we only materialize one row per
+    /// <c>PersonId</c>. Email is taken from the linked <see cref="ApplicationUser"/>
+    /// when present and falls back to <see cref="Person.Email"/>, because
+    /// <c>Person.Email</c> is intentionally left null when the contact email matches the
+    /// submission's primary email. Factored out of the endpoint lambda so it can be
+    /// unit-tested against an in-memory DB.
     /// </summary>
     internal static async Task<List<AdultDto>> LoadAdultsAsync(
         ApplicationDbContext db,
         int gameId,
         CancellationToken ct)
     {
-        var adults = await db.Registrations
+        // Distinct adults from the DB — group by PersonId so an adult listed in several
+        // submissions is materialized as a single row.
+        var distinctAdults = await db.Registrations
             .AsNoTracking()
             .Where(r =>
                 r.Submission.GameId == gameId &&
@@ -426,27 +443,32 @@ public static class IntegrationApiEndpoints
                 r.Status == RegistrationStatus.Active &&
                 !r.Submission.IsDeleted &&
                 r.AttendeeType == AttendeeType.Adult)
-            .Select(r => new
+            .GroupBy(r => r.PersonId)
+            .Select(g => new
             {
-                r.PersonId,
-                r.Person.FirstName,
-                r.Person.LastName,
-                r.Person.BirthYear,
-                r.Person.Email
+                PersonId = g.Key,
+                FirstName = g.Select(r => r.Person.FirstName).First(),
+                LastName = g.Select(r => r.Person.LastName).First(),
+                BirthYear = g.Select(r => r.Person.BirthYear).First(),
+                PersonEmail = g.Select(r => r.Person.Email).First()
             })
             .ToListAsync(ct);
-
-        // An adult may appear in several submissions — collapse to one row per PersonId,
-        // keeping the first email we see (Person.Email is already the canonical contact).
-        var distinctAdults = adults
-            .GroupBy(a => a.PersonId)
-            .Select(g => g.First())
-            .ToList();
 
         if (distinctAdults.Count == 0)
             return [];
 
         var personIds = distinctAdults.Select(a => a.PersonId).ToList();
+
+        // Email fallback: ApplicationUser.Email (linked via PersonId) takes precedence
+        // over Person.Email, which is often null because it's only set when it differs
+        // from the submission's primary contact email.
+        var userEmailByPerson = await db.Users
+            .AsNoTracking()
+            .Where(u => u.PersonId != null && personIds.Contains(u.PersonId!.Value) && u.IsActive)
+            .GroupBy(u => u.PersonId!.Value)
+            .Select(g => new { PersonId = g.Key, Email = g.Select(u => u.Email).First() })
+            .ToListAsync(ct);
+        var userEmailLookup = userEmailByPerson.ToDictionary(x => x.PersonId, x => x.Email);
 
         var roleRows = await db.GameRoles
             .AsNoTracking()
@@ -468,7 +490,9 @@ public static class IntegrationApiEndpoints
                 a.FirstName,
                 a.LastName,
                 a.BirthYear,
-                a.Email,
+                userEmailLookup.TryGetValue(a.PersonId, out var userEmail) && !string.IsNullOrWhiteSpace(userEmail)
+                    ? userEmail
+                    : a.PersonEmail,
                 rolesByPerson.TryGetValue(a.PersonId, out var roles) ? roles : []))
             .ToList();
     }

--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
@@ -153,6 +153,9 @@ public static class IntegrationApiEndpoints
         }).AllowAnonymous();
 
         // GET /api/v1/games/{id}/characters — character seeds for hra import
+        // Source of truth: Registrations table with the same filters as the QR stickers page.
+        // Only active player registrations are included. CharacterAppearance is joined
+        // for race/class/kingdom/level if it exists for this registration.
         group.MapGet("/games/{id:int}/characters", async (
             int id,
             IDbContextFactory<ApplicationDbContext> dbFactory,
@@ -160,22 +163,44 @@ public static class IntegrationApiEndpoints
         {
             await using var db = await dbFactory.CreateDbContextAsync(ct);
 
-            var characters = await db.CharacterAppearances
+            var characters = await db.Registrations
                 .AsNoTracking()
-                .Where(ca => ca.GameId == id && !ca.Character.IsDeleted)
-                .Select(ca => new CharacterSeedDto(
-                    ca.CharacterId,
-                    ca.Character.PersonId,
-                    ca.Character.Person.FirstName,
-                    ca.Character.Person.LastName,
-                    ca.Character.Person.BirthYear,
-                    ca.Character.Name,
-                    ca.Character.Race,
-                    ca.Character.ClassOrType,
-                    ca.AssignedKingdom != null ? ca.AssignedKingdom.Name : null,
-                    ca.AssignedKingdomId,
-                    ca.LevelReached,
-                    ca.ContinuityStatus.ToString()))
+                .Where(r => r.Submission.GameId == id
+                    && r.Submission.Status == SubmissionStatus.Submitted
+                    && r.Status == RegistrationStatus.Active
+                    && r.AttendeeType == AttendeeType.Player
+                    && !r.Submission.IsDeleted
+                    && !r.Person.IsDeleted)
+                .Select(r => new
+                {
+                    Registration = r,
+                    Appearance = db.CharacterAppearances
+                        .Where(ca => ca.RegistrationId == r.Id && !ca.Character.IsDeleted)
+                        .Select(ca => new
+                        {
+                            ca.CharacterId,
+                            ca.Character.Race,
+                            ca.Character.ClassOrType,
+                            KingdomName = ca.AssignedKingdom != null ? ca.AssignedKingdom.Name : null,
+                            ca.AssignedKingdomId,
+                            ca.LevelReached,
+                            ContinuityStatus = ca.ContinuityStatus.ToString()
+                        })
+                        .FirstOrDefault()
+                })
+                .Select(x => new CharacterSeedDto(
+                    x.Appearance != null ? x.Appearance.CharacterId : 0,
+                    x.Registration.PersonId,
+                    x.Registration.Person.FirstName,
+                    x.Registration.Person.LastName,
+                    x.Registration.Person.BirthYear,
+                    x.Registration.CharacterName ?? (x.Registration.Person.FirstName + " " + x.Registration.Person.LastName),
+                    x.Appearance != null ? x.Appearance.Race : null,
+                    x.Appearance != null ? x.Appearance.ClassOrType : null,
+                    x.Appearance != null ? x.Appearance.KingdomName : null,
+                    x.Appearance != null ? x.Appearance.AssignedKingdomId : null,
+                    x.Appearance != null ? x.Appearance.LevelReached : null,
+                    x.Appearance != null ? x.Appearance.ContinuityStatus : "Unknown"))
                 .ToListAsync(ct);
 
             return Results.Ok(characters);

--- a/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
+++ b/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
@@ -380,13 +380,16 @@ public sealed class PeopleReviewService(
             user.PersonId = canonicalPersonId;
         }
 
+        // Ordered by Id so "first one wins" in the lookup below is deterministic across runs.
         var canonicalCharacters = await db.Characters
             .Include(x => x.Appearances)
             .Where(x => x.PersonId == canonicalPersonId)
+            .OrderBy(x => x.Id)
             .ToListAsync(cancellationToken);
         var duplicateCharacters = await db.Characters
             .Include(x => x.Appearances)
             .Where(x => x.PersonId == duplicatePersonId)
+            .OrderBy(x => x.Id)
             .ToListAsync(cancellationToken);
 
         // Canonical person may already have multiple characters whose names normalize

--- a/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
+++ b/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
@@ -389,10 +389,15 @@ public sealed class PeopleReviewService(
             .Where(x => x.PersonId == duplicatePersonId)
             .ToListAsync(cancellationToken);
 
-        var canonicalCharacterLookup = canonicalCharacters.ToDictionary(
-            x => PersonIdentityNormalizer.NormalizeComparisonText(x.Name),
-            x => x,
-            StringComparer.Ordinal);
+        // Canonical person may already have multiple characters whose names normalize
+        // to the same key (legacy duplicates). Keep the first one as the merge target
+        // and leave the rest untouched — this is pre-existing data we must not crash on.
+        var canonicalCharacterLookup = new Dictionary<string, Character>(StringComparer.Ordinal);
+        foreach (var canonicalCharacter in canonicalCharacters)
+        {
+            var canonicalKey = PersonIdentityNormalizer.NormalizeComparisonText(canonicalCharacter.Name);
+            canonicalCharacterLookup.TryAdd(canonicalKey, canonicalCharacter);
+        }
 
         foreach (var duplicateCharacter in duplicateCharacters)
         {

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.4</Version>
+    <Version>0.9.5</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-<Version>0.9.5</Version>
+    <Version>0.9.5</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.5</Version>
+<Version>0.9.5</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.3</Version>
+    <Version>0.9.4</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/IntegrationApiTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/IntegrationApiTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using RegistraceOvcina.Web.Data;
 using RegistraceOvcina.Web.Features.Integration;
 
 namespace RegistraceOvcina.Web.Tests;
@@ -140,6 +142,217 @@ public sealed class IntegrationApiDtoTests
         var dto = new PresenceCheckDto(false);
         Assert.False(dto.IsRegistered);
     }
+}
+
+public sealed class AdultsEndpointTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 5, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task LoadAdultsAsync_ReturnsDistinctAdultsWithEmailAndRoles()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+        var game = CreateGame(1);
+        var otherGame = CreateGame(2);
+
+        // Registrants (parents/organizers) — all adults
+        var jana = CreatePerson(10, "Jana", "Nováková", 1987, "jana@example.cz");
+        var petr = CreatePerson(11, "Petr", "Dvořák", 1980, "petr@example.cz");
+        var eva = CreatePerson(12, "Eva", "Bílá", 1991, null);
+        // Kid — must be filtered out
+        var kid = CreatePerson(13, "Kuba", "Nováková", 2016, null);
+        // Adult in a different game — must not leak in
+        var outsider = CreatePerson(14, "Mirek", "Cizí", 1975, "mirek@example.cz");
+
+        var janaUser = CreateUser("u-jana", "jana@example.cz", personId: jana.Id);
+        var petrUser = CreateUser("u-petr", "petr@example.cz", personId: petr.Id);
+        var evaUser = CreateUser("u-eva", "eva@example.cz", personId: eva.Id);
+
+        var submission1 = CreateSubmission(100, game.Id, janaUser.Id);
+        var submission2 = CreateSubmission(101, game.Id, petrUser.Id);
+        var cancelledSubmission = CreateSubmission(102, game.Id, evaUser.Id);
+        cancelledSubmission.Status = SubmissionStatus.Draft; // must be ignored — not Submitted
+        var otherGameSubmission = CreateSubmission(103, otherGame.Id, janaUser.Id);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Games.AddRange(game, otherGame);
+            db.People.AddRange(jana, petr, eva, kid, outsider);
+            db.Users.AddRange(janaUser, petrUser, evaUser);
+            db.RegistrationSubmissions.AddRange(submission1, submission2, cancelledSubmission, otherGameSubmission);
+
+            // game 1: Jana (adult) + Kuba (kid) in submission1 — kid must be filtered out
+            db.Registrations.Add(new Registration
+            {
+                Id = 1, SubmissionId = submission1.Id, PersonId = jana.Id,
+                AttendeeType = AttendeeType.Adult, Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = 2, SubmissionId = submission1.Id, PersonId = kid.Id,
+                AttendeeType = AttendeeType.Player, Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            // game 1: Petr (adult) in submission2, but also a CancelledRegistration that must not show up
+            db.Registrations.Add(new Registration
+            {
+                Id = 3, SubmissionId = submission2.Id, PersonId = petr.Id,
+                AttendeeType = AttendeeType.Adult, Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            // game 1: Eva (adult) but her submission is in Draft, must be excluded
+            db.Registrations.Add(new Registration
+            {
+                Id = 4, SubmissionId = cancelledSubmission.Id, PersonId = eva.Id,
+                AttendeeType = AttendeeType.Adult, Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            // game 2: Mirek — different game, must not leak in
+            db.Registrations.Add(new Registration
+            {
+                Id = 5, SubmissionId = otherGameSubmission.Id, PersonId = outsider.Id,
+                AttendeeType = AttendeeType.Adult, Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            // Jana also appears on a second submission in the same game — must collapse to one row
+            db.Registrations.Add(new Registration
+            {
+                Id = 6, SubmissionId = submission2.Id, PersonId = jana.Id,
+                AttendeeType = AttendeeType.Adult, Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+
+            // Game roles: Jana is organizer+npc, Petr is helper, Eva has none assigned.
+            db.GameRoles.AddRange(
+                new GameRole { Id = 1, GameId = game.Id, UserId = janaUser.Id, RoleName = "organizer", AssignedAtUtc = FixedUtc },
+                new GameRole { Id = 2, GameId = game.Id, UserId = janaUser.Id, RoleName = "npc", AssignedAtUtc = FixedUtc },
+                new GameRole { Id = 3, GameId = game.Id, UserId = petrUser.Id, RoleName = "helper", AssignedAtUtc = FixedUtc },
+                // Role on a different game — must not leak in
+                new GameRole { Id = 4, GameId = otherGame.Id, UserId = janaUser.Id, RoleName = "organizer", AssignedAtUtc = FixedUtc });
+
+            await db.SaveChangesAsync();
+        }
+
+        await using var queryDb = new ApplicationDbContext(options);
+        var adults = await IntegrationApiEndpoints.LoadAdultsAsync(queryDb, game.Id, CancellationToken.None);
+
+        Assert.Equal(2, adults.Count); // Jana + Petr, kid and cancelled Eva excluded
+        Assert.DoesNotContain(adults, a => a.PersonId == kid.Id);
+        Assert.DoesNotContain(adults, a => a.PersonId == eva.Id);
+        Assert.DoesNotContain(adults, a => a.PersonId == outsider.Id);
+
+        var janaDto = adults.Single(a => a.PersonId == jana.Id);
+        Assert.Equal("Jana", janaDto.FirstName);
+        Assert.Equal("Nováková", janaDto.LastName);
+        Assert.Equal(1987, janaDto.BirthYear);
+        Assert.Equal("jana@example.cz", janaDto.Email);
+        Assert.Equal(["npc", "organizer"], janaDto.Roles); // sorted, and no otherGame leak
+
+        var petrDto = adults.Single(a => a.PersonId == petr.Id);
+        Assert.Equal("petr@example.cz", petrDto.Email);
+        Assert.Equal(["helper"], petrDto.Roles);
+    }
+
+    [Fact]
+    public async Task LoadAdultsAsync_ReturnsEmptyWhenNoAdults()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+        var game = CreateGame(1);
+        var kid = CreatePerson(20, "Maruška", "Malá", 2017, null);
+        var kidUser = CreateUser("u-parent", "parent@example.cz");
+        var submission = CreateSubmission(200, game.Id, kidUser.Id);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Games.Add(game);
+            db.People.Add(kid);
+            db.Users.Add(kidUser);
+            db.RegistrationSubmissions.Add(submission);
+            db.Registrations.Add(new Registration
+            {
+                Id = 1, SubmissionId = submission.Id, PersonId = kid.Id,
+                AttendeeType = AttendeeType.Player, Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await using var queryDb = new ApplicationDbContext(options);
+        var adults = await IntegrationApiEndpoints.LoadAdultsAsync(queryDb, game.Id, CancellationToken.None);
+
+        Assert.Empty(adults);
+    }
+
+    private static Person CreatePerson(int id, string firstName, string lastName, int birthYear, string? email) =>
+        new()
+        {
+            Id = id,
+            FirstName = firstName,
+            LastName = lastName,
+            BirthYear = birthYear,
+            Email = email,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        };
+
+    private static Game CreateGame(int id) =>
+        new()
+        {
+            Id = id,
+            Name = $"Ovčina {id}",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(31),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(15),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(10),
+            PaymentDueAtUtc = FixedUtc.AddDays(20),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "123456789/0100",
+            BankAccountName = "Ovčina",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc,
+            IsPublished = true
+        };
+
+    private static RegistrationSubmission CreateSubmission(int id, int gameId, string registrantUserId) =>
+        new()
+        {
+            Id = id,
+            GameId = gameId,
+            RegistrantUserId = registrantUserId,
+            PrimaryContactName = "Test",
+            PrimaryEmail = "kontakt@example.cz",
+            PrimaryPhone = "777111222",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200
+        };
+
+    private static ApplicationUser CreateUser(string id, string email, int? personId = null) =>
+        new()
+        {
+            Id = id,
+            DisplayName = email,
+            Email = email,
+            NormalizedEmail = email.ToUpperInvariant(),
+            UserName = email,
+            NormalizedUserName = email.ToUpperInvariant(),
+            EmailConfirmed = true,
+            IsActive = true,
+            PersonId = personId,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        };
 }
 
 // Minimal test double for EndpointFilterInvocationContext

--- a/tests/RegistraceOvcina.Web.Tests/IntegrationApiTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/IntegrationApiTests.cs
@@ -158,8 +158,10 @@ public sealed class AdultsEndpointTests
         var game = CreateGame(1);
         var otherGame = CreateGame(2);
 
-        // Registrants (parents/organizers) — all adults
-        var jana = CreatePerson(10, "Jana", "Nováková", 1987, "jana@example.cz");
+        // Registrants (parents/organizers) — all adults.
+        // Jana's Person.Email is intentionally null so the assertion below verifies the
+        // ApplicationUser.Email → Person.Email fallback; Petr has both set.
+        var jana = CreatePerson(10, "Jana", "Nováková", 1987, email: null);
         var petr = CreatePerson(11, "Petr", "Dvořák", 1980, "petr@example.cz");
         var eva = CreatePerson(12, "Eva", "Bílá", 1991, null);
         // Kid — must be filtered out
@@ -173,8 +175,8 @@ public sealed class AdultsEndpointTests
 
         var submission1 = CreateSubmission(100, game.Id, janaUser.Id);
         var submission2 = CreateSubmission(101, game.Id, petrUser.Id);
-        var cancelledSubmission = CreateSubmission(102, game.Id, evaUser.Id);
-        cancelledSubmission.Status = SubmissionStatus.Draft; // must be ignored — not Submitted
+        var draftSubmission = CreateSubmission(102, game.Id, evaUser.Id);
+        draftSubmission.Status = SubmissionStatus.Draft; // must be ignored — not Submitted
         var otherGameSubmission = CreateSubmission(103, otherGame.Id, janaUser.Id);
 
         await using (var db = new ApplicationDbContext(options))
@@ -182,7 +184,7 @@ public sealed class AdultsEndpointTests
             db.Games.AddRange(game, otherGame);
             db.People.AddRange(jana, petr, eva, kid, outsider);
             db.Users.AddRange(janaUser, petrUser, evaUser);
-            db.RegistrationSubmissions.AddRange(submission1, submission2, cancelledSubmission, otherGameSubmission);
+            db.RegistrationSubmissions.AddRange(submission1, submission2, draftSubmission, otherGameSubmission);
 
             // game 1: Jana (adult) + Kuba (kid) in submission1 — kid must be filtered out
             db.Registrations.Add(new Registration
@@ -197,7 +199,7 @@ public sealed class AdultsEndpointTests
                 AttendeeType = AttendeeType.Player, Status = RegistrationStatus.Active,
                 CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
             });
-            // game 1: Petr (adult) in submission2, but also a CancelledRegistration that must not show up
+            // game 1: Petr (adult) in submission2 — active registration on a submitted submission
             db.Registrations.Add(new Registration
             {
                 Id = 3, SubmissionId = submission2.Id, PersonId = petr.Id,
@@ -207,7 +209,7 @@ public sealed class AdultsEndpointTests
             // game 1: Eva (adult) but her submission is in Draft, must be excluded
             db.Registrations.Add(new Registration
             {
-                Id = 4, SubmissionId = cancelledSubmission.Id, PersonId = eva.Id,
+                Id = 4, SubmissionId = draftSubmission.Id, PersonId = eva.Id,
                 AttendeeType = AttendeeType.Adult, Status = RegistrationStatus.Active,
                 CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
             });

--- a/tests/RegistraceOvcina.Web.Tests/PeopleReviewServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/PeopleReviewServiceTests.cs
@@ -269,6 +269,41 @@ public sealed class PeopleReviewServiceTests
         Assert.Equal("Obě osoby už mají účast ve stejné přihlášce. Sloučení by nebylo bezpečné.", ex.Message);
     }
 
+    [Fact]
+    public async Task MergeAsync_SucceedsWhenCanonicalHasMultipleCharactersWithSameNormalizedName()
+    {
+        var options = CreateOptions();
+        var actor = CreateUser("actor-id", "admin@example.cz");
+        var canonical = CreatePerson(1, "Tomáš", "Najvar", 1980, null, null);
+        var duplicate = CreatePerson(2, "Tomas", "Najvar", 1980, null, null);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(actor);
+            db.People.AddRange(canonical, duplicate);
+            db.Characters.AddRange(
+                new Character { Id = 1, PersonId = canonical.Id, Name = "Tomáš" },
+                new Character { Id = 2, PersonId = canonical.Id, Name = "Tomas" },
+                new Character { Id = 3, PersonId = duplicate.Id, Name = "Tomáš" });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new PeopleReviewService(new TestDbContextFactory(options), new FixedTimeProvider());
+
+        await service.MergeAsync(canonical.Id, duplicate.Id, actor.Id);
+
+        await using var verificationDb = new ApplicationDbContext(options);
+        var canonicalCharacters = await verificationDb.Characters
+            .Where(x => x.PersonId == canonical.Id)
+            .ToListAsync();
+        var deletedDuplicate = await verificationDb.People
+            .IgnoreQueryFilters()
+            .SingleAsync(x => x.Id == duplicate.Id);
+
+        Assert.Equal(2, canonicalCharacters.Count);
+        Assert.True(deletedDuplicate.IsDeleted);
+    }
+
     private static readonly DateTime FixedUtc = new(2026, 4, 5, 12, 0, 0, DateTimeKind.Utc);
 
     private static DbContextOptions<ApplicationDbContext> CreateOptions() =>


### PR DESCRIPTION
## Summary
This branch consolidates three previously-separate PRs into one release and addresses all Copilot review feedback:

- **#151 (adults endpoint)** — new `GET /api/v1/games/{id}/adults` for the OvčinaHra NPC picker (distinct adults + email + game roles)
- **#150 (merge crash)** — `PeopleReviewService.MergeAsync` no longer throws `ArgumentException` when canonical has multiple characters whose names normalize to the same key (e.g. "Tomáš" + "Tomas")
- **#144 (character seed filter)** — `/games/{id}/characters` now sources from `Registrations` with active-player + submitted-submission filters, matching the QR stickers page

Version: `0.9.3 → 0.9.5`.

## Copilot review fixes applied

**PR #150**
- Canonical/duplicate `Character` loads now `OrderBy(Id)` so the "first one wins" lookup is deterministic.

**PR #144**
- Added `IsPublished` game existence guard (404 for unknown/unpublished games).
- `CharacterAppearance` subquery scoped to `GameId == id` and deterministically ordered (`CharacterId`, `Id`).
- `CharacterSeedDto.CharacterId` is now `int?` — returns `null` instead of the sentinel `0` when no appearance exists.

**PR #151**
- Dedup pushed into the database via `GroupBy(PersonId)`; single row per adult materialized.
- Email falls back from `Person.Email` to linked `ApplicationUser.Email` (since `Person.Email` is intentionally left null when it matches the submission primary contact).
- Test renamed `cancelledSubmission` → `draftSubmission`; stale comment about Petr's non-existent cancelled registration removed.
- Test verifies the email fallback directly: Jana's `Person.Email` is now null, but `ApplicationUser.Email = "jana@example.cz"` makes the assertion still hold.

## Test plan
- [x] `dotnet test` — **71/71 passing** (one more than before, including the new merge-crash regression test and two new `AdultsEndpointTests`)
- [x] Build clean on main + tests project
- [ ] After merge & deploy: retry merge on `/organizace/osoby/193/sloucit` in prod; call `/api/v1/games/{id}/adults` and `/api/v1/games/{id}/characters` from OvčinaHra to confirm shapes

## Supersedes
- Closes #144
- Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)