### PR TITLE
Sortable payments overview + named donors on game stats [v0.9.6]

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameStatsPage.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameStatsPage.razor
@@ -288,6 +288,44 @@ else
                             </tr>
                         </tbody>
                     </table>
+
+                    @if (stats.Donors.Count > 0)
+                    {
+                        <hr class="my-3" />
+                        <h6 class="mb-2 text-muted">Dobrovolné příspěvky — přehled</h6>
+                        <div class="table-responsive">
+                            <table class="table table-sm mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Kontakt</th>
+                                        <th class="text-end">Částka</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var donor in stats.Donors)
+                                    {
+                                        <tr>
+                                            <td>
+                                                <a href="/organizace/prihlasky/@donor.SubmissionId" class="text-decoration-none">@donor.ContactName</a>
+                                                @if (!string.IsNullOrWhiteSpace(donor.ContactEmail))
+                                                {
+                                                    <br />
+                                                    <small class="text-secondary">@donor.ContactEmail</small>
+                                                }
+                                            </td>
+                                            <td class="text-end fw-semibold">@donor.Amount.ToString("N0") Kč</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                                <tfoot>
+                                    <tr class="fw-semibold border-top">
+                                        <td>Celkem</td>
+                                        <td class="text-end">@stats.DonationTotal.ToString("N0") Kč</td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                    }
                 </div>
             </div>
         </div>

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/Payments.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/Payments.razor
@@ -3,6 +3,7 @@
 
 @inject PaymentService PaymentService
 @inject OrganizerSubmissionService OrganizerSubmissionService
+@inject NavigationManager Nav
 
 <PageTitle>Přehled plateb</PageTitle>
 
@@ -32,6 +33,20 @@
                 <option value="@((int)BalanceStatus.Balanced)" selected="@(selectedBalanceStatus == (int)BalanceStatus.Balanced)">Vyrovnáno</option>
                 <option value="@((int)BalanceStatus.Overpaid)" selected="@(selectedBalanceStatus == (int)BalanceStatus.Overpaid)">Přeplatek</option>
             </select>
+            <label class="form-label mb-0 text-nowrap" for="group-mode">Seskupit</label>
+            <select id="group-mode" name="group" class="form-select form-select-sm" style="min-width: 140px;" onchange="this.form.submit()">
+                <option value="" selected="@(string.IsNullOrEmpty(group))">Bez seskupení</option>
+                <option value="stav" selected="@(group == "stav")">Podle stavu</option>
+            </select>
+            @* Preserve current sort across filter changes *@
+            @if (!string.IsNullOrEmpty(sort))
+            {
+                <input type="hidden" name="sort" value="@sort" />
+            }
+            @if (!string.IsNullOrEmpty(dir))
+            {
+                <input type="hidden" name="dir" value="@dir" />
+            }
         </form>
     </div>
 </div>
@@ -50,18 +65,31 @@ else
         <table class="table align-middle">
             <thead>
                 <tr>
-                    <th>VS</th>
-                    <th>Kontakt</th>
+                    <th><a class="text-decoration-none text-body" href="@BuildSortLink("vs")">VS @RenderSortIndicator("vs")</a></th>
+                    <th><a class="text-decoration-none text-body" href="@BuildSortLink("kontakt")">Kontakt @RenderSortIndicator("kontakt")</a></th>
                     <th>Hra</th>
-                    <th class="text-end">Celkem</th>
-                    <th class="text-end">Uhrazeno</th>
-                    <th>Stav</th>
+                    <th class="text-end"><a class="text-decoration-none text-body" href="@BuildSortLink("celkem")">Celkem @RenderSortIndicator("celkem")</a></th>
+                    <th class="text-end"><a class="text-decoration-none text-body" href="@BuildSortLink("uhrazeno")">Uhrazeno @RenderSortIndicator("uhrazeno")</a></th>
+                    <th><a class="text-decoration-none text-body" href="@BuildSortLink("stav")">Stav @RenderSortIndicator("stav")</a></th>
                     <th>Akce</th>
                 </tr>
             </thead>
             <tbody>
+                @{
+                    BalanceStatus? currentGroup = null;
+                }
                 @foreach (var item in items)
                 {
+                    @if (group == "stav" && currentGroup != item.BalanceStatus)
+                    {
+                        currentGroup = item.BalanceStatus;
+                        <tr class="table-light">
+                            <td colspan="7" class="fw-semibold">
+                                <span class="badge @GetBalanceBadgeClass(item.BalanceStatus) me-2">@GetBalanceLabel(item.BalanceStatus)</span>
+                                <span class="text-muted small">@GetGroupCount(item.BalanceStatus) přihlášek · Celkem @GetGroupSum(item.BalanceStatus).ToString("N0") Kč</span>
+                            </td>
+                        </tr>
+                    }
                     <tr data-testid="@($"payment-row-{item.SubmissionId}")">
                         <td>@(item.VariableSymbol ?? "—")</td>
                         <td>
@@ -226,6 +254,15 @@ else
     [SupplyParameterFromQuery(Name = "balanceStatus")]
     private int? selectedBalanceStatus { get; set; }
 
+    [SupplyParameterFromQuery(Name = "sort")]
+    private string? sort { get; set; }
+
+    [SupplyParameterFromQuery(Name = "dir")]
+    private string? dir { get; set; }
+
+    [SupplyParameterFromQuery(Name = "group")]
+    private string? group { get; set; }
+
     [SupplyParameterFromQuery(Name = "recorded")]
     private int? recorded { get; set; }
 
@@ -262,8 +299,79 @@ else
             selectedGameId = gameFilters[0].Id;
         }
 
-        items = await PaymentService.GetPaymentOverviewAsync(selectedGameId, balanceFilter);
+        var raw = await PaymentService.GetPaymentOverviewAsync(selectedGameId, balanceFilter);
+        items = ApplySortAndGrouping(raw, sort, dir, group);
     }
+
+    private static IReadOnlyList<PaymentOverviewItem> ApplySortAndGrouping(
+        IReadOnlyList<PaymentOverviewItem> source,
+        string? sort,
+        string? dir,
+        string? group)
+    {
+        var desc = string.Equals(dir, "desc", StringComparison.OrdinalIgnoreCase);
+
+        // Primary sort key: the user's column choice. VS is the default.
+        Func<IEnumerable<PaymentOverviewItem>, IOrderedEnumerable<PaymentOverviewItem>> orderBy = sort switch
+        {
+            "kontakt" => src => desc
+                ? src.OrderByDescending(x => x.ContactName, StringComparer.CurrentCultureIgnoreCase)
+                : src.OrderBy(x => x.ContactName, StringComparer.CurrentCultureIgnoreCase),
+            "celkem" => src => desc
+                ? src.OrderByDescending(x => x.ExpectedTotal)
+                : src.OrderBy(x => x.ExpectedTotal),
+            "uhrazeno" => src => desc
+                ? src.OrderByDescending(x => x.PaidAmount)
+                : src.OrderBy(x => x.PaidAmount),
+            "stav" => src => desc
+                ? src.OrderByDescending(x => x.BalanceStatus)
+                : src.OrderBy(x => x.BalanceStatus),
+            _ /* "vs" or default */ => src => desc
+                ? src.OrderByDescending(x => x.VariableSymbol, StringComparer.Ordinal)
+                : src.OrderBy(x => x.VariableSymbol, StringComparer.Ordinal),
+        };
+
+        // When grouping by state, sort by state first so rows with the same state
+        // land next to each other, then apply the user's chosen sort inside each group.
+        IEnumerable<PaymentOverviewItem> result;
+        if (group == "stav")
+        {
+            result = source
+                .GroupBy(x => x.BalanceStatus)
+                .OrderBy(g => g.Key)
+                .SelectMany(g => orderBy(g));
+        }
+        else
+        {
+            result = orderBy(source);
+        }
+
+        return result.ToList();
+    }
+
+    private string BuildSortLink(string field)
+    {
+        // Toggle direction if the user is clicking the currently active column;
+        // otherwise default to ascending.
+        var nextDir = (sort == field && dir == "asc") ? "desc" : "asc";
+        return Nav.GetUriWithQueryParameters(new Dictionary<string, object?>
+        {
+            ["sort"] = field,
+            ["dir"] = nextDir
+        });
+    }
+
+    private MarkupString RenderSortIndicator(string field)
+    {
+        if (sort != field) return new MarkupString("");
+        return new MarkupString(dir == "desc" ? "&#x25BC;" : "&#x25B2;");
+    }
+
+    private int GetGroupCount(BalanceStatus status)
+        => items?.Count(x => x.BalanceStatus == status) ?? 0;
+
+    private decimal GetGroupSum(BalanceStatus status)
+        => items?.Where(x => x.BalanceStatus == status).Sum(x => x.ExpectedTotal) ?? 0m;
 
     private void ExpandForm(int submissionId) => expandedSubmissionId = submissionId;
 

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/Payments.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/Payments.razor
@@ -287,21 +287,41 @@ else
             errorMessage = errorParam;
         }
 
+        gameFilters = await OrganizerSubmissionService.GetGameFilterListAsync();
+        await LoadAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        // Enhanced navigation changes query params without re-running OnInitializedAsync,
+        // so we reload on parameter-set once the initial game-filter list is available.
+        if (gameFilters is not null)
+        {
+            await LoadAsync();
+        }
+    }
+
+    private async Task LoadAsync()
+    {
         BalanceStatus? balanceFilter = selectedBalanceStatus.HasValue
             ? (BalanceStatus)selectedBalanceStatus.Value
             : null;
 
-        gameFilters = await OrganizerSubmissionService.GetGameFilterListAsync();
-
         // Default to the most recent game when no filter is selected
-        if (!selectedGameId.HasValue && gameFilters.Count > 0)
+        if (!selectedGameId.HasValue && gameFilters!.Count > 0)
         {
             selectedGameId = gameFilters[0].Id;
         }
 
         var raw = await PaymentService.GetPaymentOverviewAsync(selectedGameId, balanceFilter);
-        items = ApplySortAndGrouping(raw, sort, dir, group);
+        items = ApplySortAndGrouping(raw, EffectiveSort, EffectiveDir, group);
     }
+
+    // When the URL has no explicit sort, we still want VS-asc to be "active" for the
+    // indicator and first-click toggle logic — otherwise clicking VS would keep asc
+    // instead of flipping to desc.
+    private string EffectiveSort => string.IsNullOrEmpty(sort) ? "vs" : sort!;
+    private string EffectiveDir => string.IsNullOrEmpty(dir) ? "asc" : dir!;
 
     private static IReadOnlyList<PaymentOverviewItem> ApplySortAndGrouping(
         IReadOnlyList<PaymentOverviewItem> source,
@@ -352,19 +372,31 @@ else
     private string BuildSortLink(string field)
     {
         // Toggle direction if the user is clicking the currently active column;
-        // otherwise default to ascending.
-        var nextDir = (sort == field && dir == "asc") ? "desc" : "asc";
-        return Nav.GetUriWithQueryParameters(new Dictionary<string, object?>
+        // otherwise default to ascending. Uses the effective sort so the default
+        // VS column correctly flips to desc on first click.
+        var nextDir = (EffectiveSort == field && EffectiveDir == "asc") ? "desc" : "asc";
+
+        // Build the URL from a clean base path and only forward durable filters,
+        // dropping transient parameters like recorded/error so they don't stick
+        // in the URL after a header click.
+        var parameters = new Dictionary<string, object?>
         {
             ["sort"] = field,
-            ["dir"] = nextDir
-        });
+            ["dir"] = nextDir,
+            ["gameId"] = selectedGameId,
+            ["balanceStatus"] = selectedBalanceStatus,
+            ["group"] = string.IsNullOrEmpty(group) ? null : group
+        };
+        var query = string.Join("&", parameters
+            .Where(kvp => kvp.Value is not null)
+            .Select(kvp => $"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value!.ToString()!)}"));
+        return $"/organizace/platby?{query}";
     }
 
     private MarkupString RenderSortIndicator(string field)
     {
-        if (sort != field) return new MarkupString("");
-        return new MarkupString(dir == "desc" ? "&#x25BC;" : "&#x25B2;");
+        if (EffectiveSort != field) return new MarkupString("");
+        return new MarkupString(EffectiveDir == "desc" ? "&#x25BC;" : "&#x25B2;");
     }
 
     private int GetGroupCount(BalanceStatus status)

--- a/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
+++ b/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
@@ -161,6 +161,19 @@ public sealed class GameStatsService(IDbContextFactory<ApplicationDbContext> dbC
         var unpaidSubmissionCount = submittedSubmissions
             .Count(x => x.Payments.Sum(p => p.Amount) < x.ExpectedTotalAmount && x.ExpectedTotalAmount > 0);
 
+        // Named donor breakdown, sorted largest-first. Only submissions with an
+        // actual voluntary contribution are included.
+        var donors = submittedSubmissions
+            .Where(x => x.VoluntaryDonation > 0m)
+            .OrderByDescending(x => x.VoluntaryDonation)
+            .ThenBy(x => x.PrimaryContactName, StringComparer.CurrentCulture)
+            .Select(x => new DonorEntry(
+                x.Id,
+                string.IsNullOrWhiteSpace(x.PrimaryContactName) ? "(bez jména)" : x.PrimaryContactName,
+                x.PrimaryEmail,
+                x.VoluntaryDonation))
+            .ToList();
+
         // --- Food / Meals ---
         var allFoodOrders = registrations.SelectMany(x => x.FoodOrders).ToList();
         var meals = allFoodOrders
@@ -214,6 +227,7 @@ public sealed class GameStatsService(IDbContextFactory<ApplicationDbContext> dbC
             ExpectedTotal = expectedTotal,
             PaidTotal = paidTotal,
             DonationTotal = donationTotal,
+            Donors = donors,
             UnpaidSubmissionCount = unpaidSubmissionCount,
             Meals = meals,
             IndoorWithoutRoom = indoorWithoutRoom,
@@ -291,6 +305,7 @@ public sealed class GameStats
     public decimal ExpectedTotal { get; set; }
     public decimal PaidTotal { get; set; }
     public decimal DonationTotal { get; set; }
+    public List<DonorEntry> Donors { get; set; } = [];
     public int UnpaidSubmissionCount { get; set; }
 
     // Food
@@ -305,3 +320,4 @@ public sealed record AgeBracket(string Label, int Count, int MaxCount);
 public sealed record RoomOccupancy(string RoomName, int Assigned, int Capacity);
 public sealed record KingdomStat(string Name, string? Color, int Assigned, int Target, double AverageAge);
 public sealed record MealStat(string Day, string MealName, int ChildCount, int AdultCount);
+public sealed record DonorEntry(int SubmissionId, string ContactName, string? ContactEmail, decimal Amount);

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.5</Version>
+    <Version>0.9.6</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
- **/organizace/platby** — column headers (VS, Kontakt, Celkem, Uhrazeno, Stav) are now sortable links with an active-direction indicator; state grouping added via a new "Seskupit" dropdown (Bez seskupení / Podle stavu). Within a group, rows are sorted by the user's chosen column.
- **/organizace/statistiky** — new "Dobrovolné příspěvky — přehled" table under the Finance card, listing every submission with a voluntary contribution sorted largest first, with contact name, email and a matching total footer.
- Sort state is preserved when game/state/group filters are changed.

## How sorting works
- Query params: `?sort=vs|kontakt|celkem|uhrazeno|stav&dir=asc|desc` — click any header to toggle.
- Grouping: `?group=stav` renders a group header row per `BalanceStatus`; the chosen sort applies inside each group.
- Default (no params): VS ascending.

## Plumbing
- `GameStatsService` builds `Donors` from `submittedSubmissions` (`VoluntaryDonation > 0`, ordered desc).
- New `DonorEntry` record (`SubmissionId`, `ContactName`, `ContactEmail`, `Amount`).
- `GameStats.Donors` property.
- Version `0.9.5 → 0.9.6`.

## Test plan
- [x] `dotnet test` — 71/71 passing
- [x] `dotnet build` — clean, 0 warnings
- [ ] After merge: open `/organizace/platby`, click each header, verify toggle; pick "Podle stavu" and confirm group headers render
- [ ] Open `/organizace/statistiky?gameId=…` for a game that has donations and verify the donor list is sorted largest first and the footer sum matches `DonationTotal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)