### PR TITLE
Inbox: auto-sync on open + dedup outbound + auto-link submissions [v0.9.7]

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
@@ -5,6 +5,7 @@
 @using RegistraceOvcina.Web.Features.Email
 
 @inject InboxService InboxService
+@inject MailboxSyncService MailboxSyncService
 @inject IOptions<MailboxEmailOptions> MailboxOptions
 
 <PageTitle>Pošta</PageTitle>
@@ -26,7 +27,10 @@
 }
 else if (result is null)
 {
-    <p class="text-secondary">Načítám zprávy...</p>
+    <p class="text-secondary">
+        <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+        Synchronizuji se schránkou a načítám zprávy...
+    </p>
 }
 else
 {
@@ -40,6 +44,10 @@ else
                             <p class="text-secondary mb-0">Zprávy ze sdílené poštovní schránky.</p>
                         </div>
                         <div class="d-flex gap-2">
+                            @if (autoSynced)
+                            {
+                                <span class="badge bg-success-subtle text-success-emphasis align-self-center">Automaticky synchronizováno</span>
+                            }
                             @if (synced == 1)
                             {
                                 <span class="badge bg-success align-self-center">Synchronizováno</span>
@@ -225,6 +233,7 @@ else
 
     private InboxPageResult? result;
     private bool showCompose;
+    private bool autoSynced;
 
     private void ToggleCompose()
     {
@@ -247,6 +256,11 @@ else
 
         if (page < 1) page = 1;
         if (string.IsNullOrWhiteSpace(tab)) tab = "inbox";
+
+        // Auto-sync on page open. Debounced in MailboxSyncService so repeated
+        // navigation within the cooldown window doesn't hammer the Graph API.
+        autoSynced = await MailboxSyncService.SyncIfStaleAsync();
+
         result = await InboxService.GetMessagesAsync(page, directionFilter: GetDirectionFilter());
     }
 }

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
@@ -5,7 +5,8 @@
 @using RegistraceOvcina.Web.Features.Email
 
 @inject InboxService InboxService
-@inject MailboxSyncService MailboxSyncService
+@* MailboxSyncService is only registered when the mailbox is configured, so inject it as optional. *@
+@inject IServiceProvider Services
 @inject IOptions<MailboxEmailOptions> MailboxOptions
 
 <PageTitle>Pošta</PageTitle>
@@ -259,7 +260,14 @@ else
 
         // Auto-sync on page open. Debounced in MailboxSyncService so repeated
         // navigation within the cooldown window doesn't hammer the Graph API.
-        autoSynced = await MailboxSyncService.SyncIfStaleAsync();
+        // Resolved lazily because the service is only registered when the
+        // mailbox is configured — resolving at injection time would break the
+        // "not configured" branch of this very page.
+        var syncService = Services.GetService<MailboxSyncService>();
+        if (syncService is not null)
+        {
+            autoSynced = await syncService.SyncIfStaleAsync();
+        }
 
         result = await InboxService.GetMessagesAsync(page, directionFilter: GetDirectionFilter());
     }

--- a/src/RegistraceOvcina.Web/Features/Email/MailboxSyncService.cs
+++ b/src/RegistraceOvcina.Web/Features/Email/MailboxSyncService.cs
@@ -19,6 +19,44 @@ internal sealed partial class MailboxSyncService(
         PropertyNameCaseInsensitive = true
     };
 
+    // In-memory debounce for the auto-sync triggered on page load. Kept per
+    // process — the sync button bypasses it by calling SyncInboxAsync directly,
+    // and a process restart simply performs one fresh sync.
+    private static DateTime s_lastSyncAtUtc = DateTime.MinValue;
+    private static readonly TimeSpan AutoSyncCooldown = TimeSpan.FromMinutes(2);
+    private static readonly object s_lastSyncLock = new();
+
+    /// <summary>
+    /// Runs <see cref="SyncInboxAsync"/> at most once per <see cref="AutoSyncCooldown"/>
+    /// interval. Returns <c>true</c> when the sync actually ran, <c>false</c> when the
+    /// cooldown short-circuited it. Used by the inbox page so opening it doesn't
+    /// hammer Graph on every refresh.
+    /// </summary>
+    public async Task<bool> SyncIfStaleAsync(CancellationToken cancellationToken = default)
+    {
+        lock (s_lastSyncLock)
+        {
+            if (DateTime.UtcNow - s_lastSyncAtUtc < AutoSyncCooldown)
+            {
+                return false;
+            }
+            s_lastSyncAtUtc = DateTime.UtcNow;
+        }
+
+        try
+        {
+            await SyncInboxAsync(cancellationToken);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Auto-sync on inbox open failed; page will still render cached messages");
+            // Roll the cooldown back so the user's manual retry isn't blocked
+            lock (s_lastSyncLock) { s_lastSyncAtUtc = DateTime.MinValue; }
+            return false;
+        }
+    }
+
     public async Task SyncInboxAsync(CancellationToken cancellationToken = default)
     {
         var emailOptions = options.Value;
@@ -77,7 +115,33 @@ internal sealed partial class MailboxSyncService(
             .GroupBy(x => x.Email)
             .ToDictionary(g => g.Key, g => g.First().Id);
 
+        // Preload submission primary emails for auto-linking. Active (non-cancelled,
+        // non-deleted) submissions for games that haven't ended yet win — stale
+        // submissions don't shadow current ones.
+        var submissionsByEmail = await dbContext.RegistrationSubmissions
+            .Where(s => !s.IsDeleted
+                && s.Status != SubmissionStatus.Cancelled
+                && s.PrimaryEmail != ""
+                && s.Game.EndsAtUtc >= DateTime.UtcNow.AddDays(-7))
+            .OrderByDescending(s => s.Game.StartsAtUtc)
+            .Select(s => new { s.Id, Email = s.PrimaryEmail.ToLower() })
+            .ToListAsync(cancellationToken);
+        var emailToSubmissionId = submissionsByEmail
+            .GroupBy(x => x.Email)
+            .ToDictionary(g => g.Key, g => g.First().Id);
+
+        // Pre-load unreconciled local outbound rows (the ones created by InboxService
+        // with a "composed-*" / "reply-*" placeholder id). Sync will try to "claim"
+        // them by matching to+subject+body so Graph's next surfacing of the same
+        // message doesn't create a duplicate row.
+        var localPlaceholders = await dbContext.EmailMessages
+            .Where(e => e.Direction == EmailDirection.Outbound
+                && (e.MailboxItemId.StartsWith("composed-") || e.MailboxItemId.StartsWith("reply-")))
+            .OrderByDescending(e => e.SentAtUtc)
+            .ToListAsync(cancellationToken);
+
         var newCount = 0;
+        var reconciledCount = 0;
 
         foreach (var msg in graphResponse.Value)
         {
@@ -103,6 +167,31 @@ internal sealed partial class MailboxSyncService(
             var isOutbound = !string.IsNullOrWhiteSpace(fromAddress)
                 && fromAddress.Equals(sharedMailbox, StringComparison.OrdinalIgnoreCase);
 
+            // Reconcile outbound messages with local placeholder rows from the
+            // compose/reply flow. Without this step, Graph surfacing of the same
+            // message on next sync creates a duplicate outbound row.
+            if (isOutbound)
+            {
+                var subjectKey = msg.Subject ?? "";
+                var normalizedTo = toAddresses.Trim().ToLowerInvariant();
+                var match = localPlaceholders.FirstOrDefault(p =>
+                    string.Equals(p.Subject, subjectKey, StringComparison.Ordinal)
+                    && string.Equals(p.To.Trim().ToLowerInvariant(), normalizedTo, StringComparison.Ordinal));
+
+                if (match is not null)
+                {
+                    match.MailboxItemId = msg.Id;
+                    if (msg.ReceivedDateTime?.UtcDateTime is DateTime receivedUtc)
+                    {
+                        match.ReceivedAtUtc = receivedUtc;
+                    }
+                    localPlaceholders.Remove(match);
+                    existingIds.Add(msg.Id);
+                    reconciledCount++;
+                    continue;
+                }
+            }
+
             var emailMessage = new EmailMessage
             {
                 MailboxItemId = msg.Id,
@@ -114,12 +203,17 @@ internal sealed partial class MailboxSyncService(
                 ReceivedAtUtc = msg.ReceivedDateTime?.UtcDateTime,
             };
 
-            // Auto-link to person: by sender for inbound, by recipient for outbound
+            // Auto-link to submission/person. Submission wins when a current-game
+            // PrimaryEmail matches; otherwise fall back to Person.Email.
             var linkAddress = isOutbound ? toAddresses.Split(';', StringSplitOptions.TrimEntries).FirstOrDefault() : fromAddress;
-            if (emailMessage.LinkedPersonId is null && !string.IsNullOrWhiteSpace(linkAddress))
+            if (!string.IsNullOrWhiteSpace(linkAddress))
             {
                 var normalizedLink = linkAddress.Trim().ToLowerInvariant();
-                if (emailToPersonId.TryGetValue(normalizedLink, out var personId))
+                if (emailToSubmissionId.TryGetValue(normalizedLink, out var submissionId))
+                {
+                    emailMessage.LinkedSubmissionId = submissionId;
+                }
+                else if (emailToPersonId.TryGetValue(normalizedLink, out var personId))
                 {
                     emailMessage.LinkedPersonId = personId;
                 }
@@ -140,12 +234,16 @@ internal sealed partial class MailboxSyncService(
             msg2.Direction = EmailDirection.Outbound;
         }
 
-        if (newCount > 0 || mistagged.Count > 0)
+        if (newCount > 0 || mistagged.Count > 0 || reconciledCount > 0)
         {
             await dbContext.SaveChangesAsync(cancellationToken);
         }
 
-        logger.LogInformation("Mailbox sync complete: {NewCount} new, {FixedCount} direction-fixed", newCount, mistagged.Count);
+        logger.LogInformation(
+            "Mailbox sync complete: {NewCount} new, {FixedCount} direction-fixed, {ReconciledCount} outbound reconciled",
+            newCount,
+            mistagged.Count,
+            reconciledCount);
     }
 
     private static string StripHtml(string html)

--- a/src/RegistraceOvcina.Web/Features/Email/MailboxSyncService.cs
+++ b/src/RegistraceOvcina.Web/Features/Email/MailboxSyncService.cs
@@ -26,11 +26,17 @@ internal sealed partial class MailboxSyncService(
     private static readonly TimeSpan AutoSyncCooldown = TimeSpan.FromMinutes(2);
     private static readonly object s_lastSyncLock = new();
 
+    // Serializes sync execution across the process so two overlapping page
+    // loads don't both run SyncInboxAsync and race on existingIds — without
+    // this, with no unique constraint on MailboxItemId, we'd end up with
+    // duplicates even with the cooldown in place.
+    private static readonly SemaphoreSlim s_syncMutex = new(1, 1);
+
     /// <summary>
     /// Runs <see cref="SyncInboxAsync"/> at most once per <see cref="AutoSyncCooldown"/>
-    /// interval. Returns <c>true</c> when the sync actually ran, <c>false</c> when the
-    /// cooldown short-circuited it. Used by the inbox page so opening it doesn't
-    /// hammer Graph on every refresh.
+    /// interval. Returns <c>true</c> when the sync actually ran *and* succeeded,
+    /// <c>false</c> when the cooldown short-circuited it or the sync itself failed.
+    /// Used by the inbox page so opening it doesn't hammer Graph on every refresh.
     /// </summary>
     public async Task<bool> SyncIfStaleAsync(CancellationToken cancellationToken = default)
     {
@@ -43,28 +49,46 @@ internal sealed partial class MailboxSyncService(
             s_lastSyncAtUtc = DateTime.UtcNow;
         }
 
+        // Block concurrent syncs while still respecting the cooldown above.
+        await s_syncMutex.WaitAsync(cancellationToken);
         try
         {
-            await SyncInboxAsync(cancellationToken);
-            return true;
+            var succeeded = await SyncInboxAsync(cancellationToken);
+            if (!succeeded)
+            {
+                // Roll the cooldown back so the next page load retries instead
+                // of showing "Automaticky synchronizováno" on a stale cache.
+                lock (s_lastSyncLock) { s_lastSyncAtUtc = DateTime.MinValue; }
+            }
+            return succeeded;
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Auto-sync on inbox open failed; page will still render cached messages");
-            // Roll the cooldown back so the user's manual retry isn't blocked
             lock (s_lastSyncLock) { s_lastSyncAtUtc = DateTime.MinValue; }
             return false;
         }
+        finally
+        {
+            s_syncMutex.Release();
+        }
     }
 
-    public async Task SyncInboxAsync(CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Pulls messages from the shared mailbox, reconciles outbound placeholders,
+    /// auto-links recognized senders/recipients and persists the delta. Returns
+    /// <c>true</c> on a successful round-trip (even if nothing changed) and
+    /// <c>false</c> when the sync was skipped or the Graph call failed without
+    /// throwing.
+    /// </summary>
+    public async Task<bool> SyncInboxAsync(CancellationToken cancellationToken = default)
     {
         var emailOptions = options.Value;
 
         if (!emailOptions.IsConfigured)
         {
             logger.LogWarning("Mailbox sync skipped — email is not configured");
-            return;
+            return false;
         }
 
         var accessToken = await tokenProvider.GetAccessTokenAsync(cancellationToken);
@@ -88,7 +112,7 @@ internal sealed partial class MailboxSyncService(
                 "Mailbox sync failed with status {StatusCode}: {ResponseBody}",
                 (int)response.StatusCode,
                 responseBody);
-            return;
+            return false;
         }
 
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
@@ -97,7 +121,7 @@ internal sealed partial class MailboxSyncService(
         if (graphResponse?.Value is null or { Count: 0 })
         {
             logger.LogInformation("Mailbox sync: no messages returned from Graph API");
-            return;
+            return true;
         }
 
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
@@ -106,29 +130,31 @@ internal sealed partial class MailboxSyncService(
             .Select(e => e.MailboxItemId)
             .ToHashSetAsync(cancellationToken);
 
-        // Preload people emails for auto-linking (avoids N+1 queries)
+        // Preload people emails for auto-linking (avoids N+1 queries).
+        // The DB projection pulls the raw email; we lower-case invariantly in
+        // memory so dictionary lookups match the ToLowerInvariant() callers.
         var peopleByEmail = await dbContext.People
             .Where(x => x.Email != null && !x.IsDeleted)
-            .Select(x => new { x.Id, Email = x.Email!.ToLower() })
+            .Select(x => new { x.Id, x.Email })
             .ToListAsync(cancellationToken);
         var emailToPersonId = peopleByEmail
-            .GroupBy(x => x.Email)
-            .ToDictionary(g => g.Key, g => g.First().Id);
+            .GroupBy(x => x.Email!.Trim().ToLowerInvariant())
+            .ToDictionary(g => g.Key, g => g.First().Id, StringComparer.Ordinal);
 
         // Preload submission primary emails for auto-linking. Active (non-cancelled,
-        // non-deleted) submissions for games that haven't ended yet win — stale
-        // submissions don't shadow current ones.
+        // non-deleted) submissions for games that haven't ended more than a week
+        // ago win — stale submissions don't shadow current ones.
         var submissionsByEmail = await dbContext.RegistrationSubmissions
             .Where(s => !s.IsDeleted
                 && s.Status != SubmissionStatus.Cancelled
                 && s.PrimaryEmail != ""
                 && s.Game.EndsAtUtc >= DateTime.UtcNow.AddDays(-7))
             .OrderByDescending(s => s.Game.StartsAtUtc)
-            .Select(s => new { s.Id, Email = s.PrimaryEmail.ToLower() })
+            .Select(s => new { s.Id, s.PrimaryEmail })
             .ToListAsync(cancellationToken);
         var emailToSubmissionId = submissionsByEmail
-            .GroupBy(x => x.Email)
-            .ToDictionary(g => g.Key, g => g.First().Id);
+            .GroupBy(x => x.PrimaryEmail.Trim().ToLowerInvariant())
+            .ToDictionary(g => g.Key, g => g.First().Id, StringComparer.Ordinal);
 
         // Pre-load unreconciled local outbound rows (the ones created by InboxService
         // with a "composed-*" / "reply-*" placeholder id). Sync will try to "claim"
@@ -168,15 +194,49 @@ internal sealed partial class MailboxSyncService(
                 && fromAddress.Equals(sharedMailbox, StringComparison.OrdinalIgnoreCase);
 
             // Reconcile outbound messages with local placeholder rows from the
-            // compose/reply flow. Without this step, Graph surfacing of the same
-            // message on next sync creates a duplicate outbound row.
+            // compose/reply flow. Match first on (To, Subject); when multiple
+            // candidates qualify, use a normalized body prefix to tie-break and
+            // then fall back to the most recent SentAtUtc. Without this step,
+            // Graph surfacing of the same message on next sync creates a
+            // duplicate outbound row.
             if (isOutbound)
             {
                 var subjectKey = msg.Subject ?? "";
                 var normalizedTo = toAddresses.Trim().ToLowerInvariant();
-                var match = localPlaceholders.FirstOrDefault(p =>
-                    string.Equals(p.Subject, subjectKey, StringComparison.Ordinal)
-                    && string.Equals(p.To.Trim().ToLowerInvariant(), normalizedTo, StringComparison.Ordinal));
+                var candidates = localPlaceholders
+                    .Where(p =>
+                        string.Equals(p.Subject, subjectKey, StringComparison.Ordinal)
+                        && string.Equals(p.To.Trim().ToLowerInvariant(), normalizedTo, StringComparison.Ordinal))
+                    .ToList();
+
+                EmailMessage? match = null;
+                if (candidates.Count == 1)
+                {
+                    match = candidates[0];
+                }
+                else if (candidates.Count > 1)
+                {
+                    var bodyKey = BuildReconciliationBodyKey(bodyText);
+                    if (!string.IsNullOrEmpty(bodyKey))
+                    {
+                        var refined = candidates
+                            .Where(p => string.Equals(
+                                BuildReconciliationBodyKey(p.BodyText),
+                                bodyKey,
+                                StringComparison.Ordinal))
+                            .ToList();
+                        if (refined.Count > 0)
+                        {
+                            candidates = refined;
+                        }
+                    }
+
+                    // Still ambiguous — prefer the most recently sent placeholder,
+                    // which is the one Graph is most likely surfacing.
+                    match = candidates
+                        .OrderByDescending(p => p.SentAtUtc ?? DateTime.MinValue)
+                        .FirstOrDefault();
+                }
 
                 if (match is not null)
                 {
@@ -244,6 +304,25 @@ internal sealed partial class MailboxSyncService(
             newCount,
             mistagged.Count,
             reconciledCount);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Normalized, truncated body key used to disambiguate outbound placeholders
+    /// that share the same (To, Subject). Collapses whitespace, lowercases
+    /// invariantly and clips to 200 characters so cosmetic differences in
+    /// Graph's round-tripped body don't prevent a match.
+    /// </summary>
+    private static string BuildReconciliationBodyKey(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return "";
+        }
+
+        var normalized = WhitespaceRegex().Replace(text, " ").Trim().ToLowerInvariant();
+        return normalized.Length > 200 ? normalized[..200] : normalized;
     }
 
     private static string StripHtml(string html)
@@ -288,6 +367,9 @@ internal sealed partial class MailboxSyncService(
 
     [GeneratedRegex(@"\n{3,}")]
     private static partial Regex ExcessiveNewlinesRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
 
     // Graph API response DTOs
 

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.6</Version>
+    <Version>0.9.7</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
Addresses 2 of the 3 items in #149 (the 3rd — fulltext search over current-game submissions — is deferred to a separate PR since it requires a linking UI redesign).

## Changes

### Auto-sync on open (#149 ①)
- `MailboxSyncService.SyncIfStaleAsync()` — runs a full sync at most once per 2 minutes, per process. In-memory debounce; the manual "Synchronizovat" button bypasses it.
- `/organizace/posta` now calls it from `OnParametersSetAsync` before loading messages.
- Loading state upgraded: "Synchronizuji se schránkou a načítám zprávy…" with a spinner. When auto-sync actually ran, an "Automaticky synchronizováno" badge appears next to the manual button.
- Sync failures during auto-sync roll the cooldown back so the next manual retry isn't blocked.

### Outbound duplication fix (#149 ②)
Root cause: `InboxService.SendNewMessageAsync` / `SendReplyAsync` save a local row with `MailboxItemId = "composed-<guid>"` or `"reply-<id>-<ticks>"`. Graph later surfaces the same Sent-Items message via `/messages` with its real id (`AAMkA…`), which wasn't in `existingIds`, so a duplicate row was inserted.

Fix: sync now pre-loads all unreconciled local outbound rows and, for each outbound Graph message, looks for a placeholder with matching `(To, Subject)`. On match, the placeholder's `MailboxItemId` is rewritten to the Graph id instead of inserting a new row. The placeholder is then removed from the candidate list so the same local row can't be matched twice.

### Auto-link by submission (#149 ③ partial)
Previously, sync only auto-linked by `Person.Email`. Now it preloads `PrimaryEmail` for submissions that are:
- not deleted
- not `Cancelled`
- on a game that hasn't ended more than 7 days ago

When a sender/recipient matches, the message is linked to the submission directly. Person-email match is the fallback. This gets "ideálně automaticky" from the issue.

The organizer-side fulltext search over *just current-game submissions* (#149 ③ full) is a bigger UX change in `InboxMessage.razor` and is queued for a follow-up.

## Test plan
- [x] `dotnet test` — 71/71 passing
- [x] `dotnet build` — clean
- [ ] After merge: open `/organizace/posta`, see the loading spinner + auto-sync badge, verify no duplicates appear on the Odesláno tab when composing + reopening the page; check that new messages from known submission emails show up with a "Přihláška #N" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)