### PR TITLE
Organizers can edit existing submissions after deadline [v0.9.8]

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/SubmissionDetail.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/SubmissionDetail.razor
@@ -15,8 +15,13 @@ else
         <a href="/organizace/prihlasky" class="text-decoration-none">&larr; Zpět na přihlášky</a>
     </div>
 
-    <h1 class="h3 mb-1">Přihláška #@detail.Id</h1>
-    <p class="text-secondary mb-4">@detail.GameName</p>
+    <div class="d-flex justify-content-between align-items-start mb-4 flex-wrap gap-2">
+        <div>
+            <h1 class="h3 mb-1">Přihláška #@detail.Id</h1>
+            <p class="text-secondary mb-0">@detail.GameName</p>
+        </div>
+        <a href="/prihlasky/@detail.Id" class="btn btn-primary">Upravit přihlášku</a>
+    </div>
 
     @if (!string.IsNullOrWhiteSpace(statusMessage))
     {

--- a/src/RegistraceOvcina.Web/Components/Pages/Registrations/SubmissionEditor.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Registrations/SubmissionEditor.razor
@@ -32,6 +32,15 @@ else
         </div>
     </section>
 
+    @if (submission.IsStaffView)
+    {
+        <div class="alert alert-warning mb-4" role="status">
+            <strong>Organizátorský režim.</strong> Upravujete přihlášku cizího uživatele.
+            Noví účastníci se přidávat nedají, ale stávající účastníky a jejich údaje
+            můžete měnit i po uzávěrce registrace.
+        </div>
+    }
+
     @if (!string.IsNullOrWhiteSpace(statusMessage))
     {
         <div class="toast-success" id="success-toast" role="status">@statusMessage</div>
@@ -212,6 +221,12 @@ else
                             </div>
                         }
 
+                        @* Staff after deadline can still edit existing attendees,
+                           but nobody can add new ones once the deadline has passed.
+                           The form doubles as add/edit, so gate it on CanAddAttendees
+                           unless we're already in the middle of editing someone. *@
+                        @if (submission.CanAddAttendees || editingRegistrationId is not null)
+                        {
                         <EditForm Model="attendeeInput" OnValidSubmit="SaveAttendeeAsync" OnInvalidSubmit="ScrollToErrors" FormName="attendee" id="attendee-form">
                             <DataAnnotationsValidator />
                             <h3 class="h5 mb-3">@(editingRegistrationId is not null ? "Upravit účastníka" : "Přidat účastníka")</h3>
@@ -489,6 +504,14 @@ else
                                 }
                             </div>
                         </EditForm>
+                        }
+                        else
+                        {
+                            <div class="alert alert-secondary mb-0">
+                                <strong>Registrace je uzavřená</strong> — noví účastníci se již nedají přidat.
+                                Stávající účastníky můžete nadále upravovat pomocí tlačítka <em>Upravit</em> u konkrétní karty.
+                            </div>
+                        }
                     </div>
                 </section>
 
@@ -828,6 +851,11 @@ function scrollToValidationErrors() {
         }
     }
 
+    // Cached per-load — staff (Admin/Organizer) can open any submission and edit
+    // existing data past the registration deadline. This flag is refreshed on
+    // every LoadAsync so a role change picked up in the same session is honored.
+    private bool isStaff;
+
     private async Task LoadAsync()
     {
         var user = await GetCurrentUserAsync();
@@ -838,7 +866,10 @@ function scrollToValidationErrors() {
             return;
         }
 
-        submission = await SubmissionService.GetSubmissionAsync(SubmissionId, user.Id);
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        isStaff = authState.User.IsInRole(RoleNames.Admin) || authState.User.IsInRole(RoleNames.Organizer);
+
+        submission = await SubmissionService.GetSubmissionAsync(SubmissionId, user.Id, isStaff);
         if (submission is null)
         {
             return;
@@ -913,7 +944,7 @@ function scrollToValidationErrors() {
 
         try
         {
-            await SubmissionService.UpdateContactAsync(SubmissionId, user.Id, contactInput);
+            await SubmissionService.UpdateContactAsync(SubmissionId, user.Id, contactInput, isStaff);
             statusMessage = "Kontaktní údaje byly uložené.";
             await LoadAsync();
         }
@@ -951,7 +982,7 @@ function scrollToValidationErrors() {
 
         try
         {
-            await SubmissionService.UpdateDonationAsync(SubmissionId, user.Id, donationInput.Amount);
+            await SubmissionService.UpdateDonationAsync(SubmissionId, user.Id, donationInput.Amount, isStaff);
             statusMessage = "Příspěvek byl uložený.";
             await LoadAsync();
         }
@@ -980,13 +1011,13 @@ function scrollToValidationErrors() {
         {
             if (editingRegistrationId is not null)
             {
-                await SubmissionService.UpdateAttendeeAsync(SubmissionId, editingRegistrationId.Value, user.Id, attendeeInput);
+                await SubmissionService.UpdateAttendeeAsync(SubmissionId, editingRegistrationId.Value, user.Id, attendeeInput, isStaff);
                 statusMessage = "Účastník byl upraven.";
                 editingRegistrationId = null;
             }
             else
             {
-                await SubmissionService.AddAttendeeAsync(SubmissionId, user.Id, attendeeInput);
+                await SubmissionService.AddAttendeeAsync(SubmissionId, user.Id, attendeeInput, isStaff);
                 statusMessage = "Účastník byl přidán.";
             }
             attendeeInput = CreateDefaultAttendeeInput(null);

--- a/src/RegistraceOvcina.Web/Features/Submissions/SubmissionService.cs
+++ b/src/RegistraceOvcina.Web/Features/Submissions/SubmissionService.cs
@@ -108,6 +108,7 @@ public sealed class SubmissionService(
     public async Task<SubmissionEditorViewModel?> GetSubmissionAsync(
         int submissionId,
         string userId,
+        bool isStaff = false,
         CancellationToken cancellationToken = default)
     {
         await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
@@ -121,7 +122,7 @@ public sealed class SubmissionService(
             .Include(x => x.Registrations)
                 .ThenInclude(x => x.FoodOrders)
             .Include(x => x.Payments)
-            .FirstOrDefaultAsync(x => x.Id == submissionId && x.RegistrantUserId == userId, cancellationToken);
+            .FirstOrDefaultAsync(x => x.Id == submissionId && (isStaff || x.RegistrantUserId == userId), cancellationToken);
 
         if (submission is null)
         {
@@ -174,10 +175,16 @@ public sealed class SubmissionService(
             RegistrationClosesAtUtc = submission.Game.RegistrationClosesAtUtc,
             MealOrderingClosesAtUtc = submission.Game.MealOrderingClosesAtUtc,
             PaymentDueAtUtc = submission.Game.PaymentDueAtUtc,
+            // Staff (Admin/Organizer) can keep editing attendee details, food and
+            // lodging after the deadline has passed; CanAddAttendees stays gated by
+            // the real deadline so nobody (user or staff) can grow the submission.
             CanEditRegistration = submission.Status != SubmissionStatus.Cancelled
-                && nowUtc <= submission.Game.RegistrationClosesAtUtc,
+                && (isStaff || nowUtc <= submission.Game.RegistrationClosesAtUtc),
             CanEditMeals = submission.Status != SubmissionStatus.Cancelled
-                && nowUtc <= submission.Game.MealOrderingClosesAtUtc,
+                && (isStaff || nowUtc <= submission.Game.MealOrderingClosesAtUtc),
+            CanAddAttendees = submission.Status != SubmissionStatus.Cancelled
+                && nowUtc <= submission.Game.RegistrationClosesAtUtc,
+            IsStaffView = isStaff && submission.RegistrantUserId != userId,
             BankAccount = submission.Game.BankAccount,
             BankAccountName = submission.Game.BankAccountName,
             LodgingIndoorPrice = submission.Game.LodgingIndoorPrice,
@@ -232,13 +239,14 @@ public sealed class SubmissionService(
         int submissionId,
         string userId,
         ContactInput input,
+        bool isStaff = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(input);
 
         await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var submission = await db.RegistrationSubmissions
-            .FirstOrDefaultAsync(x => x.Id == submissionId && x.RegistrantUserId == userId, cancellationToken)
+            .FirstOrDefaultAsync(x => x.Id == submissionId && (isStaff || x.RegistrantUserId == userId), cancellationToken)
             ?? throw new ValidationException("Přihláška nebyla nalezena.");
         EnsureEditable(submission);
 
@@ -264,6 +272,7 @@ public sealed class SubmissionService(
         int submissionId,
         string userId,
         decimal amount,
+        bool isStaff = false,
         CancellationToken cancellationToken = default)
     {
         await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
@@ -272,7 +281,7 @@ public sealed class SubmissionService(
             .Include(x => x.Registrations).ThenInclude(r => r.Person)
             .Include(x => x.Registrations).ThenInclude(r => r.FoodOrders)
             .AsSplitQuery()
-            .FirstOrDefaultAsync(x => x.Id == submissionId && x.RegistrantUserId == userId, cancellationToken)
+            .FirstOrDefaultAsync(x => x.Id == submissionId && (isStaff || x.RegistrantUserId == userId), cancellationToken)
             ?? throw new ValidationException("Přihláška nebyla nalezena.");
         EnsureEditable(submission);
 
@@ -288,9 +297,15 @@ public sealed class SubmissionService(
         int submissionId,
         string userId,
         AttendeeInput input,
+        bool isStaff = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(input);
+
+        // NOTE: isStaff only bypasses the owner filter so staff can add an attendee
+        // to someone else's submission while registration is still open. It does
+        // NOT bypass the deadline — EnsureRegistrationOpen is called without
+        // isStaff so adding new people is blocked for everyone after the deadline.
 
         await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var submission = await db.RegistrationSubmissions
@@ -300,7 +315,7 @@ public sealed class SubmissionService(
                 .ThenInclude(x => x.Person)
             .Include(x => x.Registrations)
                 .ThenInclude(x => x.FoodOrders)
-            .FirstOrDefaultAsync(x => x.Id == submissionId && x.RegistrantUserId == userId, cancellationToken)
+            .FirstOrDefaultAsync(x => x.Id == submissionId && (isStaff || x.RegistrantUserId == userId), cancellationToken)
             ?? throw new ValidationException("Přihláška nebyla nalezena.");
 
         EnsureRegistrationOpen(submission);
@@ -461,6 +476,7 @@ public sealed class SubmissionService(
         int registrationId,
         string userId,
         AttendeeInput input,
+        bool isStaff = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(input);
@@ -473,9 +489,9 @@ public sealed class SubmissionService(
                 .ThenInclude(x => x.Person)
             .Include(x => x.Registrations)
                 .ThenInclude(x => x.FoodOrders)
-            .FirstOrDefaultAsync(x => x.Id == submissionId && x.RegistrantUserId == userId, cancellationToken)
+            .FirstOrDefaultAsync(x => x.Id == submissionId && (isStaff || x.RegistrantUserId == userId), cancellationToken)
             ?? throw new ValidationException("Přihláška nebyla nalezena.");
-        EnsureRegistrationOpen(submission);
+        EnsureRegistrationOpen(submission, isStaff);
 
         var registration = await db.Registrations
             .Include(x => x.Person)
@@ -596,6 +612,7 @@ public sealed class SubmissionService(
         int submissionId,
         int registrationId,
         string userId,
+        bool isStaff = false,
         CancellationToken cancellationToken = default)
     {
         await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
@@ -605,9 +622,11 @@ public sealed class SubmissionService(
                 .ThenInclude(x => x.Person)
             .Include(x => x.Registrations)
                 .ThenInclude(x => x.FoodOrders)
-            .FirstOrDefaultAsync(x => x.Id == submissionId && x.RegistrantUserId == userId, cancellationToken)
+            .FirstOrDefaultAsync(x => x.Id == submissionId && (isStaff || x.RegistrantUserId == userId), cancellationToken)
             ?? throw new ValidationException("Přihláška nebyla nalezena.");
-        EnsureRegistrationOpen(submission);
+        // Staff may remove attendees after the deadline (e.g. no-show clean up)
+        // even though no-one can add new people past the deadline.
+        EnsureRegistrationOpen(submission, isStaff);
 
         var registration = await db.Registrations
             .Include(x => x.Person)
@@ -634,16 +653,17 @@ public sealed class SubmissionService(
         int submissionId,
         string userId,
         List<FoodOrderInput> orders,
+        bool isStaff = false,
         CancellationToken cancellationToken = default)
     {
         await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var submission = await db.RegistrationSubmissions
             .Include(x => x.Registrations).ThenInclude(x => x.FoodOrders)
             .Include(x => x.Game).ThenInclude(x => x.MealOptions)
-            .FirstOrDefaultAsync(x => x.Id == submissionId && x.RegistrantUserId == userId, cancellationToken)
+            .FirstOrDefaultAsync(x => x.Id == submissionId && (isStaff || x.RegistrantUserId == userId), cancellationToken)
             ?? throw new ValidationException("Přihláška nebyla nalezena.");
 
-        EnsureMealOrderingOpen(submission);
+        EnsureMealOrderingOpen(submission, isStaff);
 
         var validRegistrationIds = submission.Registrations.Select(x => x.Id).ToHashSet();
         var validMealOptionIds = submission.Game.MealOptions.Where(x => x.IsActive).ToDictionary(x => x.Id);
@@ -828,17 +848,23 @@ public sealed class SubmissionService(
             throw new ValidationException("Zrušená přihláška nelze upravovat.");
     }
 
-    private void EnsureRegistrationOpen(RegistrationSubmission submission)
+    private void EnsureRegistrationOpen(RegistrationSubmission submission, bool isStaff = false)
     {
         EnsureEditable(submission);
+        // Staff (Admin/Organizer) can edit attendee data after the deadline has passed —
+        // they are explicitly allowed to adjust food, lodging, preferences etc. on
+        // behalf of registrants. Adding and removing attendees is still blocked for
+        // everyone once the deadline passes; those methods do not pass isStaff=true.
+        if (isStaff) return;
         var now = timeProvider.GetUtcNow().UtcDateTime;
         if (now > submission.Game.RegistrationClosesAtUtc)
             throw new ValidationException("Registrace pro tuto hru je už uzavřená.");
     }
 
-    private void EnsureMealOrderingOpen(RegistrationSubmission submission)
+    private void EnsureMealOrderingOpen(RegistrationSubmission submission, bool isStaff = false)
     {
         EnsureEditable(submission);
+        if (isStaff) return;
         var now = timeProvider.GetUtcNow().UtcDateTime;
         if (now > submission.Game.MealOrderingClosesAtUtc)
             throw new ValidationException("Objednávání jídel pro tuto hru je už uzavřené.");
@@ -1042,6 +1068,17 @@ public sealed class SubmissionEditorViewModel
     public DateTime PaymentDueAtUtc { get; init; }
     public bool CanEditRegistration { get; init; }
     public bool CanEditMeals { get; init; }
+    /// <summary>
+    /// True only while the game registration deadline has not passed. Used to
+    /// gate the "add attendee" UI — staff cannot add new people after the
+    /// deadline even when they can still edit the existing ones.
+    /// </summary>
+    public bool CanAddAttendees { get; init; }
+    /// <summary>
+    /// True when the editor was opened by a staff user acting on behalf of
+    /// another registrant. The UI can show a "viewing as organizer" banner.
+    /// </summary>
+    public bool IsStaffView { get; init; }
     public string BankAccount { get; init; } = "";
     public string BankAccountName { get; init; } = "";
     public decimal LodgingIndoorPrice { get; init; }

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -757,7 +757,8 @@ public class Program
 
                     try
                     {
-                        await submissionService.UpdateContactAsync(submissionId, user.Id, input);
+                        var isStaff = httpContext.User.IsInRole(RoleNames.Admin) || httpContext.User.IsInRole(RoleNames.Organizer);
+                        await submissionService.UpdateContactAsync(submissionId, user.Id, input, isStaff);
                         return Results.LocalRedirect($"/prihlasky/{submissionId}?contactSaved=1");
                     }
                     catch (ValidationException ex)
@@ -783,7 +784,8 @@ public class Program
 
                     try
                     {
-                        await submissionService.AddAttendeeAsync(submissionId, user.Id, input);
+                        var isStaff = httpContext.User.IsInRole(RoleNames.Admin) || httpContext.User.IsInRole(RoleNames.Organizer);
+                        await submissionService.AddAttendeeAsync(submissionId, user.Id, input, isStaff);
                         return Results.LocalRedirect($"/prihlasky/{submissionId}?attendeeAdded=1");
                     }
                     catch (ValidationException ex)
@@ -810,7 +812,8 @@ public class Program
 
                     try
                     {
-                        await submissionService.RemoveAttendeeAsync(submissionId, registrationId, user.Id);
+                        var isStaff = httpContext.User.IsInRole(RoleNames.Admin) || httpContext.User.IsInRole(RoleNames.Organizer);
+                        await submissionService.RemoveAttendeeAsync(submissionId, registrationId, user.Id, isStaff);
                         return Results.LocalRedirect($"/prihlasky/{submissionId}?attendeeRemoved=1");
                     }
                     catch (ValidationException ex)
@@ -836,7 +839,8 @@ public class Program
 
                     try
                     {
-                        await submissionService.UpdateAttendeeAsync(submissionId, registrationId, user.Id, input);
+                        var isStaff = httpContext.User.IsInRole(RoleNames.Admin) || httpContext.User.IsInRole(RoleNames.Organizer);
+                        await submissionService.UpdateAttendeeAsync(submissionId, registrationId, user.Id, input, isStaff);
                         return Results.LocalRedirect($"/prihlasky/{submissionId}?attendeeUpdated=1");
                     }
                     catch (ValidationException ex)
@@ -869,7 +873,8 @@ public class Program
                             orders.Add(new FoodOrderInput(regId, mealOptionId, new DateTime(dayTicks, DateTimeKind.Utc)));
                         }
 
-                        await submissionService.SaveFoodOrdersAsync(submissionId, user.Id, orders);
+                        var isStaff = httpContext.User.IsInRole(RoleNames.Admin) || httpContext.User.IsInRole(RoleNames.Organizer);
+                        await submissionService.SaveFoodOrdersAsync(submissionId, user.Id, orders, isStaff);
                         return Results.LocalRedirect($"/prihlasky/{submissionId}?foodSaved=1");
                     }
                     catch (ValidationException ex)

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.7</Version>
+    <Version>0.9.8</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
Requested: let organizers keep editing existing registrations after the deadline has passed (food, lodging, notes, contact info, per-attendee details) **without letting anyone add new people**.

## Rules enforced
- **Past deadline, staff (Admin/Organizer):** can open any submission, edit contact, donation, attendee details, food and lodging. Can also remove attendees (e.g. no-show cleanup).
- **Past deadline, regular user:** no change — editor stays locked exactly as before. No self-service.
- **Add new attendee:** blocked for **everyone** (user and staff) once the registration deadline has passed. `AddAttendeeAsync` calls `EnsureRegistrationOpen(submission)` without `isStaff`, so the deadline check always fires.

## Plumbing
- `SubmissionService`: optional `bool isStaff = false` on every mutation method. Bypasses `RegistrantUserId == userId` filter when set. `EnsureRegistrationOpen`/`EnsureMealOrderingOpen` skip deadline check when `isStaff`; `AddAttendeeAsync` deliberately doesn't pass `isStaff` into the guard.
- `SubmissionEditorViewModel`: `CanAddAttendees` (deadline-hard, no staff override) and `IsStaffView` (staff editing someone else's submission).
- Form handlers in `Program.cs` read `isStaff = user.IsInRole(Admin) || user.IsInRole(Organizer)` from `HttpContext` and forward to service.
- `SubmissionEditor.razor` caches `isStaff` per load and passes it through; shows an "Organizátorský režim" banner when applicable; gates the add/edit attendee form on `CanAddAttendees` (plain add form is replaced with an informational notice once the deadline passes).
- `SubmissionDetail.razor` (organizer) gets a prominent "Upravit přihlášku" button linking to `/prihlasky/{id}`.

## Test plan
- [x] `dotnet test` — 71/71 passing
- [x] `dotnet build` — clean, 0 warnings from this change
- [ ] After merge: as organizer, open `/organizace/prihlasky/<id>` → click "Upravit přihlášku" → verify banner, can edit meals/lodging/notes, cannot add new attendees (notice shown). As regular user, open own submission past deadline → no changes, still locked.

Version `0.9.7 → 0.9.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)