### PR TITLE
Kingdom XLSX export + inbox sent shows To + fulltext mail linking [v0.9.9]

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
@@ -132,7 +132,7 @@ else
                                     <tr>
                                         <th>Datum</th>
                                         <th>Směr</th>
-                                        <th>Od</th>
+                                        <th>@(tab == "sent" ? "Komu" : "Od / Komu")</th>
                                         <th>Předmět</th>
                                         <th>Propojeno s</th>
                                         <th>Akce</th>
@@ -157,7 +157,7 @@ else
                                                     <span class="badge bg-success-subtle text-success-emphasis">Odesláno</span>
                                                 }
                                             </td>
-                                            <td>@msg.From</td>
+                                            <td>@(msg.Direction == EmailDirection.Outbound ? msg.To : msg.From)</td>
                                             <td>
                                                 <a href="/organizace/posta/@msg.Id" data-testid="@($"inbox-subject-{msg.Id}")">
                                                     @(string.IsNullOrWhiteSpace(msg.Subject) ? "(bez předmětu)" : msg.Subject)

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/InboxMessage.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/InboxMessage.razor
@@ -124,36 +124,48 @@ else
                             <div class="col-12 col-md-6">
                                 <form method="post" action="/organizace/posta/@messageId/propojit-prihlasku">
                                     <AntiforgeryToken />
-                                    <label class="form-label" for="submission-select">Propojit s přihláškou</label>
+                                    <label class="form-label" for="submission-input">Propojit s přihláškou (aktuální hra)</label>
                                     <div class="d-flex gap-2">
-                                        <select id="submission-select" name="submissionId" class="form-select" data-testid="link-submission-select">
+                                        <input id="submission-input" list="submission-list" class="form-control"
+                                               placeholder="Hledejte jménem nebo číslem..."
+                                               autocomplete="off"
+                                               data-testid="link-submission-select"
+                                               @onchange="OnSubmissionSelected" />
+                                        <input type="hidden" name="submissionId" value="@selectedSubmissionId" />
+                                        <datalist id="submission-list">
                                             @if (submissions is not null)
                                             {
                                                 @foreach (var s in submissions)
                                                 {
-                                                    <option value="@s.Id">@s.Label</option>
+                                                    <option value="@s.Label" data-id="@s.Id"></option>
                                                 }
                                             }
-                                        </select>
-                                        <button type="submit" class="btn btn-outline-primary" data-testid="link-submission-button">Propojit</button>
+                                        </datalist>
+                                        <button type="submit" class="btn btn-outline-primary" disabled="@(selectedSubmissionId is null)" data-testid="link-submission-button">Propojit</button>
                                     </div>
                                 </form>
                             </div>
                             <div class="col-12 col-md-6">
                                 <form method="post" action="/organizace/posta/@messageId/propojit-osobu">
                                     <AntiforgeryToken />
-                                    <label class="form-label" for="person-select">Propojit s osobou</label>
+                                    <label class="form-label" for="person-input">Propojit s osobou</label>
                                     <div class="d-flex gap-2">
-                                        <select id="person-select" name="personId" class="form-select" data-testid="link-person-select">
+                                        <input id="person-input" list="person-list" class="form-control"
+                                               placeholder="Hledejte jménem nebo e-mailem..."
+                                               autocomplete="off"
+                                               data-testid="link-person-select"
+                                               @onchange="OnPersonSelected" />
+                                        <input type="hidden" name="personId" value="@selectedPersonId" />
+                                        <datalist id="person-list">
                                             @if (people is not null)
                                             {
                                                 @foreach (var p in people)
                                                 {
-                                                    <option value="@p.Id">@p.Name</option>
+                                                    <option value="@p.Name" data-id="@p.Id"></option>
                                                 }
                                             }
-                                        </select>
-                                        <button type="submit" class="btn btn-outline-primary" data-testid="link-person-button">Propojit</button>
+                                        </datalist>
+                                        <button type="submit" class="btn btn-outline-primary" disabled="@(selectedPersonId is null)" data-testid="link-person-button">Propojit</button>
                                     </div>
                                 </form>
                             </div>
@@ -184,6 +196,8 @@ else
     private EmailMessage? message;
     private List<SubmissionLookupItem>? submissions;
     private List<PersonLookupItem>? people;
+    private int? selectedSubmissionId;
+    private int? selectedPersonId;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -191,8 +205,21 @@ else
 
         if (message is not null && message.LinkedSubmissionId is null && message.LinkedPersonId is null)
         {
-            submissions = await InboxService.GetSubmissionLookupAsync();
+            var gameId = await InboxService.GetMostRecentGameIdAsync();
+            submissions = await InboxService.GetSubmissionLookupAsync(gameId);
             people = await InboxService.GetPersonLookupAsync();
         }
+    }
+
+    private void OnSubmissionSelected(ChangeEventArgs e)
+    {
+        var text = e.Value?.ToString();
+        selectedSubmissionId = submissions?.FirstOrDefault(s => s.Label == text)?.Id;
+    }
+
+    private void OnPersonSelected(ChangeEventArgs e)
+    {
+        var text = e.Value?.ToString();
+        selectedPersonId = people?.FirstOrDefault(p => p.Name == text)?.Id;
     }
 }

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/KingdomAssignment.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/KingdomAssignment.razor
@@ -20,9 +20,12 @@ else
             <h1 class="h4 mb-1">Rozdělení &mdash; @board.GameName</h1>
             <p class="text-secondary small mb-0">Přetáhněte hráče mezi království. Celkem: @TotalPlayerCount</p>
         </div>
-        <div class="form-check form-switch">
-            <input class="form-check-input" type="checkbox" id="detail-toggle" checked="@showDetail" @onchange="ToggleDetail" />
-            <label class="form-check-label small" for="detail-toggle">Podrobnosti</label>
+        <div class="d-flex align-items-center gap-3">
+            <a href="/organizace/hry/@GameId/kralovstvi/export.xlsx" class="btn btn-sm btn-outline-success">Stáhnout Excel</a>
+            <div class="form-check form-switch mb-0">
+                <input class="form-check-input" type="checkbox" id="detail-toggle" checked="@showDetail" @onchange="ToggleDetail" />
+                <label class="form-check-label small" for="detail-toggle">Podrobnosti</label>
+            </div>
         </div>
     </div>
 

--- a/src/RegistraceOvcina.Web/Features/Email/InboxService.cs
+++ b/src/RegistraceOvcina.Web/Features/Email/InboxService.cs
@@ -145,12 +145,19 @@ public sealed class InboxService(
         await db.SaveChangesAsync();
     }
 
-    public async Task<List<SubmissionLookupItem>> GetSubmissionLookupAsync()
+    public async Task<List<SubmissionLookupItem>> GetSubmissionLookupAsync(int? gameId = null)
     {
         await using var db = await dbContextFactory.CreateDbContextAsync();
 
-        return await db.RegistrationSubmissions
-            .Where(s => s.Status == SubmissionStatus.Submitted)
+        var query = db.RegistrationSubmissions
+            .Where(s => s.Status == SubmissionStatus.Submitted);
+
+        if (gameId.HasValue)
+        {
+            query = query.Where(s => s.GameId == gameId.Value);
+        }
+
+        return await query
             .OrderByDescending(s => s.SubmittedAtUtc)
             .Select(s => new SubmissionLookupItem(
                 s.Id,
@@ -159,18 +166,40 @@ public sealed class InboxService(
             .ToListAsync();
     }
 
-    public async Task<List<PersonLookupItem>> GetPersonLookupAsync()
+    public async Task<List<PersonLookupItem>> GetPersonLookupAsync(string? searchTerm = null)
     {
         await using var db = await dbContextFactory.CreateDbContextAsync();
 
-        return await db.People
+        var query = db.People.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(searchTerm))
+        {
+            var term = searchTerm.Trim();
+            query = query.Where(p =>
+                (p.FirstName + " " + p.LastName).Contains(term)
+                || (p.LastName + " " + p.FirstName).Contains(term)
+                || (p.Email != null && p.Email.Contains(term)));
+        }
+
+        return await query
             .OrderBy(p => p.LastName)
             .ThenBy(p => p.FirstName)
+            .Take(50)
             .Select(p => new PersonLookupItem(
                 p.Id,
-                $"{p.LastName} {p.FirstName}"))
+                $"{p.LastName} {p.FirstName}" + (p.Email != null ? $" ({p.Email})" : "")))
             .AsNoTracking()
             .ToListAsync();
+    }
+
+    public async Task<int?> GetMostRecentGameIdAsync(CancellationToken ct = default)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+        return await db.Games
+            .AsNoTracking()
+            .OrderByDescending(g => g.StartsAtUtc)
+            .Select(g => (int?)g.Id)
+            .FirstOrDefaultAsync(ct);
     }
 
     public bool CanReply => mailboxOptions.Value.IsConfigured

--- a/src/RegistraceOvcina.Web/Features/Kingdoms/KingdomExportService.cs
+++ b/src/RegistraceOvcina.Web/Features/Kingdoms/KingdomExportService.cs
@@ -1,0 +1,96 @@
+using ClosedXML.Excel;
+
+namespace RegistraceOvcina.Web.Features.Kingdoms;
+
+public sealed class KingdomExportService
+{
+    public byte[] BuildXlsx(AssignmentBoard board)
+    {
+        using var workbook = new XLWorkbook();
+        var currentYear = DateTime.UtcNow.Year;
+
+        // --- Sheet 1: Přehled (5-column overview, one cell per player) ---
+        var overviewSheet = workbook.AddWorksheet("Přehled");
+
+        var allColumns = new List<(string Title, List<PlayerCard> Players)>();
+
+        foreach (var kingdom in board.Kingdoms)
+        {
+            allColumns.Add((kingdom.DisplayName, kingdom.Players));
+        }
+
+        allColumns.Add(("Nepřidělení", board.UnassignedPlayers));
+
+        for (var col = 0; col < allColumns.Count; col++)
+        {
+            var (title, players) = allColumns[col];
+            var xlCol = col + 1;
+
+            overviewSheet.Cell(1, xlCol).Value = $"{title} ({players.Count})";
+            overviewSheet.Cell(1, xlCol).Style.Font.Bold = true;
+            overviewSheet.Cell(1, xlCol).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+
+            for (var row = 0; row < players.Count; row++)
+            {
+                var p = players[row];
+                overviewSheet.Cell(row + 2, xlCol).Value =
+                    $"{p.PersonName}, {p.Age(currentYear)} let" +
+                    (!string.IsNullOrWhiteSpace(p.GroupName) ? $", {p.GroupName}" : "");
+            }
+
+            overviewSheet.Column(xlCol).AdjustToContents(1, players.Count + 1, 15, 45);
+        }
+
+        // --- Sheets 2+: one per kingdom + Nepřidělení, values split by columns ---
+        foreach (var (title, players) in allColumns)
+        {
+            var sheetName = title.Length > 31 ? title[..31] : title;
+            var sheet = workbook.AddWorksheet(sheetName);
+
+            var headers = new[]
+            {
+                "Jméno", "Příjmení", "Věk", "Skupina", "Preference",
+                "Postava", "Poznámka hráče", "Poznámka skupiny",
+                "Org. poznámky", "Zákonný zástupce", "Předchozí království"
+            };
+
+            for (var h = 0; h < headers.Length; h++)
+            {
+                sheet.Cell(1, h + 1).Value = headers[h];
+                sheet.Cell(1, h + 1).Style.Font.Bold = true;
+            }
+
+            for (var row = 0; row < players.Count; row++)
+            {
+                var p = players[row];
+                var nameParts = p.PersonName.Split(' ', 2);
+                var firstName = nameParts[0];
+                var lastName = nameParts.Length > 1 ? nameParts[1] : "";
+                var xlRow = row + 2;
+
+                sheet.Cell(xlRow, 1).Value = firstName;
+                sheet.Cell(xlRow, 2).Value = lastName;
+                sheet.Cell(xlRow, 3).Value = p.Age(currentYear);
+                sheet.Cell(xlRow, 4).Value = p.GroupName ?? "";
+                sheet.Cell(xlRow, 5).Value = p.PreferredKingdomName ?? "";
+                sheet.Cell(xlRow, 6).Value = p.CharacterName ?? "";
+                sheet.Cell(xlRow, 7).Value = p.RegistrantNote ?? "";
+                sheet.Cell(xlRow, 8).Value = p.SubmissionNote ?? "";
+                sheet.Cell(xlRow, 9).Value = p.OrganizerNotes ?? "";
+                sheet.Cell(xlRow, 10).Value = p.GuardianName ?? "";
+                sheet.Cell(xlRow, 11).Value = p.PreviousKingdomName ?? "";
+            }
+
+            sheet.Columns().AdjustToContents(1, players.Count + 1, 8, 40);
+
+            if (players.Count > 0)
+            {
+                sheet.RangeUsed()!.SetAutoFilter();
+            }
+        }
+
+        using var stream = new MemoryStream();
+        workbook.SaveAs(stream);
+        return stream.ToArray();
+    }
+}

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -242,6 +242,7 @@ public class Program
         builder.Services.AddScoped<InboxService>();
         builder.Services.AddScoped<KingdomService>();
         builder.Services.AddScoped<KingdomAssignmentService>();
+        builder.Services.AddSingleton<KingdomExportService>();
         builder.Services.AddScoped<LodgingAssignmentService>();
         builder.Services.AddScoped<PeopleReviewService>();
         builder.Services.AddScoped<SubmissionService>();
@@ -1239,6 +1240,22 @@ public class Program
                     {
                         return Results.LocalRedirect($"/organizace/hry/{gameId}/kralovstvi?error={Uri.EscapeDataString(ex.Message)}");
                     }
+                })
+            .RequireAuthorization(AuthorizationPolicies.StaffOnly);
+        app.MapGet(
+                "/organizace/hry/{gameId:int}/kralovstvi/export.xlsx",
+                async (int gameId, KingdomAssignmentService assignmentService, KingdomExportService exportService, CancellationToken ct) =>
+                {
+                    var board = await assignmentService.GetAssignmentBoardAsync(gameId, ct);
+                    if (board is null)
+                    {
+                        return Results.NotFound();
+                    }
+
+                    var xlsx = exportService.BuildXlsx(board);
+                    return Results.File(xlsx,
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                        $"kralovstvi-{board.GameName.Replace(' ', '-')}.xlsx");
                 })
             .RequireAuthorization(AuthorizationPolicies.StaffOnly);
         app.MapPost(

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.8</Version>
+    <Version>0.9.9</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
Closes #124 (kingdom Excel export) and completes #149 ③ (mail linking UX).

### Issue #124 — XLSX export hráčů po národech
- **Sheet 1 "Přehled"**: 5+ columns (one per kingdom + Nepřidělení). Each cell = "Jméno, věk, skupina" combined. Column count in header.
- **Sheets 2+**: one per kingdom + one for unassigned. Split columns: Jméno, Příjmení, Věk, Skupina, Preference, Postava, Poznámka hráče, Poznámka skupiny, Org. poznámky, Zákonný zástupce, Předchozí království. Auto-filter on each sheet.
- Endpoint: `GET /organizace/hry/{gameId}/kralovstvi/export.xlsx` (StaffOnly)
- Button "Stáhnout Excel" on kingdom assignment page.

### Issue #149 ③ — Mail linking improvements
- Submission lookup filtered to **most recent game only** (was: all games).
- Person lookup capped at 50, includes email in label.
- Both converted from `<select>` to `<input list=datalist>` — **native browser fulltext search**.
- New service methods: `GetMostRecentGameIdAsync`, `GetSubmissionLookupAsync(gameId?)`, `GetPersonLookupAsync(searchTerm?)`.

### Inbox sent tab fix
- "Od" column shows **recipient (Komu)** for outbound messages instead of the shared mailbox address. Header adapts per tab.

## Test plan
- [x] `dotnet test` — 77/77 passing
- [x] `dotnet build` — clean
- [ ] After merge: open kingdom assignment → "Stáhnout Excel" → verify 6 sheets with correct data, sorting, and auto-filters
- [ ] Open /organizace/posta → Odesláno tab → verify "Komu" column shows recipients
- [ ] Open a message detail → verify datalist search works for submissions and people

🤖 Generated with [Claude Code](https://claude.com/claude-code)