### PR TITLE
feat: character prep — pre-collect character name, equipment, note (v0.9.10)

### DIFF
--- a/docs/plans/2026-04-20-character-prep-design.md
+++ b/docs/plans/2026-04-20-character-prep-design.md
@@ -26,12 +26,20 @@ On the morning of the LARP, 40 kids are handed a list of starting-equipment opti
 
 ## 3. Data model & migration
 
+> **Note (updated post-implementation 2026-04-21):** this section was revised to
+> match the shipped schema. `StartingEquipmentOptions.Id` and
+> `Registrations.StartingEquipmentOptionId` use **`int` identity PKs/FKs** (not
+> `Guid`), matching the existing `int` PK convention used by `Game`,
+> `Registration`, and `RegistrationSubmission`. The FK from
+> `StartingEquipmentOptions → Games` is `OnDelete(Restrict)`, not `Cascade`,
+> matching the project convention for per-game reference tables.
+
 ### 3.1 New table `StartingEquipmentOptions`
 
 | Column | Type | Notes |
 |---|---|---|
-| `Id` | `Guid` PK | |
-| `GameId` | `Guid` FK → `Games` | `OnDelete(Cascade)` |
+| `Id` | `int` PK (identity) | |
+| `GameId` | `int` FK → `Games` | `OnDelete(Restrict)` — matches project convention for per-game reference tables |
 | `Key` | `string(50)` | Stable identifier (e.g. `tesak`, `dyka-svitky`, `mince`). Unique per `GameId`. |
 | `DisplayName` | `string(100)` | Rendered verbatim to parent (`Tesák (3/1)`) |
 | `Description` | `string(500)?` | Nullable muted subtext |
@@ -43,7 +51,7 @@ Unique filtered index on `(GameId, Key)`.
 
 | Column | Type | Notes |
 |---|---|---|
-| `StartingEquipmentOptionId` | `Guid?` FK → `StartingEquipmentOptions` | `OnDelete(Restrict)` — dropping an option must be deliberate |
+| `StartingEquipmentOptionId` | `int?` FK → `StartingEquipmentOptions` | `OnDelete(Restrict)` — dropping an option must be deliberate |
 | `CharacterPrepNote` | `string(4000)?` | Distinct from `RegistrantNote` (parent's note); never overwritten by parent edits to the submission editor |
 | `CharacterPrepUpdatedAtUtc` | `DateTimeOffset?` | Stamped on every successful prep-page save |
 

--- a/docs/plans/2026-04-20-character-prep-design.md
+++ b/docs/plans/2026-04-20-character-prep-design.md
@@ -1,0 +1,232 @@
+# Character Prep — Design
+
+> Date: 2026-04-20 | Status: approved, ready for implementation plan | Target game: Ovčina 2026 (start 2026-05-01)
+
+## 1. Problem
+
+On the morning of the LARP, 40 kids are handed a list of starting-equipment options and asked to choose one each. This blocks the opening of the game for 30+ minutes. In parallel, the organizers have a quiet data quality problem: the `Character` entity is not reliably linked back to the `Person` who plays it, because character names were collected informally and not systematically during registration.
+
+**Goal:** pre-collect each Player's character name, starting-equipment choice, and an optional note before the game, so the start isn't blocked and the character ↔ person link is clean when OvčinaHra imports the data.
+
+**Non-goal:** redesigning the submission flow, re-opening the parent-facing registration editor after the deadline, or building a full character-building experience.
+
+## 2. Decisions (summary)
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Fields per Player: character name + 1-of-5 starting equipment + optional note | Minimum viable, matches the on-site bottleneck |
+| 2 | Equipment options stored in a per-game reference table | Rebalancing next year is data, not a deploy |
+| 3 | Only write `Registration` fields on save — do not touch `Character` entity | Minimum blast radius. OvčinaHra already reads from `Registration`. |
+| 4 | Two email templates: Pozvánka (full) + Připomínka (short, direct) | Natural two-beat flow; reminder doesn't need formality |
+| 5 | Options schema is string-only — no stat columns | OvčinaHra is the stat engine; registrace just stores the pick |
+| 6 | Access via opaque token on a dedicated anonymous page, one token per submission | Forwardable from parent to child; no login friction |
+| 7 | Organizer dashboard with stats widget, filter, Excel export, per-row reminder | Real operational visibility |
+| 8 | Nothing required; partial save allowed | Lowest friction; dashboard is the enforcement surface |
+| 9 | Only `AttendeeType = Player` rows appear on the prep page | NPCs/helpers get gear from organizer crate |
+
+## 3. Data model & migration
+
+### 3.1 New table `StartingEquipmentOptions`
+
+| Column | Type | Notes |
+|---|---|---|
+| `Id` | `Guid` PK | |
+| `GameId` | `Guid` FK → `Games` | `OnDelete(Cascade)` |
+| `Key` | `string(50)` | Stable identifier (e.g. `tesak`, `dyka-svitky`, `mince`). Unique per `GameId`. |
+| `DisplayName` | `string(100)` | Rendered verbatim to parent (`Tesák (3/1)`) |
+| `Description` | `string(500)?` | Nullable muted subtext |
+| `SortOrder` | `int` | |
+
+Unique filtered index on `(GameId, Key)`.
+
+### 3.2 New columns on `Registrations`
+
+| Column | Type | Notes |
+|---|---|---|
+| `StartingEquipmentOptionId` | `Guid?` FK → `StartingEquipmentOptions` | `OnDelete(Restrict)` — dropping an option must be deliberate |
+| `CharacterPrepNote` | `string(4000)?` | Distinct from `RegistrantNote` (parent's note); never overwritten by parent edits to the submission editor |
+| `CharacterPrepUpdatedAtUtc` | `DateTimeOffset?` | Stamped on every successful prep-page save |
+
+`Registration.CharacterName` already exists (max 200) and is reused as-is. Pre-filled if already populated.
+
+### 3.3 New columns on `RegistrationSubmissions`
+
+| Column | Type | Notes |
+|---|---|---|
+| `CharacterPrepToken` | `string(64)?` | Base64Url-encoded 32 random bytes (~43 chars). Null until first pozvánka. Unique filtered index: `CharacterPrepToken IS NOT NULL`. |
+| `CharacterPrepInvitedAtUtc` | `DateTimeOffset?` | Timestamp of first Pozvánka send; drives "Nezváno / Čeká" state |
+| `CharacterPrepReminderLastSentAtUtc` | `DateTimeOffset?` | Timestamp of last Připomínka send; drives 24h throttle |
+
+### 3.4 Migration
+
+One EF migration: **`AddCharacterPrepAndStartingEquipment`**. Creates `StartingEquipmentOptions`, adds three columns to `Registrations`, adds three columns to `RegistrationSubmissions`, plus indexes.
+
+Seed data for the 2026 game goes via a one-off organizer action on the `Konfigurovat výbavu` admin page, **not inside the migration**. Migration code must remain reusable for future games.
+
+## 4. Token flow
+
+### 4.1 Generation
+First time the organizer triggers a pozvánka for a submission, `CharacterPrepToken` is populated via `RandomNumberGenerator.GetBytes(32)` + `Base64UrlEncode`. Stays null until then. Lazy — no background generation.
+
+### 4.2 URL shape
+`https://registrace.ovcina.cz/postavy/{token}`.
+
+### 4.3 Lookup
+Route `/postavy/{token}` anonymous Blazor Server page. Resolver does an indexed query by `CharacterPrepToken` (single column equality). Not found ⇒ 404 page with Czech copy: *"Odkaz již neplatí nebo je neznámý, kontaktujte organizátory."*
+
+### 4.4 Lock
+When `Game.StartDateUtc <= DateTimeOffset.UtcNow`, the page is rendered read-only: inputs disabled, save button hidden, banner *"Hra již začala, změny nelze provést."* Staff accessing through the dashboard bypass the lock.
+
+### 4.5 Regeneration
+Organizer button `Vygenerovat nový odkaz` on `SubmissionDetail.razor` replaces the token. Old link immediately 404s. Use case: link leaked, parent lost it, or household changed.
+
+### 4.6 Auth model
+Anonymous. Token *is* the auth. Equivalent to the existing `LoginToken` magic-link pattern but scoped to one submission's prep data. Token grants read + write only to: that submission's Player attendees' `CharacterName`, `StartingEquipmentOptionId`, `CharacterPrepNote`. No access to payments, inbox, other households.
+
+### 4.7 Rate limiting
+Light rate-limit by IP + token prefix. Reuse existing middleware if present; otherwise low priority — attack surface is narrow (sensitivity is low; write scope is narrow).
+
+## 5. Parent-facing prep page
+
+### 5.1 Route & layout
+- Route: `/postavy/{token}`, Blazor Server, `[AllowAnonymous]`
+- Minimal top chrome (no org sidebar) — this is a semi-public landing page
+- Mobile-first — parents will open from phone
+
+### 5.2 Structure
+1. **Header** — *"Příprava postav pro {GameName}"* + 2-sentence explanation + collapsible help with option meanings.
+2. **One card per Player attendee** (ordered by Person name, NPCs/helpers hidden):
+   - Title: `{Person.FirstName} {Person.LastName}` (non-editable)
+   - `Jméno postavy` — text input, max 200, pre-filled from `Registration.CharacterName`
+   - `Startovní výbava` — radio group of the 5 options; `DisplayName` as label, `Description` as muted subtext; pre-selected from `StartingEquipmentOptionId`
+   - `Poznámka` — 4-row textarea, max 4000, pre-filled from `CharacterPrepNote`; placeholder encourages free-text *"Cokoliv, co bychom měli vědět o postavě..."*
+   - Muted timestamp *"Uloženo: {when}"* after successful save, sourced from `CharacterPrepUpdatedAtUtc`
+3. **Single `Uložit` button** at the bottom. One server-side submit, one transaction for all rows. All fields optional. Trimmed whitespace. Toast *"Uloženo, díky"* on success.
+4. **Read-only mode** when game has started — same cards, inputs disabled, save button hidden, banner up top.
+
+### 5.3 Reuse
+Form submit pattern matches `SubmissionEditor.razor`. Toast service, layout primitives, validation pattern all existing.
+
+## 6. Email flow
+
+### 6.1 Templates (both Czech, HTML via Graph outbound)
+
+**Pozvánka** — full first invitation. Greeting, explain the bottleneck warmly, visual list of the 5 options with `DisplayName` + `Description`, big button-link to the prep URL + plain fallback URL, soft deadline (`Game.StartDateUtc - 3 days`), organizer contact, names of the household's Player attendees listed as confirmation. Subject: *"Příprava postav pro {GameName} — vyber startovní výbavu"*.
+
+**Připomínka** — short, first-person, no branding fluff. 2–3 sentences: *"Ahoj, neviděli jsme tě ještě na stránce s přípravou postav. Odkaz je tady: {URL}. Díky! —Organizátoři"*. Subject: *"Připomínka: příprava postav pro {GameName}"*.
+
+Both rendered server-side from razor/scriban or the existing template pattern.
+
+### 6.2 Send surfaces
+
+**Bulk** — dashboard page has two buttons:
+- `Poslat pozvánku (X domácností)` — submissions where `CharacterPrepInvitedAtUtc IS NULL`
+- `Poslat připomínku (Y domácností)` — submissions invited but with ≥1 Player row where `StartingEquipmentOptionId IS NULL`; disabled when Y=0
+
+**Per-submission** — `SubmissionDetail.razor` grows a `Příprava postav` section with the same two buttons (scoped to this submission) + the current token (with copy-to-clipboard and a `Vygenerovat nový odkaz` link).
+
+### 6.3 Throttle
+Reminder send guard: if `CharacterPrepReminderLastSentAtUtc >= DateTimeOffset.UtcNow - 24h`, reject with UI error. Enforced server-side.
+
+### 6.4 Outbox logging
+Every send goes through the existing `EmailMessage` table with `LinkedSubmissionId` set, so organizers see history in the existing inbox/sent UI.
+
+### 6.5 Post-game-start behavior
+Both buttons disabled when `Game.StartDateUtc <= now`.
+
+## 7. Organizer dashboard
+
+### 7.1 Route & access
+`/organizace/hry/{gameId}/priprava-postav` — staff-only (`[Authorize]` with existing staff policy).
+
+### 7.2 Layout
+1. **Stats strip** — 4 tiles (`Domácností celkem`, `Pozvaných`, `Plně vyplněných`, `Čeká na vyplnění`) matching GameStatsPage style.
+2. **Action bar** — `Poslat pozvánku`, `Poslat připomínku`, `Stáhnout Excel`, `Konfigurovat výbavu`.
+3. **Filter row** — status dropdown (`Všichni / Nezvaní / Čekající / Hotovo`) + full-text search over person and character name.
+4. **Table** — one row per Player attendee:
+
+   | Sloupec | Zdroj |
+   |---|---|
+   | Domácnost | `RegistrationSubmission.PrimaryContactName` → link to SubmissionDetail |
+   | Hráč | `Person.FirstName + ' ' + LastName` |
+   | Jméno postavy | `Registration.CharacterName` or `—` |
+   | Výbava | `StartingEquipmentOption.DisplayName` or `—` (red indicator on empty) |
+   | Poznámka | `CharacterPrepNote` truncated to 80 chars + tooltip |
+   | Stav | Badge: `Nezváno` / `Čeká` / `Hotovo` |
+   | Naposledy upraveno | Relative `CharacterPrepUpdatedAtUtc` |
+   | Akce | `Otevřít odkaz`, `Poslat připomínku` |
+
+5. **Sortable columns** matching the Payments page pattern.
+6. **Optional row-expand** showing full note + send timeline (`Pozvaná {date}, připomenuta {date}`).
+
+### 7.3 Staff override
+`Otevřít odkaz` opens `/postavy/{token}` in a new tab. The page detects staff auth and bypasses the `Game.StartDateUtc` read-only lock.
+
+### 7.4 Stats widget on `GameStatsPage`
+Single tile: *"Příprava postav: {filled}/{total} vyplněno"* → linking to the dashboard.
+
+### 7.5 Performance
+One `IQueryable<RegistrationRowView>` projection joining `Registration → Person → RegistrationSubmission → StartingEquipmentOption`. Paginated 20/page. Fast even at 40–100 rows; designed to handle more.
+
+### 7.6 Configuration sub-page
+`Konfigurovat výbavu` (`/organizace/hry/{gameId}/priprava-postav/vybava`) — simple CRUD table over `StartingEquipmentOptions` for the current game: add, edit (DisplayName, Description, SortOrder), soft-delete (or hard-delete with confirmation if no `Registration` references). Seed button copies options from another game as a starting point.
+
+## 8. Excel export
+
+Endpoint: `GET /organizace/hry/{gameId}/priprava-postav/export.xlsx`. Mirrors the Kingdom XLSX pattern (`KingdomExportService.cs`). Service: `CharacterPrepExportService` at `Features/CharacterPrep/CharacterPrepExportService.cs`.
+
+One sheet `Příprava postav`:
+
+| Sloupec |
+|---|
+| Hráč |
+| Rok narození |
+| Jméno postavy |
+| Startovní výbava |
+| Poznámka |
+| Domácnost |
+| Email domácnosti |
+
+One row per Player attendee (`AttendeeType = Player`), ordered by Person name. Includes everyone regardless of fill status. Empty cells stay empty.
+
+Formatting: bold header, frozen row 1, autofilter, auto-width capped at 40 chars. Filename: `priprava-postav-{GameName-slug}-{yyyyMMdd}.xlsx`.
+
+## 9. Testing strategy
+
+### Unit
+- `CharacterPrepServiceTests.cs` — EnsureTokenAsync idempotence, RotateTokenAsync invalidates, SaveAsync writes + timestamps, non-Player rows ignored, null-clearing allowed, game-start lock flag, bulk-invite filter, reminder filter, 24h throttle, Players-only filter
+- `CharacterPrepExportServiceTests.cs` — bytes non-zero, valid XLSX, header row, row count, empty cells
+
+### Integration (`WebApplicationFactory`)
+- `GET /postavy/{valid}` 200 with Player names
+- `GET /postavy/{unknown}` 404
+- `GET /postavy/{rotatedOld}` 404
+- Anonymous access allowed; no info leak from 404
+- Excel endpoint requires staff
+
+### E2E (Playwright)
+- `CharacterPrepSmokeTests.cs`: organizer pozvánka → parent opens link → fills one row → saves → reloads → values pre-filled
+
+### Snapshot (optional)
+- Verify snapshot of rendered Pozvánka HTML for a fixed seed. Skip if Verify isn't already in csproj.
+
+### Manual QA checklist (in PR description)
+- Pozvánka bulk send creates 40 outbox rows with correct links
+- Real email link resolves, save persists, reload pre-fills
+- Staff prep link bypasses read-only lock after game start
+- Excel encodes Czech chars correctly, column widths reasonable
+- Regenerated token 404s old link
+
+## 10. Out of scope (v1)
+
+- SMS reminders (no infra; email only)
+- Automatic scheduled sends (no cron for v1; organizers click)
+- Auto-creating `Character` / `CharacterAppearance` entities (separate organizer workflow)
+- Per-player tokens (one token per submission is forwardable and sufficient)
+- Stat modeling in the options table (OvčinaHra is the stat engine)
+- Configurable deadlines beyond `Game.StartDateUtc`
+
+## 11. Open questions
+
+- **Seed data for 2026 game** — who seeds the 5 rows for the May 1 game, and when? Recommendation: do it in the first PR via an organizer console action, not via migration. Document the 5 rows (DisplayName + Description) before merge.
+- **OvčinaHra import** — how does OvčinaHra discover which loadout each player picked? Recommendation: extend the existing `/api/v1/games/{id}/adults`-style character seed endpoint with `StartingEquipmentKey` per registration. Small follow-up PR, not part of this design's scope.

--- a/docs/plans/2026-04-20-character-prep-implementation.md
+++ b/docs/plans/2026-04-20-character-prep-implementation.md
@@ -1,0 +1,687 @@
+# Character Prep Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let parents pre-select each Player's character name + starting equipment + optional note via a tokenized link, so the LARP starts on time and OvčinaHra import has clean character↔person links.
+
+**Architecture:** Per-game reference table for the 5 equipment options (admin-configurable). Three new columns on `Registration` carry the prep data; three on `RegistrationSubmission` carry the opaque token + send-history timestamps. An anonymous Blazor Server page resolves `/postavy/{token}` to the household's prep view. Staff bulk-send invitations + reminders via the existing Graph outbound pipeline. Organizer dashboard gives per-row visibility and Excel export.
+
+**Tech Stack:** .NET 10, Blazor Server, EF Core (PostgreSQL), ClosedXML (already in csproj for Kingdom export), xUnit, Microsoft Graph for outbound email, Playwright for E2E.
+
+**Design doc:** `docs/plans/2026-04-20-character-prep-design.md`
+
+**Repo root:** `C:\Users\TomášPajonk\source\repos\timurlain\registrace-ovcina-cz`
+**Web project cwd for EF commands:** `src/RegistraceOvcina.Web`
+**Test project:** `tests/RegistraceOvcina.Tests` (if path differs, adjust — do not move files)
+
+**House rules (carry into every task):**
+- No commit without explicit user approval. TDD means: write test → fail → implement → pass → stage. STOP before `git commit`.
+- Every property addition or rename to a model class ⇒ EF migration generated in the same task.
+- Czech UI strings, Czech date formatting.
+- Soft-deleted Persons/Submissions already filtered by global query filter — do not bypass.
+- Version bump `0.9.9 → 0.9.10` lives in Task 24 (final task before PR).
+
+**Parallel-friendly clusters** — after Phase 1 (schema) lands, Phases 3-7 can be dispatched to subagents in parallel (each owns a vertical slice). Phase 2 (core services) gates all downstream work. Phase 8 (E2E) comes last.
+
+---
+
+## Phase 1 — Schema & migration (sequential, blocks everything)
+
+### Task 1: Create `StartingEquipmentOption` entity
+
+**Files:**
+- Create: `src/RegistraceOvcina.Web/Data/StartingEquipmentOption.cs` (match the folder where existing entities like `Game`, `Registration` live — if they live in a subfolder, place alongside them)
+- Modify: `src/RegistraceOvcina.Web/Data/ApplicationDbContext.cs`
+- Test: `tests/RegistraceOvcina.Tests/Data/StartingEquipmentOptionConfigurationTests.cs`
+
+**Step 1: Failing test** — assert that `DbContext.StartingEquipmentOptions` is registered, has the six expected columns, a unique `(GameId, Key)` index, and `OnDelete(Cascade)` from Game.
+
+```csharp
+public class StartingEquipmentOptionConfigurationTests : DbContextTestBase
+{
+    [Fact]
+    public void DbSet_is_registered_and_entity_has_expected_shape()
+    {
+        var entity = Context.Model.FindEntityType(typeof(StartingEquipmentOption));
+        Assert.NotNull(entity);
+        Assert.NotNull(entity!.FindProperty(nameof(StartingEquipmentOption.Key)));
+        Assert.Equal(50, entity.FindProperty(nameof(StartingEquipmentOption.Key))!.GetMaxLength());
+        Assert.Equal(100, entity.FindProperty(nameof(StartingEquipmentOption.DisplayName))!.GetMaxLength());
+        Assert.Equal(500, entity.FindProperty(nameof(StartingEquipmentOption.Description))!.GetMaxLength());
+        var uniqueIdx = entity.GetIndexes().Single(i => i.IsUnique);
+        Assert.Equal(new[] { nameof(StartingEquipmentOption.GameId), nameof(StartingEquipmentOption.Key) },
+            uniqueIdx.Properties.Select(p => p.Name).ToArray());
+    }
+}
+```
+
+**Step 2:** Run `dotnet test --filter StartingEquipmentOptionConfigurationTests` → expect compile error (type doesn't exist).
+
+**Step 3:** Create the entity:
+
+```csharp
+namespace RegistraceOvcina.Web.Data;
+
+public sealed class StartingEquipmentOption
+{
+    public Guid Id { get; set; }
+    public Guid GameId { get; set; }
+    public Game Game { get; set; } = default!;
+    public string Key { get; set; } = default!;
+    public string DisplayName { get; set; } = default!;
+    public string? Description { get; set; }
+    public int SortOrder { get; set; }
+}
+```
+
+Add to `ApplicationDbContext`:
+
+```csharp
+public DbSet<StartingEquipmentOption> StartingEquipmentOptions => Set<StartingEquipmentOption>();
+```
+
+In `OnModelCreating`:
+
+```csharp
+builder.Entity<StartingEquipmentOption>(entity =>
+{
+    entity.HasKey(x => x.Id);
+    entity.Property(x => x.Key).HasMaxLength(50).IsRequired();
+    entity.Property(x => x.DisplayName).HasMaxLength(100).IsRequired();
+    entity.Property(x => x.Description).HasMaxLength(500);
+    entity.HasIndex(x => new { x.GameId, x.Key }).IsUnique();
+    entity.HasOne(x => x.Game)
+        .WithMany()
+        .HasForeignKey(x => x.GameId)
+        .OnDelete(DeleteBehavior.Cascade);
+});
+```
+
+**Step 4:** Run tests → PASS.
+
+**Step 5:** Stage changes. Do not commit — this task lands together with Tasks 2-4.
+
+---
+
+### Task 2: Add three columns to `Registration`
+
+**Files:**
+- Modify: model class `Registration` (search: `class Registration` under `src/RegistraceOvcina.Web/Data`)
+- Modify: `src/RegistraceOvcina.Web/Data/ApplicationDbContext.cs` (the `builder.Entity<Registration>` block)
+- Test: `tests/RegistraceOvcina.Tests/Data/RegistrationCharacterPrepColumnsTests.cs`
+
+**Step 1:** Failing test:
+
+```csharp
+[Fact]
+public void Registration_has_character_prep_columns()
+{
+    var entity = Context.Model.FindEntityType(typeof(Registration));
+    Assert.NotNull(entity!.FindProperty("StartingEquipmentOptionId"));
+    Assert.True(entity.FindProperty("StartingEquipmentOptionId")!.IsNullable);
+    Assert.Equal(4000, entity.FindProperty("CharacterPrepNote")!.GetMaxLength());
+    Assert.NotNull(entity.FindProperty("CharacterPrepUpdatedAtUtc"));
+}
+```
+
+**Step 2:** Run → FAIL (properties don't exist).
+
+**Step 3:** Add to `Registration`:
+
+```csharp
+public Guid? StartingEquipmentOptionId { get; set; }
+public StartingEquipmentOption? StartingEquipmentOption { get; set; }
+public string? CharacterPrepNote { get; set; }
+public DateTimeOffset? CharacterPrepUpdatedAtUtc { get; set; }
+```
+
+In `ApplicationDbContext.OnModelCreating` inside the `Registration` block, after the existing property configs:
+
+```csharp
+entity.Property(x => x.CharacterPrepNote).HasMaxLength(4000);
+entity.HasOne(x => x.StartingEquipmentOption)
+    .WithMany()
+    .HasForeignKey(x => x.StartingEquipmentOptionId)
+    .OnDelete(DeleteBehavior.Restrict);
+```
+
+**Step 4:** Run tests → PASS.
+
+**Step 5:** Stage; no commit yet.
+
+---
+
+### Task 3: Add three columns to `RegistrationSubmission`
+
+**Files:**
+- Modify: `RegistrationSubmission` model class
+- Modify: `ApplicationDbContext.cs` (`builder.Entity<RegistrationSubmission>` block)
+- Test: `tests/RegistraceOvcina.Tests/Data/RegistrationSubmissionTokenColumnsTests.cs`
+
+**Step 1:** Failing test asserts the three new columns exist, the unique filtered index on `CharacterPrepToken` is configured.
+
+```csharp
+[Fact]
+public void Submission_has_prep_token_columns_and_unique_filtered_index()
+{
+    var entity = Context.Model.FindEntityType(typeof(RegistrationSubmission))!;
+    Assert.Equal(64, entity.FindProperty("CharacterPrepToken")!.GetMaxLength());
+    Assert.NotNull(entity.FindProperty("CharacterPrepInvitedAtUtc"));
+    Assert.NotNull(entity.FindProperty("CharacterPrepReminderLastSentAtUtc"));
+    var uniqueOnToken = entity.GetIndexes().Single(i =>
+        i.Properties.Count == 1 && i.Properties[0].Name == "CharacterPrepToken");
+    Assert.True(uniqueOnToken.IsUnique);
+    Assert.NotNull(uniqueOnToken.GetFilter()); // partial index filter
+}
+```
+
+**Step 2:** Run → FAIL.
+
+**Step 3:** Add to `RegistrationSubmission`:
+
+```csharp
+public string? CharacterPrepToken { get; set; }
+public DateTimeOffset? CharacterPrepInvitedAtUtc { get; set; }
+public DateTimeOffset? CharacterPrepReminderLastSentAtUtc { get; set; }
+```
+
+In the DbContext entity block:
+
+```csharp
+entity.Property(x => x.CharacterPrepToken).HasMaxLength(64);
+entity.HasIndex(x => x.CharacterPrepToken)
+    .IsUnique()
+    .HasFilter("\"CharacterPrepToken\" IS NOT NULL");
+```
+
+**Step 4:** Run tests → PASS.
+
+**Step 5:** Stage.
+
+---
+
+### Task 4: Generate and apply the migration
+
+**Files:**
+- Create: `src/RegistraceOvcina.Web/Migrations/<timestamp>_AddCharacterPrepAndStartingEquipment.cs`
+- Create: snapshot updates
+
+**Step 1:** Generate:
+
+```bash
+cd src/RegistraceOvcina.Web && dotnet ef migrations add AddCharacterPrepAndStartingEquipment
+```
+
+**Step 2:** Verify the generated `.cs` file contains:
+- `CreateTable("StartingEquipmentOptions", ...)` with the 6 columns + unique index on `(GameId, Key)` + FK to `Games` with cascade delete
+- `AddColumn` × 3 on `Registrations` (`StartingEquipmentOptionId`, `CharacterPrepNote`, `CharacterPrepUpdatedAtUtc`) + FK + index on `StartingEquipmentOptionId`
+- `AddColumn` × 3 on `RegistrationSubmissions` (`CharacterPrepToken`, `CharacterPrepInvitedAtUtc`, `CharacterPrepReminderLastSentAtUtc`) + unique filtered index on `CharacterPrepToken`
+
+**Step 3:** Confirm no stray changes:
+
+```bash
+cd src/RegistraceOvcina.Web && dotnet ef migrations has-pending-model-changes
+```
+
+Expected output: `No pending model changes are present.`
+
+**Step 4:** Apply against local Postgres:
+
+```bash
+cd src/RegistraceOvcina.Web && dotnet ef database update
+```
+
+**Step 5:** Run `dotnet test` at repo root. All 77 existing tests + the 3 new config tests = 80 PASS. Stage migration files.
+
+**Phase 1 commit point:** ask user for permission to commit "feat: schema for character prep feature" with migration + entity changes.
+
+---
+
+## Phase 2 — Core services (sequential)
+
+### Task 5: `CharacterPrepTokenService`
+
+**Files:**
+- Create: `src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepTokenService.cs`
+- Test: `tests/RegistraceOvcina.Tests/Features/CharacterPrep/CharacterPrepTokenServiceTests.cs`
+
+**Behavior:**
+- `Task<string> EnsureTokenAsync(Guid submissionId, CancellationToken ct)` — if submission has no token, generate one + save; return current token.
+- `Task<string> RotateTokenAsync(Guid submissionId, CancellationToken ct)` — always generate a fresh one, overwrite, save.
+- `Task<RegistrationSubmission?> FindBySubmissionTokenAsync(string token, CancellationToken ct)` — single-column indexed lookup.
+
+**Tests (red → green per test):**
+1. `EnsureTokenAsync_generates_token_on_first_call` — returns non-empty, 43-ish chars, Base64Url charset (`^[A-Za-z0-9_-]+$`)
+2. `EnsureTokenAsync_is_idempotent` — second call returns the same value
+3. `RotateTokenAsync_replaces_existing_token` — returns different value, old token no longer resolves
+4. `FindBySubmissionTokenAsync_returns_null_for_unknown`
+5. `FindBySubmissionTokenAsync_returns_null_for_soft_deleted_submission` — respects the global query filter
+
+**Implementation skeleton:**
+
+```csharp
+public sealed class CharacterPrepTokenService(ApplicationDbContext db)
+{
+    public async Task<string> EnsureTokenAsync(Guid submissionId, CancellationToken ct)
+    {
+        var submission = await db.RegistrationSubmissions.FirstAsync(x => x.Id == submissionId, ct);
+        if (!string.IsNullOrEmpty(submission.CharacterPrepToken))
+            return submission.CharacterPrepToken;
+        submission.CharacterPrepToken = GenerateToken();
+        await db.SaveChangesAsync(ct);
+        return submission.CharacterPrepToken;
+    }
+
+    public async Task<string> RotateTokenAsync(Guid submissionId, CancellationToken ct) { /* ... */ }
+    public Task<RegistrationSubmission?> FindBySubmissionTokenAsync(string token, CancellationToken ct) =>
+        db.RegistrationSubmissions.FirstOrDefaultAsync(x => x.CharacterPrepToken == token, ct);
+
+    private static string GenerateToken() =>
+        Base64UrlTextEncoder.Encode(RandomNumberGenerator.GetBytes(32));
+}
+```
+
+**DI:** register as scoped in `Program.cs` alongside existing feature services.
+
+---
+
+### Task 6: `CharacterPrepService.GetPrepViewAsync`
+
+**Files:**
+- Create: `src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepService.cs`
+- Create: `src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepViewModels.cs` (records: `CharacterPrepView`, `CharacterPrepRow`)
+- Test: `tests/RegistraceOvcina.Tests/Features/CharacterPrep/CharacterPrepServiceGetViewTests.cs`
+
+**Behavior:**
+
+```csharp
+public sealed record CharacterPrepView(
+    Guid SubmissionId,
+    Guid GameId,
+    string GameName,
+    bool IsReadOnly,              // Game.StartDateUtc <= now
+    IReadOnlyList<CharacterPrepRow> Rows,
+    IReadOnlyList<StartingEquipmentOptionView> Options);
+
+public sealed record CharacterPrepRow(
+    Guid RegistrationId,
+    string PersonFullName,
+    string? CharacterName,
+    Guid? StartingEquipmentOptionId,
+    string? CharacterPrepNote,
+    DateTimeOffset? UpdatedAtUtc);
+
+public sealed record StartingEquipmentOptionView(
+    Guid Id, string DisplayName, string? Description, int SortOrder);
+```
+
+`GetPrepViewAsync(RegistrationSubmission, nowUtc)` filters `AttendeeType == Player`, orders rows by Person lastname+firstname, orders options by `SortOrder`, computes `IsReadOnly` from `Game.StartDateUtc`.
+
+**Tests:**
+1. `Returns_only_player_attendees_in_order`
+2. `IsReadOnly_true_when_game_started`
+3. `Options_ordered_by_SortOrder`
+4. `Rows_preserve_existing_values` — round-trip a pre-populated Registration
+
+---
+
+### Task 7: `CharacterPrepService.SaveAsync`
+
+Same file, same test file.
+
+**Behavior:** `Task SaveAsync(Guid submissionId, IEnumerable<CharacterPrepSaveRow> rows, DateTimeOffset nowUtc, CancellationToken ct)`.
+
+```csharp
+public sealed record CharacterPrepSaveRow(
+    Guid RegistrationId,
+    string? CharacterName,
+    Guid? StartingEquipmentOptionId,
+    string? CharacterPrepNote);
+```
+
+Behavior:
+- Load registrations for the submission in one query, filter by Player
+- For each incoming row, find matching Registration by Id AND SubmissionId (defense: reject mismatched)
+- Trim `CharacterName` and `CharacterPrepNote` (convert empty to null)
+- Validate `StartingEquipmentOptionId` belongs to the same GameId (reject with `ArgumentException` otherwise)
+- Stamp `CharacterPrepUpdatedAtUtc = nowUtc` only when at least one field changed
+- `SaveChangesAsync` in a single batch
+
+**Tests:**
+1. `Saves_character_name_equipment_note`
+2. `Stamps_UpdatedAtUtc_only_when_something_changed`
+3. `Trims_and_nulls_empty_strings`
+4. `Ignores_rows_for_foreign_submissions`
+5. `Ignores_rows_for_non_Player_attendees`
+6. `Rejects_equipment_option_from_different_game`
+7. `Clearing_all_fields_is_allowed`
+
+---
+
+### Task 8: Bulk-invite filters + reminder throttle (service methods)
+
+**Files:** same `CharacterPrepService.cs`
+**Test:** `tests/RegistraceOvcina.Tests/Features/CharacterPrep/CharacterPrepServiceBulkFiltersTests.cs`
+
+**Methods:**
+- `Task<IReadOnlyList<RegistrationSubmission>> ListInvitationTargetsAsync(Guid gameId, CancellationToken ct)` — submissions with ≥1 Player attendee AND `CharacterPrepInvitedAtUtc IS NULL`
+- `Task<IReadOnlyList<RegistrationSubmission>> ListReminderTargetsAsync(Guid gameId, DateTimeOffset nowUtc, CancellationToken ct)` — invited AND ≥1 Player row with `StartingEquipmentOptionId IS NULL` AND (`CharacterPrepReminderLastSentAtUtc IS NULL` OR `CharacterPrepReminderLastSentAtUtc < nowUtc - 24h`)
+- `Task MarkInvitedAsync(Guid submissionId, DateTimeOffset nowUtc, CancellationToken ct)`
+- `Task MarkReminderSentAsync(Guid submissionId, DateTimeOffset nowUtc, CancellationToken ct)`
+
+**Tests cover each filter edge including the 24h throttle boundary.**
+
+---
+
+## Phase 3 — Email (depends on Phase 2)
+
+### Task 9: Email template renderer — Pozvánka + Připomínka
+
+**Files:**
+- Create: `src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepEmailRenderer.cs`
+- Create: Razor components or inline string builders matching the project's existing email template style (check `MailboxSyncService.cs` for reference)
+- Test: `tests/RegistraceOvcina.Tests/Features/CharacterPrep/CharacterPrepEmailRendererTests.cs`
+
+**Render contract:**
+
+```csharp
+public sealed record RenderedEmail(string Subject, string HtmlBody, string PlainTextBody);
+
+public interface ICharacterPrepEmailRenderer
+{
+    RenderedEmail RenderPozvanka(CharacterPrepEmailModel model);
+    RenderedEmail RenderPripominka(CharacterPrepEmailModel model);
+}
+
+public sealed record CharacterPrepEmailModel(
+    string GameName,
+    DateTimeOffset GameStartDateUtc,
+    string PrepUrl,
+    IReadOnlyList<string> PlayerFullNames,
+    IReadOnlyList<StartingEquipmentOptionView> Options,
+    string OrganizerContactEmail);
+```
+
+**Tests:** snapshot each template (Verify or hand-rolled golden file). Assert `PrepUrl` appears, subject is correct, player names render, deadline (`GameStart - 3 days`) appears in Pozvánka only.
+
+---
+
+### Task 10: `CharacterPrepMailService` — single-submission sends
+
+**Files:**
+- Create: `src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepMailService.cs`
+- Test: `tests/RegistraceOvcina.Tests/Features/CharacterPrep/CharacterPrepMailServiceTests.cs`
+
+**Methods:**
+- `Task SendPozvankaAsync(Guid submissionId, DateTimeOffset nowUtc, CancellationToken ct)` — ensures token, renders, sends via existing Graph outbound (`MailboxSyncService` or whatever the single-email send path is), writes `EmailMessage` with `LinkedSubmissionId`, marks invited.
+- `Task SendPripominkaAsync(Guid submissionId, DateTimeOffset nowUtc, CancellationToken ct)` — requires token already exists, throws if still null. Enforces 24h throttle via service check; send → `EmailMessage` + `MarkReminderSentAsync`.
+- `Task SendBulkPozvankaAsync(Guid gameId, DateTimeOffset nowUtc, CancellationToken ct)` — loops `ListInvitationTargetsAsync`, sends each, collects errors, returns `BulkSendResult { Sent, Failed, FirstError }`.
+- `Task SendBulkPripominkaAsync(Guid gameId, DateTimeOffset nowUtc, CancellationToken ct)` — same shape.
+
+**Tests:**
+1. Pozvánka sends and marks invited
+2. Second Pozvánka on same submission is rejected (or: allowed idempotently; pick one — recommendation: allowed, "re-send pozvánka" is a valid organizer action, but behavior must be deterministic — pick NO-OP with a warning in the return result)
+3. Připomínka within 24h throws
+4. Připomínka after 24h succeeds
+5. Bulk pozvánka iterates all targets and emits one EmailMessage row per send
+6. Bulk pripominka skips submissions that are fully filled
+7. Send failure for one submission does not abort the whole batch — collected into `Failed` count
+
+**DI:** scoped. Register in `Program.cs`.
+
+---
+
+## Phase 4 — Parent-facing prep page (depends on Phase 2)
+
+### Task 11: Route `/postavy/{token}` — anonymous, 404 path
+
+**Files:**
+- Create: `src/RegistraceOvcina.Web/Components/Pages/CharacterPrep/CharacterPrep.razor`
+- Create: `src/RegistraceOvcina.Web/Components/Pages/CharacterPrep/CharacterPrepNotFound.razor`
+- Test: `tests/RegistraceOvcina.Tests/Integration/CharacterPrepPageTests.cs` (WebApplicationFactory)
+
+**Behavior:**
+- `@page "/postavy/{Token}"`
+- `@attribute [AllowAnonymous]`
+- `@rendermode InteractiveServer` (match existing Blazor patterns — check project conventions)
+- `OnInitializedAsync` calls `CharacterPrepTokenService.FindBySubmissionTokenAsync`. If null, navigate to `CharacterPrepNotFound` or render the not-found component inline. Copy: *"Odkaz již neplatí nebo je neznámý, kontaktujte organizátory."*
+- Minimal chrome layout — no organizer sidebar
+
+**Tests:**
+1. `GET /postavy/unknown → 404 page HTML`
+2. `GET /postavy/{valid} → 200 and contains game name`
+3. Anonymous access works (no cookie required)
+
+---
+
+### Task 12: Prep page card UI + pre-fill
+
+**Same file**: `CharacterPrep.razor`.
+
+**UI:**
+- Header + explanatory paragraph
+- One card per `CharacterPrepRow`:
+  - Title: Person full name
+  - Input `Jméno postavy` (`<InputText>` bound to `row.CharacterName`)
+  - Radio group `Startovní výbava` bound to `row.StartingEquipmentOptionId`, one radio per option, label = `DisplayName`, subtext = `Description`
+  - Textarea `Poznámka` bound to `row.CharacterPrepNote`
+  - Footer muted text: *"Uloženo: {UpdatedAtUtc:d. M. yyyy HH:mm}"* if non-null
+- Pre-fill from the view model already loaded
+
+**Test (bUnit component test):** `tests/RegistraceOvcina.Tests/Components/CharacterPrepPageRenderTests.cs` — renders cards for 3 Player attendees, radio groups have 5 options, pre-fill values appear in inputs.
+
+---
+
+### Task 13: Prep page save handler
+
+**Same file.**
+
+**Behavior:**
+- `Uložit` submits `List<CharacterPrepSaveRow>` derived from bound state
+- Call `CharacterPrepService.SaveAsync(submissionId, rows, DateTimeOffset.UtcNow, ct)`
+- On success: toast *"Uloženo, díky"*, refresh timestamps from a reload of the view
+- On failure: toast error, log via ILogger
+
+**Test (integration):** `tests/RegistraceOvcina.Tests/Integration/CharacterPrepSaveFlowTests.cs` — POST save flow writes DB columns, second GET returns pre-filled values.
+
+---
+
+### Task 14: Read-only mode after game start
+
+**Same file.**
+
+**Behavior:**
+- When `view.IsReadOnly`, all `<InputText>`/radio/textarea are `disabled`, save button hidden, banner *"Hra již začala, změny nelze provést."*
+- Staff override: detect `User.Identity?.IsAuthenticated && User.IsInRole("Staff")` (check project's actual staff-check convention). If staff, bypass.
+
+**Test:** `Game_started_renders_readonly_unless_staff` — two scenarios, parametrized test.
+
+---
+
+## Phase 5 — Organizer dashboard (depends on Phase 2)
+
+### Task 15: Dashboard route + stats strip
+
+**Files:**
+- Create: `src/RegistraceOvcina.Web/Components/Pages/Organizer/CharacterPrepDashboard.razor`
+- Service method: `CharacterPrepService.GetDashboardStatsAsync(Guid gameId)` returning record `{ TotalHouseholds, Invited, FullyFilled, Pending }`
+- Test: `tests/RegistraceOvcina.Tests/Features/CharacterPrep/CharacterPrepDashboardStatsTests.cs`
+
+**UI:** route `/organizace/hry/{gameId}/priprava-postav`, `[Authorize]` staff policy, 4 stat tiles matching `GameStatsPage` style.
+
+---
+
+### Task 16: Dashboard table + filter + sort
+
+**Same file.**
+
+**Service:** `Task<PagedResult<CharacterPrepDashboardRow>> GetDashboardRowsAsync(Guid gameId, DashboardFilter filter, int page, int pageSize)` with status filter (`All | NotInvited | Waiting | Done`) and search string.
+
+**Row projection:** Household name, Person name, Character name, Option DisplayName, Note (truncated), Status badge, UpdatedAt relative, Action buttons column.
+
+**Test:** `CharacterPrepDashboardRowsTests` — full-text search hits person + character name; status filter matches expected rows.
+
+---
+
+### Task 17: Dashboard action bar (bulk buttons, per-row reminder)
+
+**Same file.**
+
+**Buttons:**
+- `Poslat pozvánku (N)` — disabled if N=0 or game started — invokes `SendBulkPozvankaAsync`
+- `Poslat připomínku (M)` — disabled if M=0 or game started — invokes `SendBulkPripominkaAsync`
+- Per-row `Poslat připomínku` on each `Waiting`/`NotInvited` row
+- `Stáhnout Excel` wired to endpoint from Task 22
+
+On success: toast with counts (*"Posláno: 32 pozvánek, 0 chyb"*).
+
+**Test:** `CharacterPrepDashboardActionsTests` — bulk button click sends, Email outbox rows are written. Integration test via WAF.
+
+---
+
+### Task 18: Stats widget on `GameStatsPage`
+
+**Files:**
+- Modify: `src/RegistraceOvcina.Web/Components/Pages/Organizer/GameStatsPage.razor`
+- Modify: `Features/Stats/GameStatsService.cs` to also return `CharacterPrepFilled` and `CharacterPrepTotal`
+- Test: update existing `GameStatsServiceTests` (or add new `GameStatsCharacterPrepTests.cs`)
+
+**UI:** one tile *"Příprava postav: {filled}/{total} vyplněno"* linking to the dashboard.
+
+---
+
+## Phase 6 — Admin config page (depends on Phase 1 only)
+
+### Task 19: `StartingEquipmentOption` CRUD page
+
+**Files:**
+- Create: `src/RegistraceOvcina.Web/Components/Pages/Organizer/StartingEquipmentOptions.razor`
+- Service: `CharacterPrepOptionsService` (new file `Features/CharacterPrep/CharacterPrepOptionsService.cs`) with `List / Create / Update / Delete / CopyFromGame`
+- Test: `tests/RegistraceOvcina.Tests/Features/CharacterPrep/CharacterPrepOptionsServiceTests.cs`
+
+**UI:** route `/organizace/hry/{gameId}/priprava-postav/vybava`, staff-only. Table of current options with inline edit, "Přidat" button, delete guard (fail with message if any Registration references the option).
+
+**Tests:** create, update, soft-fail delete when referenced, copy 5 rows from another game.
+
+---
+
+## Phase 7 — Excel export (depends on Phase 1 + the dashboard service)
+
+### Task 20: `CharacterPrepExportService`
+
+**Files:**
+- Create: `src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepExportService.cs`
+- Create endpoint: add to existing `IntegrationApiEndpoints.cs` OR create `Features/CharacterPrep/CharacterPrepEndpoints.cs` (follow Kingdom export's pattern, which lives at — grep for its MapGet to confirm)
+- Test: `tests/RegistraceOvcina.Tests/Features/CharacterPrep/CharacterPrepExportServiceTests.cs`
+
+**Behavior:** builds XLSX using ClosedXML (same library as `KingdomExportService`). One sheet "Příprava postav" with columns: Hráč, Rok narození, Jméno postavy, Startovní výbava, Poznámka, Domácnost, Email domácnosti. Header bold, frozen row 1, autofilter, auto-width capped at 40. Filename `priprava-postav-{slug}-{yyyyMMdd}.xlsx`.
+
+**Tests:**
+1. Non-empty byte array
+2. Valid XLSX (roundtrip open)
+3. Correct header row
+4. Row count == Player attendees count
+5. Empty cells stay empty
+6. Czech characters encode correctly (compare a `Šárka` cell byte-for-byte after load)
+
+**Endpoint:** `GET /organizace/hry/{gameId}/priprava-postav/export.xlsx`, staff auth, returns `FileContentResult`.
+
+---
+
+## Phase 8 — Submission detail integration (depends on Phase 2-3)
+
+### Task 21: "Příprava postav" section on `SubmissionDetail.razor`
+
+**Files:**
+- Modify: `src/RegistraceOvcina.Web/Components/Pages/Organizer/SubmissionDetail.razor`
+
+**UI:** new card between existing sections:
+- Current state badge (Nezváno / Čeká / Hotovo)
+- Token URL with copy-to-clipboard button (hidden if token null — button "Vygenerovat odkaz" generates via `EnsureTokenAsync`)
+- Timeline: *Pozvaná: {date} • Připomenuta: {date}* (hide empty ones)
+- Buttons `Poslat pozvánku`, `Poslat připomínku`, `Vygenerovat nový odkaz` (the last one prompts a JS `confirm` since it invalidates the old link)
+
+**Test:** extend `SubmissionDetailTests` or create `SubmissionDetailCharacterPrepSectionTests.cs`. Hit the three buttons, verify DB side effects.
+
+---
+
+## Phase 9 — E2E + final polish
+
+### Task 22: E2E smoke test (Playwright)
+
+**Files:**
+- Create: `tests/RegistraceOvcina.E2E/CharacterPrepSmokeTests.cs`
+
+**Scenario:**
+1. Seed a game, one submission with two Player attendees, 5 equipment options
+2. Organizer logs in, visits dashboard, clicks `Poslat pozvánku` bulk button
+3. Extract `CharacterPrepToken` from DB (simulates parent receiving email)
+4. Browser opens `/postavy/{token}` anonymously
+5. Fill character name + pick equipment for both kids, save
+6. Reload page, verify values pre-filled
+7. Organizer dashboard shows both rows as `Hotovo`
+
+**Playwright install guard:** first run does `playwright install chromium` if missing (existing harness pattern). Skip with `[Fact(Skip = "...")]` if CI browsers aren't installed.
+
+---
+
+### Task 23: Seed the 5 equipment options for Ovčina 2026
+
+**Files:**
+- Create: one-off data seed exposed via `StartingEquipmentOptions` admin page (Task 19) OR a `/organizace/hry/{gameId}/priprava-postav/seed-defaults` endpoint that inserts the 5 defaults
+
+**5 defaults** (insert for the current Ovčina 2026 game after Phase 1 migrates):
+
+| Key | DisplayName | Description |
+|---|---|---|
+| `tesak` | `Tesák (3/1)` | `Útok 3, obrana 1` |
+| `dlouhy-nuz` | `Dlouhý nůž (2/2)` | `Útok 2, obrana 2` |
+| `vrhaci-nuz` | `Vrhací nůž (3/0)` | `Útok 3, obrana 0` |
+| `dyka-svitky` | `Dýka (1/2), 4 svitky kouzel` | `Útok 1, obrana 2 + 4 svitky kouzel` |
+| `mince` | `5 měďáků / grošů` | `Žádná zbraň, 5 mincí do začátku` |
+
+**Ask user to confirm the 5 rows verbatim before seeding.**
+
+---
+
+### Task 24: Version bump + PR
+
+**Files:**
+- Modify: `src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj` → `<Version>0.9.9</Version>` becomes `<Version>0.9.10</Version>`
+
+**Steps:**
+1. Bump version
+2. Confirm full test suite passes at repo root: `dotnet test`
+3. Start app locally via `run-app.bat`, walk through the manual QA checklist from design doc §7 / §11
+4. Create feature branch `feature/character-prep` (all-lowercase per project convention)
+5. **Ask user for permission to commit + push + open PR**
+6. When approved: stage everything, commit with message `feat: character prep page + equipment options + email flow (v0.9.10)`, push, `gh pr create` with the design doc link in the body
+
+---
+
+## Parallelization map (for subagent dispatch)
+
+```
+Phase 1 (Tasks 1-4)  [MUST FINISH FIRST]
+    │
+    ├──► Phase 2 (Tasks 5-8)  [MUST FINISH BEFORE Phase 3-5,7-8]
+    │       │
+    │       ├──► Phase 3 (Tasks 9-10)  [email]  ─┐
+    │       ├──► Phase 4 (Tasks 11-14) [page]   ─┤
+    │       ├──► Phase 5 (Tasks 15-18) [admin]  ─┤  ALL PARALLELIZABLE
+    │       ├──► Phase 7 (Task 20)     [excel]  ─┤
+    │       └──► Phase 8 (Task 21)     [subdetail]┘
+    │
+    └──► Phase 6 (Task 19) [options CRUD]  PARALLELIZABLE WITH Phase 2 onward
+    
+Phase 9 Task 22 (E2E)  [LAST, after all above]
+Phase 9 Task 23 (Seed) [after Task 19]
+Phase 9 Task 24 (Bump+PR) [LAST-LAST]
+```
+
+**Recommended dispatch** (three concurrent subagents after Phase 2):
+- Subagent A: Phases 3 (email) + 8 (submission detail integration) — these share the mail service
+- Subagent B: Phases 4 (parent page) + 7 (excel) — independent, both read-only view consumers
+- Subagent C: Phases 5 (dashboard) + 6 (config CRUD) — admin UI cluster
+
+Each subagent owns a commit boundary at phase end, subject to user approval.

--- a/src/RegistraceOvcina.Web/Components/Pages/CharacterPrep/CharacterPrep.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/CharacterPrep/CharacterPrep.razor
@@ -1,0 +1,264 @@
+@page "/postavy/{Token}"
+@attribute [AllowAnonymous]
+@rendermode InteractiveServer
+
+@using System.Globalization
+@using System.Security.Claims
+@using RegistraceOvcina.Web.Features.CharacterPrep
+@using RegistraceOvcina.Web.Security
+@inject CharacterPrepTokenService TokenService
+@inject CharacterPrepService PrepService
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ILogger<CharacterPrep> Logger
+
+<PageTitle>Příprava postavy — Ovčina</PageTitle>
+
+@if (_loading)
+{
+    <p class="text-secondary">Načítám…</p>
+}
+else if (_view is null)
+{
+    <section class="empty-state" data-testid="character-prep-not-found">
+        <h1 class="h3 mb-3">Odkaz není platný</h1>
+        <p class="mb-0">Odkaz již neplatí nebo je neznámý, kontaktujte organizátory.</p>
+    </section>
+}
+else
+{
+    <section class="mb-4">
+        <h1 class="h3 mb-1">Příprava postav — @_view.GameName</h1>
+        <p class="text-secondary mb-0">
+            Vyplňte jméno postavy a startovní výbavu pro každé dítě. Uložit můžete postupně,
+            údaje se zpracují při startu hry.
+        </p>
+    </section>
+
+    @if (IsLocked)
+    {
+        <div class="alert alert-warning" role="alert" data-testid="character-prep-readonly-banner">
+            Hra již začala, změny nelze provést.
+        </div>
+    }
+    else if (_view.IsReadOnly && _staffOverride)
+    {
+        <div class="alert alert-info" role="alert" data-testid="character-prep-staff-override">
+            Hra již začala — úpravy jsou povoleny pouze organizátorům.
+        </div>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(_statusMessage))
+    {
+        <div class="alert alert-success" role="status" data-testid="character-prep-status">@_statusMessage</div>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(_errorMessage))
+    {
+        <div class="alert alert-danger" role="alert" data-testid="character-prep-error">@_errorMessage</div>
+    }
+
+    <EditForm Model="this" OnValidSubmit="OnSave" FormName="character-prep">
+        <div class="d-flex flex-column gap-3">
+            @foreach (var row in _editRows)
+            {
+                <article class="card shadow-sm" data-testid="@($"prep-card-{row.RegistrationId}")">
+                    <div class="card-body p-4">
+                        <h2 class="h5 mb-3">@row.PersonFullName</h2>
+
+                        <div class="mb-3">
+                            <label class="form-label" for="@($"name-{row.RegistrationId}")">Jméno postavy</label>
+                            <InputText id="@($"name-{row.RegistrationId}")"
+                                       class="form-control"
+                                       @bind-Value="row.CharacterName"
+                                       disabled="@IsLocked"
+                                       data-testid="@($"character-name-{row.RegistrationId}")" />
+                        </div>
+
+                        <div class="mb-3">
+                            <span class="form-label d-block">Startovní výbava</span>
+                            <InputRadioGroup @bind-Value="row.StartingEquipmentOptionId"
+                                             Name="@($"equipment-{row.RegistrationId}")">
+                                @foreach (var option in _view.Options)
+                                {
+                                    var radioId = $"equip-{row.RegistrationId}-{option.Id}";
+                                    <div class="form-check">
+                                        <InputRadio class="form-check-input"
+                                                    id="@radioId"
+                                                    Value="@((int?)option.Id)"
+                                                    disabled="@IsLocked"
+                                                    data-testid="@radioId" />
+                                        <label class="form-check-label" for="@radioId">
+                                            <strong>@option.DisplayName</strong>
+                                            @if (!string.IsNullOrWhiteSpace(option.Description))
+                                            {
+                                                <span class="d-block small text-secondary">@option.Description</span>
+                                            }
+                                        </label>
+                                    </div>
+                                }
+                            </InputRadioGroup>
+                        </div>
+
+                        <div class="mb-2">
+                            <label class="form-label" for="@($"note-{row.RegistrationId}")">Poznámka</label>
+                            <InputTextArea id="@($"note-{row.RegistrationId}")"
+                                           class="form-control"
+                                           rows="4"
+                                           maxlength="4000"
+                                           placeholder="Cokoliv, co bychom měli vědět o postavě. Zvláštní schopnosti, alergie v roli, speciální přání…"
+                                           @bind-Value="row.CharacterPrepNote"
+                                           disabled="@IsLocked"
+                                           data-testid="@($"character-note-{row.RegistrationId}")" />
+                        </div>
+
+                        @if (row.UpdatedAtUtc.HasValue)
+                        {
+                            <div class="small text-secondary">
+                                Uloženo: @row.UpdatedAtUtc.Value.ToLocalTime().ToString("d. M. yyyy HH:mm", CzechCulture)
+                            </div>
+                        }
+                    </div>
+                </article>
+            }
+        </div>
+
+        @if (!IsLocked)
+        {
+            <div class="mt-4">
+                <button type="submit"
+                        class="btn btn-primary"
+                        disabled="@_saving"
+                        data-testid="character-prep-save">
+                    @(_saving ? "Ukládám…" : "Uložit")
+                </button>
+            </div>
+        }
+    </EditForm>
+}
+
+@code {
+    private static readonly CultureInfo CzechCulture = new("cs-CZ");
+
+    [Parameter]
+    public string Token { get; set; } = string.Empty;
+
+    private bool _loading = true;
+    private bool _saving;
+    private string? _statusMessage;
+    private string? _errorMessage;
+    private CharacterPrepView? _view;
+    private List<EditableRow> _editRows = [];
+    private int _submissionId;
+    private bool _staffOverride;
+
+    /// <summary>
+    /// True when the form must be presented in read-only mode: the game has
+    /// started AND the current request is NOT from a staff user.
+    /// </summary>
+    private bool IsLocked => _view is not null && _view.IsReadOnly && !_staffOverride;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _staffOverride = await ResolveStaffOverrideAsync();
+        await LoadViewAsync();
+        _loading = false;
+    }
+
+    private async Task LoadViewAsync()
+    {
+        var submission = await TokenService.FindBySubmissionTokenAsync(Token, CancellationToken.None);
+        if (submission is null)
+        {
+            _view = null;
+            _editRows = [];
+            return;
+        }
+
+        _submissionId = submission.Id;
+        _view = await PrepService.GetPrepViewAsync(submission.Id, DateTimeOffset.UtcNow, CancellationToken.None);
+        _editRows = _view?.Rows.Select(EditableRow.From).ToList() ?? [];
+    }
+
+    private async Task<bool> ResolveStaffOverrideAsync()
+    {
+        try
+        {
+            var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+            var user = authState.User;
+            if (user.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+            return user.IsInRole(RoleNames.Admin) || user.IsInRole(RoleNames.Organizer);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private async Task OnSave()
+    {
+        if (_view is null || IsLocked)
+        {
+            return;
+        }
+
+        _saving = true;
+        _statusMessage = null;
+        _errorMessage = null;
+
+        try
+        {
+            var saveRows = _editRows.Select(r => r.ToSaveRow()).ToList();
+            await PrepService.SaveAsync(_submissionId, saveRows, DateTimeOffset.UtcNow, CancellationToken.None);
+            await LoadViewAsync();
+            _statusMessage = "Uloženo, díky.";
+        }
+        catch (ArgumentException argEx)
+        {
+            Logger.LogWarning(argEx, "Character prep save rejected for submission {SubmissionId}.", _submissionId);
+            _errorMessage = "Některé hodnoty se nepodařilo uložit. Zkontrolujte prosím výběr startovní výbavy.";
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Character prep save failed for submission {SubmissionId}.", _submissionId);
+            _errorMessage = "Uložení se nepodařilo. Zkuste to prosím znovu později.";
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    /// <summary>
+    /// Mutable mirror of <see cref="CharacterPrepRow"/> — the record is immutable so Blazor
+    /// cannot two-way-bind into it. The page projects rows into this class on load and
+    /// back to <see cref="CharacterPrepSaveRow"/> on save.
+    /// </summary>
+    private sealed class EditableRow
+    {
+        public int RegistrationId { get; init; }
+        public string PersonFullName { get; init; } = string.Empty;
+        public string? CharacterName { get; set; }
+        public int? StartingEquipmentOptionId { get; set; }
+        public string? CharacterPrepNote { get; set; }
+        public DateTimeOffset? UpdatedAtUtc { get; init; }
+
+        public static EditableRow From(CharacterPrepRow source) => new()
+        {
+            RegistrationId = source.RegistrationId,
+            PersonFullName = source.PersonFullName,
+            CharacterName = source.CharacterName,
+            StartingEquipmentOptionId = source.StartingEquipmentOptionId,
+            CharacterPrepNote = source.CharacterPrepNote,
+            UpdatedAtUtc = source.UpdatedAtUtc
+        };
+
+        public CharacterPrepSaveRow ToSaveRow() => new(
+            RegistrationId,
+            CharacterName,
+            StartingEquipmentOptionId,
+            CharacterPrepNote);
+    }
+}

--- a/src/RegistraceOvcina.Web/Components/Pages/CharacterPrep/CharacterPrep.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/CharacterPrep/CharacterPrep.razor
@@ -3,7 +3,6 @@
 @rendermode InteractiveServer
 
 @using System.Globalization
-@using System.Security.Claims
 @using RegistraceOvcina.Web.Features.CharacterPrep
 @using RegistraceOvcina.Web.Security
 @inject CharacterPrepTokenService TokenService
@@ -69,6 +68,7 @@ else
                             <label class="form-label" for="@($"name-{row.RegistrationId}")">Jméno postavy</label>
                             <InputText id="@($"name-{row.RegistrationId}")"
                                        class="form-control"
+                                       maxlength="200"
                                        @bind-Value="row.CharacterName"
                                        disabled="@IsLocked"
                                        data-testid="@($"character-name-{row.RegistrationId}")" />

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/CharacterPrepDashboard.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/CharacterPrepDashboard.razor
@@ -31,7 +31,7 @@ else
         <div class="col-md-3">
             <div class="card shadow-sm border-start border-4 border-primary">
                 <div class="card-body">
-                    <h2 class="mb-0">@stats.TotalHouseholds</h2>
+                    <h2 class="mb-0" data-testid="prep-stat-total-households">@stats.TotalHouseholds</h2>
                     <span class="text-secondary">domácností s hráči</span>
                 </div>
             </div>
@@ -39,7 +39,7 @@ else
         <div class="col-md-3">
             <div class="card shadow-sm border-start border-4 border-info">
                 <div class="card-body">
-                    <h2 class="mb-0">@stats.Invited</h2>
+                    <h2 class="mb-0" data-testid="prep-stat-invited">@stats.Invited</h2>
                     <span class="text-secondary">pozváno</span>
                 </div>
             </div>
@@ -52,7 +52,7 @@ else
             }
             <div class="card shadow-sm border-start border-4 @filledBorder">
                 <div class="card-body">
-                    <h2 class="mb-0">@stats.FullyFilled</h2>
+                    <h2 class="mb-0" data-testid="prep-stat-fully-filled">@stats.FullyFilled</h2>
                     <span class="text-secondary">kompletně vyplněno</span>
                 </div>
             </div>
@@ -63,7 +63,7 @@ else
             }
             <div class="card shadow-sm border-start border-4 @pendingBorder">
                 <div class="card-body">
-                    <h2 class="mb-0">@stats.Pending</h2>
+                    <h2 class="mb-0" data-testid="prep-stat-pending">@stats.Pending</h2>
                     <span class="text-secondary">čeká na vyplnění</span>
                 </div>
             </div>
@@ -143,7 +143,7 @@ else
                 <tbody>
                     @foreach (var row in rowsPage.Rows)
                     {
-                        <tr>
+                        <tr data-testid="@($"prep-row-{row.RegistrationId}")">
                             <td>
                                 <a class="text-decoration-none"
                                    href="/organizace/prihlaska/@row.SubmissionId">
@@ -155,7 +155,7 @@ else
                             <td>@(row.EquipmentDisplayName ?? "—")</td>
                             <td class="small text-muted" style="max-width: 240px;">@Truncate(row.CharacterPrepNote, 60)</td>
                             <td>
-                                <span class="badge @StatusBadgeClass(row.Status)">@StatusLabel(row.Status)</span>
+                                <span class="badge @StatusBadgeClass(row.Status)" data-testid="@($"prep-status-{row.RegistrationId}")">@StatusLabel(row.Status)</span>
                             </td>
                             <td class="small text-muted">
                                 @(row.UpdatedAtUtc.HasValue

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/CharacterPrepDashboard.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/CharacterPrepDashboard.razor
@@ -1,0 +1,399 @@
+@page "/organizace/hry/{GameId:int}/priprava-postav"
+@attribute [Authorize(Policy = AuthorizationPolicies.StaffOnly)]
+@rendermode InteractiveServer
+
+@using Microsoft.EntityFrameworkCore
+@using RegistraceOvcina.Web.Data
+@using RegistraceOvcina.Web.Features.CharacterPrep
+@using RegistraceOvcina.Web.Security
+
+@inject CharacterPrepService PrepService
+@inject CharacterPrepMailService MailService
+@inject IDbContextFactory<ApplicationDbContext> DbContextFactory
+
+<PageTitle>Příprava postav — @(gameName ?? "Načítání…")</PageTitle>
+
+@if (stats is null || gameName is null)
+{
+    <div class="text-center py-5">
+        <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Načítání…</span>
+        </div>
+    </div>
+}
+else
+{
+    <h2 class="mb-1">Příprava postav — @gameName</h2>
+    <p class="text-secondary mb-4">Přehled, rozesílka pozvánek a připomínek.</p>
+
+    @* ────────── Stat tiles (mirror GameStatsPage style) ────────── *@
+    <div class="row g-3 mb-4">
+        <div class="col-md-3">
+            <div class="card shadow-sm border-start border-4 border-primary">
+                <div class="card-body">
+                    <h2 class="mb-0">@stats.TotalHouseholds</h2>
+                    <span class="text-secondary">domácností s hráči</span>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card shadow-sm border-start border-4 border-info">
+                <div class="card-body">
+                    <h2 class="mb-0">@stats.Invited</h2>
+                    <span class="text-secondary">pozváno</span>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            @{
+                var filledBorder = stats.TotalHouseholds > 0 && stats.FullyFilled == stats.TotalHouseholds
+                    ? "border-success"
+                    : "border-warning";
+            }
+            <div class="card shadow-sm border-start border-4 @filledBorder">
+                <div class="card-body">
+                    <h2 class="mb-0">@stats.FullyFilled</h2>
+                    <span class="text-secondary">kompletně vyplněno</span>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            @{
+                var pendingBorder = stats.Pending == 0 ? "border-success" : "border-danger";
+            }
+            <div class="card shadow-sm border-start border-4 @pendingBorder">
+                <div class="card-body">
+                    <h2 class="mb-0">@stats.Pending</h2>
+                    <span class="text-secondary">čeká na vyplnění</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @* ────────── Action bar ────────── *@
+    <div class="d-flex flex-wrap gap-2 align-items-center mb-3">
+        <button type="button" class="btn btn-primary"
+                disabled="@(invitationCount == 0 || gameHasStarted || isBusy)"
+                @onclick="SendBulkPozvankaAsync">
+            Poslat pozvánku (@invitationCount)
+        </button>
+        <button type="button" class="btn btn-outline-primary"
+                disabled="@(reminderCount == 0 || gameHasStarted || isBusy)"
+                @onclick="SendBulkPripominkaAsync">
+            Poslat připomínku (@reminderCount)
+        </button>
+        @* Phase 7 wires Excel export — dashboard link is stubbed for now. *@
+        <a class="btn btn-outline-secondary disabled" aria-disabled="true" href="#"
+           title="Bude doplněno v další fázi">Stáhnout Excel</a>
+        <a class="btn btn-outline-secondary"
+           href="/organizace/hry/@GameId/priprava-postav/vybava">Konfigurovat výbavu</a>
+
+        <div class="ms-auto d-flex gap-2 align-items-center">
+            <select class="form-select form-select-sm" style="min-width: 180px;"
+                    @bind="selectedStatus" @bind:after="ReloadRowsAsync">
+                <option value="">Všichni</option>
+                <option value="NotInvited">Nezvaní</option>
+                <option value="Waiting">Čekající</option>
+                <option value="Done">Hotovo</option>
+            </select>
+            <input type="text" class="form-control form-control-sm" style="min-width: 200px;"
+                   placeholder="Jméno nebo postava…"
+                   @bind="searchText" @bind:event="oninput" @onkeyup="OnSearchKeyUp" />
+            <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="ReloadRowsAsync">
+                Hledat
+            </button>
+        </div>
+    </div>
+
+    @if (!string.IsNullOrWhiteSpace(statusMessage))
+    {
+        <div class="alert alert-success py-2 small" role="status">@statusMessage</div>
+    }
+    @if (!string.IsNullOrWhiteSpace(errorMessage))
+    {
+        <div class="alert alert-danger py-2 small" role="alert">@errorMessage</div>
+    }
+
+    @* ────────── Rows table ────────── *@
+    @if (rowsPage is null)
+    {
+        <p class="text-secondary">Načítám řádky…</p>
+    }
+    else if (rowsPage.Total == 0)
+    {
+        <div class="empty-state">Žádní hráči neodpovídají filtru.</div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table align-middle">
+                <thead>
+                    <tr>
+                        <th>Domácnost</th>
+                        <th>Hráč</th>
+                        <th>Jméno postavy</th>
+                        <th>Výbava</th>
+                        <th>Poznámka</th>
+                        <th>Stav</th>
+                        <th>Naposledy upraveno</th>
+                        <th class="text-end">Akce</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var row in rowsPage.Rows)
+                    {
+                        <tr>
+                            <td>
+                                <a class="text-decoration-none"
+                                   href="/organizace/prihlaska/@row.SubmissionId">
+                                    @row.HouseholdName
+                                </a>
+                            </td>
+                            <td>@row.PersonFullName</td>
+                            <td>@(row.CharacterName ?? "—")</td>
+                            <td>@(row.EquipmentDisplayName ?? "—")</td>
+                            <td class="small text-muted" style="max-width: 240px;">@Truncate(row.CharacterPrepNote, 60)</td>
+                            <td>
+                                <span class="badge @StatusBadgeClass(row.Status)">@StatusLabel(row.Status)</span>
+                            </td>
+                            <td class="small text-muted">
+                                @(row.UpdatedAtUtc.HasValue
+                                    ? row.UpdatedAtUtc.Value.UtcDateTime.ToString("dd.MM.yyyy HH:mm")
+                                    : "—")
+                            </td>
+                            <td class="text-end">
+                                @if (!string.IsNullOrEmpty(row.SubmissionToken))
+                                {
+                                    <a class="btn btn-sm btn-outline-secondary me-1"
+                                       href="/postavy/@row.SubmissionToken" target="_blank" rel="noopener">
+                                        Otevřít odkaz
+                                    </a>
+                                }
+                                @if (row.Status != CharacterPrepStatus.Done)
+                                {
+                                    <button type="button" class="btn btn-sm btn-outline-primary"
+                                            disabled="@(gameHasStarted || isBusy)"
+                                            @onclick="() => SendPerRowReminderAsync(row)">
+                                        @(row.Status == CharacterPrepStatus.NotInvited
+                                            ? "Poslat pozvánku"
+                                            : "Poslat připomínku")
+                                    </button>
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+
+        var pageCount = (int)Math.Ceiling((double)rowsPage.Total / rowsPage.PageSize);
+        if (pageCount > 1)
+        {
+            <div class="d-flex align-items-center gap-2">
+                <button type="button" class="btn btn-sm btn-outline-secondary"
+                        disabled="@(currentPage <= 1 || isBusy)"
+                        @onclick="() => GoToPageAsync(currentPage - 1)">
+                    ← Předchozí
+                </button>
+                <span class="small text-muted">Strana @currentPage z @pageCount</span>
+                <button type="button" class="btn btn-sm btn-outline-secondary"
+                        disabled="@(currentPage >= pageCount || isBusy)"
+                        @onclick="() => GoToPageAsync(currentPage + 1)">
+                    Další →
+                </button>
+            </div>
+        }
+    }
+}
+
+@code {
+    [Parameter] public int GameId { get; set; }
+
+    private const int PageSize = 20;
+
+    private string? gameName;
+    private bool gameHasStarted;
+    private CharacterPrepStats? stats;
+    private PagedResult<CharacterPrepDashboardRow>? rowsPage;
+    private int currentPage = 1;
+    private string searchText = "";
+    private string selectedStatus = "";
+    private int invitationCount;
+    private int reminderCount;
+
+    private bool isBusy;
+    private string? statusMessage;
+    private string? errorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadGameMetaAsync();
+        await ReloadAllAsync();
+    }
+
+    private async Task LoadGameMetaAsync()
+    {
+        await using var db = await DbContextFactory.CreateDbContextAsync();
+        var game = await db.Games
+            .AsNoTracking()
+            .Where(x => x.Id == GameId)
+            .Select(x => new { x.Name, x.StartsAtUtc })
+            .FirstOrDefaultAsync();
+        gameName = game?.Name ?? "";
+        gameHasStarted = game is not null
+            && DateTime.SpecifyKind(game.StartsAtUtc, DateTimeKind.Utc) <= DateTime.UtcNow;
+    }
+
+    private async Task ReloadAllAsync()
+    {
+        var now = DateTimeOffset.UtcNow;
+        stats = await PrepService.GetDashboardStatsAsync(GameId, CancellationToken.None);
+        var invitationTargets = await PrepService.ListInvitationTargetsAsync(GameId, CancellationToken.None);
+        invitationCount = invitationTargets.Count;
+        var reminderTargets = await PrepService.ListReminderTargetsAsync(GameId, now, CancellationToken.None);
+        reminderCount = reminderTargets.Count;
+        await ReloadRowsAsync();
+    }
+
+    private async Task ReloadRowsAsync()
+    {
+        var status = ParseStatus(selectedStatus);
+        rowsPage = await PrepService.GetDashboardRowsAsync(
+            GameId,
+            new DashboardFilter(status, searchText),
+            currentPage,
+            PageSize,
+            CancellationToken.None);
+    }
+
+    private async Task GoToPageAsync(int page)
+    {
+        currentPage = Math.Max(1, page);
+        await ReloadRowsAsync();
+    }
+
+    private async Task OnSearchKeyUp(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+        {
+            currentPage = 1;
+            await ReloadRowsAsync();
+        }
+    }
+
+    private async Task SendBulkPozvankaAsync()
+    {
+        if (isBusy || gameHasStarted) return;
+        isBusy = true;
+        ClearMessages();
+        try
+        {
+            var result = await MailService.SendBulkPozvankaAsync(
+                GameId, DateTimeOffset.UtcNow, CancellationToken.None);
+            statusMessage = $"Posláno: {result.Sent} pozvánek, {result.Failed} chyb.";
+            if (result.Failed > 0 && !string.IsNullOrEmpty(result.FirstError))
+            {
+                statusMessage += $" První chyba: {result.FirstError}";
+            }
+            await ReloadAllAsync();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = "Odesílání pozvánek selhalo: " + ex.Message;
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task SendBulkPripominkaAsync()
+    {
+        if (isBusy || gameHasStarted) return;
+        isBusy = true;
+        ClearMessages();
+        try
+        {
+            var result = await MailService.SendBulkPripominkaAsync(
+                GameId, DateTimeOffset.UtcNow, CancellationToken.None);
+            statusMessage = $"Posláno: {result.Sent} připomínek, {result.Failed} chyb.";
+            if (result.Failed > 0 && !string.IsNullOrEmpty(result.FirstError))
+            {
+                statusMessage += $" První chyba: {result.FirstError}";
+            }
+            await ReloadAllAsync();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = "Odesílání připomínek selhalo: " + ex.Message;
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task SendPerRowReminderAsync(CharacterPrepDashboardRow row)
+    {
+        if (isBusy || gameHasStarted) return;
+        isBusy = true;
+        ClearMessages();
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+            var result = row.Status == CharacterPrepStatus.NotInvited
+                ? await MailService.SendPozvankaAsync(row.SubmissionId, now, CancellationToken.None)
+                : await MailService.SendPripominkaAsync(row.SubmissionId, now, CancellationToken.None);
+
+            statusMessage = result switch
+            {
+                SendSingleResult.Sent => $"Odesláno — {row.HouseholdName}.",
+                SendSingleResult.AlreadyInvited => $"{row.HouseholdName} už pozvánku dostal/a.",
+                SendSingleResult.ThrottledSkipped => $"Připomínka přeskočena (24h limit) — {row.HouseholdName}.",
+                SendSingleResult.MissingRecipient => $"Chybí e-mail — {row.HouseholdName}.",
+                SendSingleResult.Error => $"Chyba při odesílání — {row.HouseholdName}.",
+                _ => null
+            };
+            await ReloadAllAsync();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = "Odeslání selhalo: " + ex.Message;
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private static CharacterPrepStatus? ParseStatus(string value) =>
+        Enum.TryParse<CharacterPrepStatus>(value, out var parsed) ? parsed : null;
+
+    private static string StatusBadgeClass(CharacterPrepStatus status) => status switch
+    {
+        CharacterPrepStatus.NotInvited => "bg-secondary",
+        CharacterPrepStatus.Waiting => "bg-warning text-dark",
+        CharacterPrepStatus.Done => "bg-success",
+        _ => "bg-secondary"
+    };
+
+    private static string StatusLabel(CharacterPrepStatus status) => status switch
+    {
+        CharacterPrepStatus.NotInvited => "Nezváno",
+        CharacterPrepStatus.Waiting => "Čeká",
+        CharacterPrepStatus.Done => "Hotovo",
+        _ => "—"
+    };
+
+    private static string? Truncate(string? value, int max)
+    {
+        if (string.IsNullOrEmpty(value)) return null;
+        return value.Length <= max ? value : value[..max] + "…";
+    }
+
+    private void ClearMessages()
+    {
+        statusMessage = null;
+        errorMessage = null;
+    }
+}

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/CharacterPrepDashboard.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/CharacterPrepDashboard.razor
@@ -91,7 +91,7 @@ else
 
         <div class="ms-auto d-flex gap-2 align-items-center">
             <select class="form-select form-select-sm" style="min-width: 180px;"
-                    @bind="selectedStatus" @bind:after="ReloadRowsAsync">
+                    @bind="selectedStatus" @bind:after="OnStatusFilterChangedAsync">
                 <option value="">Všichni</option>
                 <option value="NotInvited">Nezvaní</option>
                 <option value="Waiting">Čekající</option>
@@ -99,8 +99,8 @@ else
             </select>
             <input type="text" class="form-control form-control-sm" style="min-width: 200px;"
                    placeholder="Jméno nebo postava…"
-                   @bind="searchText" @bind:event="oninput" @onkeyup="OnSearchKeyUp" />
-            <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="ReloadRowsAsync">
+                   @bind="searchText" @bind:event="oninput" @bind:after="OnSearchTextChangedAsync" @onkeyup="OnSearchKeyUp" />
+            <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="OnSearchClickedAsync">
                 Hledat
             </button>
         </div>
@@ -146,7 +146,7 @@ else
                         <tr data-testid="@($"prep-row-{row.RegistrationId}")">
                             <td>
                                 <a class="text-decoration-none"
-                                   href="/organizace/prihlaska/@row.SubmissionId">
+                                   href="/organizace/prihlasky/@row.SubmissionId">
                                     @row.HouseholdName
                                 </a>
                             </td>
@@ -276,6 +276,33 @@ else
     private async Task OnSearchKeyUp(KeyboardEventArgs e)
     {
         if (e.Key == "Enter")
+        {
+            currentPage = 1;
+            await ReloadRowsAsync();
+        }
+    }
+
+    // Filter/search handlers below reset pagination before reloading so a user
+    // on page N with the previous filter doesn't land on an empty table after
+    // the result set shrinks.
+    private async Task OnStatusFilterChangedAsync()
+    {
+        currentPage = 1;
+        await ReloadRowsAsync();
+    }
+
+    private async Task OnSearchClickedAsync()
+    {
+        currentPage = 1;
+        await ReloadRowsAsync();
+    }
+
+    private async Task OnSearchTextChangedAsync()
+    {
+        // Live-update pagination only when the textbox is cleared. Non-empty
+        // typing waits for Enter or the Hledat button so we don't hammer the DB
+        // on every keystroke.
+        if (string.IsNullOrWhiteSpace(searchText))
         {
             currentPage = 1;
             await ReloadRowsAsync();

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/CharacterPrepDashboard.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/CharacterPrepDashboard.razor
@@ -82,9 +82,10 @@ else
                 @onclick="SendBulkPripominkaAsync">
             Poslat připomínku (@reminderCount)
         </button>
-        @* Phase 7 wires Excel export — dashboard link is stubbed for now. *@
-        <a class="btn btn-outline-secondary disabled" aria-disabled="true" href="#"
-           title="Bude doplněno v další fázi">Stáhnout Excel</a>
+        <a class="btn btn-outline-secondary"
+           href="@($"/organizace/hry/{GameId}/priprava-postav/export.xlsx")">
+            Stáhnout Excel
+        </a>
         <a class="btn btn-outline-secondary"
            href="/organizace/hry/@GameId/priprava-postav/vybava">Konfigurovat výbavu</a>
 

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameStatsPage.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameStatsPage.razor
@@ -80,6 +80,31 @@ else
         </div>
     </div>
 
+    @* ────────── Character Prep Widget ────────── *@
+    <div class="row g-3 mb-4">
+        <div class="col-md-6">
+            @{
+                var prepBorder = stats.CharacterPrepTotal > 0 && stats.CharacterPrepFilled == stats.CharacterPrepTotal
+                    ? "border-success"
+                    : stats.CharacterPrepFilled > 0 ? "border-warning" : "border-secondary";
+            }
+            <a class="text-decoration-none text-body"
+               href="/organizace/hry/@GameId/priprava-postav">
+                <div class="card shadow-sm border-start border-4 @prepBorder">
+                    <div class="card-body d-flex align-items-center">
+                        <div>
+                            <h5 class="mb-1">Příprava postav</h5>
+                            <div class="text-secondary">
+                                @stats.CharacterPrepFilled / @stats.CharacterPrepTotal vyplněno
+                            </div>
+                        </div>
+                        <span class="ms-auto text-muted small">Otevřít →</span>
+                    </div>
+                </div>
+            </a>
+        </div>
+    </div>
+
     @* ────────── Action Items ────────── *@
     @if (stats.UnpaidSubmissionCount > 0 || stats.PlayersWithoutKingdom > 0 || stats.IndoorWithoutRoom > 0)
     {

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/StartingEquipmentOptions.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/StartingEquipmentOptions.razor
@@ -4,12 +4,14 @@
 
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.EntityFrameworkCore
+@using Microsoft.JSInterop
 @using RegistraceOvcina.Web.Data
 @using RegistraceOvcina.Web.Features.CharacterPrep
 @using RegistraceOvcina.Web.Security
 
 @inject CharacterPrepOptionsService OptionsService
 @inject IDbContextFactory<ApplicationDbContext> DbContextFactory
+@inject IJSRuntime JS
 
 <PageTitle>Startovní výbava — @(gameName ?? "Načítání…")</PageTitle>
 
@@ -139,7 +141,7 @@ else
                                 Upravit
                             </button>
                             <button type="button" class="btn btn-sm btn-outline-danger"
-                                    @onclick="() => DeleteAsync(opt.Id)"
+                                    @onclick="() => DeleteAsync(opt)"
                                     disabled="@isBusy">
                                 Smazat
                             </button>
@@ -389,14 +391,17 @@ else
         }
     }
 
-    private async Task DeleteAsync(int optionId)
+    private async Task DeleteAsync(StartingEquipmentOptionDto opt)
     {
         if (isBusy) return;
+        var confirmed = await JS.InvokeAsync<bool>(
+            "confirm", $"Opravdu smazat výbavu \"{opt.DisplayName}\"?");
+        if (!confirmed) return;
         isBusy = true;
         ClearMessages();
         try
         {
-            var deleted = await OptionsService.TryDeleteAsync(optionId, CancellationToken.None);
+            var deleted = await OptionsService.TryDeleteAsync(opt.Id, CancellationToken.None);
             if (deleted)
             {
                 statusMessage = "Výbava smazána.";

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/StartingEquipmentOptions.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/StartingEquipmentOptions.razor
@@ -1,0 +1,441 @@
+@page "/organizace/hry/{GameId:int}/priprava-postav/vybava"
+@attribute [Authorize(Policy = AuthorizationPolicies.StaffOnly)]
+@rendermode InteractiveServer
+
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.EntityFrameworkCore
+@using RegistraceOvcina.Web.Data
+@using RegistraceOvcina.Web.Features.CharacterPrep
+@using RegistraceOvcina.Web.Security
+
+@inject CharacterPrepOptionsService OptionsService
+@inject IDbContextFactory<ApplicationDbContext> DbContextFactory
+
+<PageTitle>Startovní výbava — @(gameName ?? "Načítání…")</PageTitle>
+
+@if (gameName is null || options is null)
+{
+    <div class="text-center py-5">
+        <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Načítání…</span>
+        </div>
+    </div>
+}
+else
+{
+    <nav aria-label="breadcrumb" class="mb-2">
+        <ol class="breadcrumb small mb-0">
+            <li class="breadcrumb-item">
+                <a href="/organizace/hry/@GameId/priprava-postav">Příprava postav</a>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">Startovní výbava</li>
+        </ol>
+    </nav>
+
+    <h2 class="mb-1">Startovní výbava pro @gameName</h2>
+    <p class="text-secondary mb-4">
+        Seznam výbav, které rodiče vybírají při přípravě postav.
+        Klíč (<code>Key</code>) je neměnný identifikátor; DisplayName, popis a
+        pořadí lze kdykoliv upravit.
+    </p>
+
+    @if (!string.IsNullOrEmpty(statusMessage))
+    {
+        <div class="alert alert-success" role="alert">@statusMessage</div>
+    }
+    @if (!string.IsNullOrEmpty(errorMessage))
+    {
+        <div class="alert alert-danger" role="alert">@errorMessage</div>
+    }
+
+    <div class="mb-3">
+        @if (!showAddForm)
+        {
+            <button type="button" class="btn btn-primary" @onclick="ShowAddForm" disabled="@isBusy">
+                + Přidat novou výbavu
+            </button>
+        }
+        else
+        {
+            <div class="card">
+                <div class="card-header">Nová výbava</div>
+                <div class="card-body">
+                    <div class="row g-3">
+                        <div class="col-md-3">
+                            <label class="form-label" for="add-key">Klíč (neměnný)</label>
+                            <input id="add-key" class="form-control" maxlength="50"
+                                   @bind="addKey" placeholder="napr. tesak" />
+                            <div class="form-text">Malá písmena bez mezer, max. 50 znaků.</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label" for="add-displayName">Název pro rodiče</label>
+                            <input id="add-displayName" class="form-control" maxlength="100"
+                                   @bind="addDisplayName" placeholder="Tesák" />
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label" for="add-description">Popis (volitelný)</label>
+                            <input id="add-description" class="form-control" maxlength="500"
+                                   @bind="addDescription" placeholder="útok/obrana 3/1" />
+                        </div>
+                        <div class="col-md-2">
+                            <label class="form-label" for="add-sortOrder">Pořadí</label>
+                            <input id="add-sortOrder" type="number" min="0" class="form-control"
+                                   @bind="addSortOrder" />
+                        </div>
+                    </div>
+                    <div class="mt-3 d-flex gap-2">
+                        <button type="button" class="btn btn-primary"
+                                @onclick="SaveNewAsync" disabled="@isBusy">
+                            Uložit
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary"
+                                @onclick="CancelAdd" disabled="@isBusy">
+                            Zrušit
+                        </button>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+
+    @if (options.Count == 0)
+    {
+        <div class="empty-state text-secondary py-4">
+            Zatím žádné výbavy. Přidejte první nahoře nebo zkopírujte z jiné hry (viz dole).
+        </div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-hover align-middle">
+                <thead>
+                    <tr>
+                        <th style="width: 15%;">Klíč</th>
+                        <th style="width: 25%;">Název pro rodiče</th>
+                        <th style="width: 35%;">Popis</th>
+                        <th style="width: 10%;">Pořadí</th>
+                        <th style="width: 15%;" class="text-end">Akce</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach (var opt in options)
+                {
+                    <tr>
+                        <td><code>@opt.Key</code></td>
+                        <td>@opt.DisplayName</td>
+                        <td class="text-secondary">@(opt.Description ?? "—")</td>
+                        <td>@opt.SortOrder</td>
+                        <td class="text-end">
+                            <button type="button" class="btn btn-sm btn-outline-primary me-1"
+                                    @onclick="() => BeginEdit(opt)"
+                                    disabled="@(isBusy || editOptionId == opt.Id)">
+                                Upravit
+                            </button>
+                            <button type="button" class="btn btn-sm btn-outline-danger"
+                                    @onclick="() => DeleteAsync(opt.Id)"
+                                    disabled="@isBusy">
+                                Smazat
+                            </button>
+                        </td>
+                    </tr>
+                    @if (editOptionId == opt.Id)
+                    {
+                        <tr>
+                            <td colspan="5" class="bg-light">
+                                <div class="row g-3">
+                                    <div class="col-md-3">
+                                        <label class="form-label">Klíč</label>
+                                        <input class="form-control" value="@opt.Key" disabled />
+                                        <div class="form-text">Klíč se nedá změnit.</div>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label class="form-label" for="edit-displayName">Název pro rodiče</label>
+                                        <input id="edit-displayName" class="form-control" maxlength="100"
+                                               @bind="editDisplayName" />
+                                    </div>
+                                    <div class="col-md-3">
+                                        <label class="form-label" for="edit-description">Popis</label>
+                                        <input id="edit-description" class="form-control" maxlength="500"
+                                               @bind="editDescription" />
+                                    </div>
+                                    <div class="col-md-2">
+                                        <label class="form-label" for="edit-sortOrder">Pořadí</label>
+                                        <input id="edit-sortOrder" type="number" min="0" class="form-control"
+                                               @bind="editSortOrder" />
+                                    </div>
+                                </div>
+                                <div class="mt-3 d-flex gap-2">
+                                    <button type="button" class="btn btn-primary"
+                                            @onclick="SaveEditAsync" disabled="@isBusy">
+                                        Uložit
+                                    </button>
+                                    <button type="button" class="btn btn-outline-secondary"
+                                            @onclick="CancelEdit" disabled="@isBusy">
+                                        Zrušit
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                }
+                </tbody>
+            </table>
+        </div>
+    }
+
+    <hr class="my-4" />
+
+    <section>
+        <h4>Zkopírovat výbavu z jiné hry</h4>
+        <p class="text-secondary">
+            Zkopíruje všechny výbavy z vybrané hry. Klíče, které už v této hře existují,
+            se přeskočí (stávající hodnoty zůstanou nedotčené).
+        </p>
+
+        @if (otherGames is not null && otherGames.Count > 0)
+        {
+            <div class="row g-2 align-items-end">
+                <div class="col-md-6">
+                    <label class="form-label" for="copy-source">Zdrojová hra</label>
+                    <select id="copy-source" class="form-select"
+                            @bind="copySourceGameId" disabled="@isBusy">
+                        <option value="0">— Vyberte hru —</option>
+                        @foreach (var g in otherGames)
+                        {
+                            <option value="@g.Id">@g.Name</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <button type="button" class="btn btn-outline-primary"
+                            @onclick="CopyFromAsync"
+                            disabled="@(isBusy || copySourceGameId <= 0)">
+                        Zkopírovat
+                    </button>
+                </div>
+            </div>
+        }
+        else
+        {
+            <p class="text-secondary fst-italic">Žádné další hry k dispozici.</p>
+        }
+    </section>
+}
+
+@code {
+    [Parameter] public int GameId { get; set; }
+
+    private string? gameName;
+    private List<StartingEquipmentOptionDto>? options;
+    private List<GameOption>? otherGames;
+    private bool isBusy;
+    private string? statusMessage;
+    private string? errorMessage;
+
+    // Add form state
+    private bool showAddForm;
+    private string addKey = "";
+    private string addDisplayName = "";
+    private string addDescription = "";
+    private int addSortOrder;
+
+    // Edit form state
+    private int? editOptionId;
+    private string editDisplayName = "";
+    private string editDescription = "";
+    private int editSortOrder;
+
+    // Copy-from state
+    private int copySourceGameId;
+
+    private sealed record GameOption(int Id, string Name);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadGameNameAsync();
+        await ReloadOptionsAsync();
+        await LoadOtherGamesAsync();
+    }
+
+    private async Task LoadGameNameAsync()
+    {
+        await using var db = await DbContextFactory.CreateDbContextAsync();
+        var game = await db.Games.AsNoTracking()
+            .Where(x => x.Id == GameId)
+            .Select(x => new { x.Name })
+            .FirstOrDefaultAsync();
+        gameName = game?.Name ?? "(neznámá hra)";
+    }
+
+    private async Task ReloadOptionsAsync()
+    {
+        var list = await OptionsService.ListAsync(GameId, CancellationToken.None);
+        options = list.ToList();
+    }
+
+    private async Task LoadOtherGamesAsync()
+    {
+        await using var db = await DbContextFactory.CreateDbContextAsync();
+        otherGames = await db.Games.AsNoTracking()
+            .Where(x => x.Id != GameId)
+            .OrderByDescending(x => x.StartsAtUtc)
+            .Select(x => new GameOption(x.Id, x.Name))
+            .ToListAsync();
+    }
+
+    private void ShowAddForm()
+    {
+        ClearMessages();
+        showAddForm = true;
+        addKey = "";
+        addDisplayName = "";
+        addDescription = "";
+        addSortOrder = 0;
+    }
+
+    private void CancelAdd()
+    {
+        showAddForm = false;
+        ClearMessages();
+    }
+
+    private async Task SaveNewAsync()
+    {
+        if (isBusy) return;
+        isBusy = true;
+        ClearMessages();
+        try
+        {
+            await OptionsService.CreateAsync(
+                GameId, addKey, addDisplayName,
+                string.IsNullOrWhiteSpace(addDescription) ? null : addDescription,
+                addSortOrder, CancellationToken.None);
+            statusMessage = $"Výbava přidána: {addDisplayName}.";
+            showAddForm = false;
+            await ReloadOptionsAsync();
+        }
+        catch (ArgumentException ex)
+        {
+            errorMessage = "Neplatná data: " + ex.Message;
+        }
+        catch (InvalidOperationException ex)
+        {
+            errorMessage = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            errorMessage = "Uložení selhalo: " + ex.Message;
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private void BeginEdit(StartingEquipmentOptionDto opt)
+    {
+        ClearMessages();
+        editOptionId = opt.Id;
+        editDisplayName = opt.DisplayName;
+        editDescription = opt.Description ?? "";
+        editSortOrder = opt.SortOrder;
+    }
+
+    private void CancelEdit()
+    {
+        editOptionId = null;
+        ClearMessages();
+    }
+
+    private async Task SaveEditAsync()
+    {
+        if (isBusy || editOptionId is null) return;
+        isBusy = true;
+        ClearMessages();
+        try
+        {
+            await OptionsService.UpdateAsync(
+                editOptionId.Value,
+                editDisplayName,
+                string.IsNullOrWhiteSpace(editDescription) ? null : editDescription,
+                editSortOrder,
+                CancellationToken.None);
+            statusMessage = "Výbava uložena.";
+            editOptionId = null;
+            await ReloadOptionsAsync();
+        }
+        catch (ArgumentException ex)
+        {
+            errorMessage = "Neplatná data: " + ex.Message;
+        }
+        catch (InvalidOperationException ex)
+        {
+            errorMessage = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            errorMessage = "Uložení selhalo: " + ex.Message;
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task DeleteAsync(int optionId)
+    {
+        if (isBusy) return;
+        isBusy = true;
+        ClearMessages();
+        try
+        {
+            var deleted = await OptionsService.TryDeleteAsync(optionId, CancellationToken.None);
+            if (deleted)
+            {
+                statusMessage = "Výbava smazána.";
+                await ReloadOptionsAsync();
+            }
+            else
+            {
+                errorMessage = "Nelze smazat: výbava je použita u některých přihlášek.";
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = "Smazání selhalo: " + ex.Message;
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task CopyFromAsync()
+    {
+        if (isBusy || copySourceGameId <= 0) return;
+        isBusy = true;
+        ClearMessages();
+        try
+        {
+            await OptionsService.CopyFromGameAsync(
+                copySourceGameId, GameId, CancellationToken.None);
+            statusMessage = "Výbava zkopírována (existující klíče byly přeskočeny).";
+            copySourceGameId = 0;
+            await ReloadOptionsAsync();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = "Kopírování selhalo: " + ex.Message;
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private void ClearMessages()
+    {
+        statusMessage = null;
+        errorMessage = null;
+    }
+}

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/StartingEquipmentOptions.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/StartingEquipmentOptions.razor
@@ -54,6 +54,13 @@ else
             <button type="button" class="btn btn-primary" @onclick="ShowAddForm" disabled="@isBusy">
                 + Přidat novou výbavu
             </button>
+            @if (options.Count == 0)
+            {
+                <button type="button" class="btn btn-outline-primary ms-2"
+                        @onclick="SeedDefaultsAsync" disabled="@isBusy">
+                    Vložit výchozí výbavu
+                </button>
+            }
         }
         else
         {
@@ -403,6 +410,31 @@ else
         catch (Exception ex)
         {
             errorMessage = "Smazání selhalo: " + ex.Message;
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task SeedDefaultsAsync()
+    {
+        if (isBusy) return;
+        isBusy = true;
+        ClearMessages();
+        try
+        {
+            await OptionsService.SeedDefaultsAsync(GameId, CancellationToken.None);
+            statusMessage = "Výchozí výbava byla vložena (5 položek).";
+            await ReloadOptionsAsync();
+        }
+        catch (InvalidOperationException ex)
+        {
+            errorMessage = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            errorMessage = "Vložení výchozí výbavy selhalo: " + ex.Message;
         }
         finally
         {

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/SubmissionDetail.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/SubmissionDetail.razor
@@ -1,7 +1,18 @@
 @page "/organizace/prihlasky/{submissionId:int}"
 @attribute [Authorize(Policy = AuthorizationPolicies.StaffOnly)]
+@rendermode InteractiveServer
+
+@using Microsoft.EntityFrameworkCore
+@using RegistraceOvcina.Web.Features.CharacterPrep
 
 @inject OrganizerSubmissionService OrganizerSubmissionService
+@inject CharacterPrepService CharacterPrepService
+@inject CharacterPrepTokenService CharacterPrepTokenService
+@inject CharacterPrepMailService CharacterPrepMailService
+@inject IOptions<CharacterPrepOptions> CharacterPrepOptionsAccessor
+@inject IDbContextFactory<ApplicationDbContext> DbContextFactory
+@inject IJSRuntime JS
+@inject TimeProvider TimeProvider
 
 <PageTitle>Přihláška #@SubmissionId</PageTitle>
 
@@ -152,6 +163,98 @@ else
                     }
                 </div>
             </section>
+
+            @* Character prep section *@
+            <section class="card shadow-sm mb-4" data-testid="character-prep-section">
+                <div class="card-body p-4">
+                    <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+                        <h2 class="h5 mb-0">Příprava postav</h2>
+                        <span class="badge @GetPrepStatusBadgeClass(prepStatus) fs-6" data-testid="prep-status-badge">
+                            @GetPrepStatusLabel(prepStatus)
+                        </span>
+                    </div>
+
+                    @if (gameId.HasValue)
+                    {
+                        <a href="/organizace/hry/@gameId/priprava-postav" class="small text-decoration-none d-inline-block mb-3">
+                            Zobrazit přehled přípravy postav &rarr;
+                        </a>
+                    }
+
+                    @if (!string.IsNullOrWhiteSpace(prepMessage))
+                    {
+                        <div class="alert alert-success small py-2" role="status">@prepMessage</div>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(prepError))
+                    {
+                        <div class="alert alert-danger small py-2" role="alert">@prepError</div>
+                    }
+
+                    <div class="mb-3">
+                        <label class="form-label small text-secondary mb-1">Odkaz pro rodiče</label>
+                        @if (string.IsNullOrEmpty(prepToken))
+                        {
+                            <div class="d-flex gap-2 align-items-center">
+                                <span class="text-secondary small flex-grow-1">Odkaz zatím nebyl vygenerován.</span>
+                                <button type="button" class="btn btn-sm btn-outline-primary"
+                                        @onclick="GenerateLinkAsync" disabled="@prepBusy"
+                                        data-testid="generate-link-btn">
+                                    Vygenerovat odkaz
+                                </button>
+                            </div>
+                        }
+                        else
+                        {
+                            <div class="input-group input-group-sm">
+                                <input type="text" class="form-control" readonly value="@PrepUrl"
+                                       data-testid="prep-url-input" />
+                                <button type="button" class="btn btn-outline-secondary"
+                                        @onclick="CopyLinkAsync"
+                                        data-testid="copy-link-btn">
+                                    Kopírovat
+                                </button>
+                            </div>
+                        }
+                    </div>
+
+                    @if (prepInvitedAtUtc.HasValue || prepReminderAtUtc.HasValue)
+                    {
+                        <dl class="row small mb-3">
+                            @if (prepInvitedAtUtc.HasValue)
+                            {
+                                <dt class="col-sm-5 text-secondary">Pozvaná</dt>
+                                <dd class="col-sm-7">@CzechTime.Format(prepInvitedAtUtc.Value.UtcDateTime)</dd>
+                            }
+                            @if (prepReminderAtUtc.HasValue)
+                            {
+                                <dt class="col-sm-5 text-secondary">Naposledy připomenuta</dt>
+                                <dd class="col-sm-7">@CzechTime.Format(prepReminderAtUtc.Value.UtcDateTime)</dd>
+                            }
+                        </dl>
+                    }
+
+                    <div class="d-flex flex-wrap gap-2">
+                        <button type="button" class="btn btn-sm btn-primary"
+                                @onclick="SendInvitationAsync"
+                                disabled="@(prepBusy || prepInvitedAtUtc.HasValue || GameStarted)"
+                                data-testid="send-pozvanka-btn">
+                            Poslat pozvánku
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-primary"
+                                @onclick="SendReminderAsync"
+                                disabled="@(prepBusy || !CanSendReminder)"
+                                data-testid="send-pripominka-btn">
+                            Poslat připomínku
+                        </button>
+                        <button type="button" class="btn btn-sm btn-outline-danger ms-auto"
+                                @onclick="RegenerateLinkAsync"
+                                disabled="@(prepBusy || string.IsNullOrEmpty(prepToken))"
+                                data-testid="rotate-link-btn">
+                            Vygenerovat nový odkaz
+                        </button>
+                    </div>
+                </div>
+            </section>
         </div>
 
         @* Right column — sidebar *@
@@ -292,10 +395,211 @@ else
     private string? statusMessage;
     private string? errorMessage;
 
+    // --- Character prep state ---
+    private int? gameId;
+    private DateTime? gameStartsAtUtc;
+    private string? prepToken;
+    private DateTimeOffset? prepInvitedAtUtc;
+    private DateTimeOffset? prepReminderAtUtc;
+    private CharacterPrepStatus? prepStatus;
+    private string? prepMessage;
+    private string? prepError;
+    private bool prepBusy;
+
+    private bool GameStarted =>
+        gameStartsAtUtc.HasValue && gameStartsAtUtc.Value <= TimeProvider.GetUtcNow().UtcDateTime;
+
+    private bool CanSendReminder
+    {
+        get
+        {
+            if (!prepInvitedAtUtc.HasValue || GameStarted)
+            {
+                return false;
+            }
+            if (prepReminderAtUtc is { } last)
+            {
+                var threshold = TimeProvider.GetUtcNow().AddHours(-24);
+                if (last >= threshold)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    private string PrepUrl
+    {
+        get
+        {
+            var baseUrl = (CharacterPrepOptionsAccessor.Value.PublicBaseUrl ?? "").TrimEnd('/');
+            return string.IsNullOrEmpty(prepToken) ? "" : $"{baseUrl}/postavy/{prepToken}";
+        }
+    }
+
     protected override async Task OnInitializedAsync()
     {
         detail = await OrganizerSubmissionService.GetSubmissionDetailAsync(SubmissionId);
+        await LoadCharacterPrepStateAsync();
     }
+
+    private async Task LoadCharacterPrepStateAsync()
+    {
+        await using var db = await DbContextFactory.CreateDbContextAsync();
+        var row = await db.RegistrationSubmissions
+            .AsNoTracking()
+            .Where(x => x.Id == SubmissionId)
+            .Select(x => new
+            {
+                x.GameId,
+                x.CharacterPrepToken,
+                x.CharacterPrepInvitedAtUtc,
+                x.CharacterPrepReminderLastSentAtUtc,
+                GameStartsAtUtc = x.Game.StartsAtUtc,
+            })
+            .FirstOrDefaultAsync();
+
+        if (row is null)
+        {
+            return;
+        }
+
+        gameId = row.GameId;
+        gameStartsAtUtc = row.GameStartsAtUtc;
+        prepToken = row.CharacterPrepToken;
+        prepInvitedAtUtc = row.CharacterPrepInvitedAtUtc;
+        prepReminderAtUtc = row.CharacterPrepReminderLastSentAtUtc;
+        prepStatus = await CharacterPrepService.GetSubmissionStatusAsync(SubmissionId, CancellationToken.None);
+    }
+
+    private async Task GenerateLinkAsync()
+    {
+        await RunPrepActionAsync(async () =>
+        {
+            prepToken = await CharacterPrepTokenService.EnsureTokenAsync(SubmissionId, CancellationToken.None);
+            prepMessage = "Odkaz byl vygenerován.";
+        });
+    }
+
+    private async Task CopyLinkAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", PrepUrl);
+            prepMessage = "Odkaz byl zkopírován do schránky.";
+            prepError = null;
+        }
+        catch (Exception ex)
+        {
+            prepError = $"Kopírování se nezdařilo: {ex.Message}";
+            prepMessage = null;
+        }
+    }
+
+    private async Task SendInvitationAsync()
+    {
+        await RunPrepActionAsync(async () =>
+        {
+            var result = await CharacterPrepMailService.SendPozvankaAsync(
+                SubmissionId,
+                TimeProvider.GetUtcNow(),
+                CancellationToken.None);
+            ApplySendResult(result, wasReminder: false);
+            await LoadCharacterPrepStateAsync();
+        });
+    }
+
+    private async Task SendReminderAsync()
+    {
+        await RunPrepActionAsync(async () =>
+        {
+            var result = await CharacterPrepMailService.SendPripominkaAsync(
+                SubmissionId,
+                TimeProvider.GetUtcNow(),
+                CancellationToken.None);
+            ApplySendResult(result, wasReminder: true);
+            await LoadCharacterPrepStateAsync();
+        });
+    }
+
+    private async Task RegenerateLinkAsync()
+    {
+        var confirmed = await JS.InvokeAsync<bool>("confirm",
+            "Tím zneplatníš stávající odkaz. Pokračovat?");
+        if (!confirmed)
+        {
+            return;
+        }
+
+        await RunPrepActionAsync(async () =>
+        {
+            prepToken = await CharacterPrepTokenService.RotateTokenAsync(SubmissionId, CancellationToken.None);
+            prepMessage = "Odkaz vygenerován, starý je neplatný.";
+        });
+    }
+
+    private async Task RunPrepActionAsync(Func<Task> action)
+    {
+        if (prepBusy)
+        {
+            return;
+        }
+        prepBusy = true;
+        prepMessage = null;
+        prepError = null;
+        try
+        {
+            await action();
+        }
+        catch (Exception ex)
+        {
+            prepError = $"Akci se nepodařilo dokončit: {ex.Message}";
+        }
+        finally
+        {
+            prepBusy = false;
+        }
+    }
+
+    private void ApplySendResult(SendSingleResult result, bool wasReminder)
+    {
+        switch (result)
+        {
+            case SendSingleResult.Sent:
+                prepMessage = wasReminder ? "Připomínka odeslána." : "Pozvánka odeslána.";
+                break;
+            case SendSingleResult.AlreadyInvited:
+                prepError = "Pozvánka již byla odeslána dříve.";
+                break;
+            case SendSingleResult.ThrottledSkipped:
+                prepError = "Připomínka byla odeslána v posledních 24 hodinách, počkej.";
+                break;
+            case SendSingleResult.MissingRecipient:
+                prepError = "Chybí e-mail příjemce — nelze odeslat.";
+                break;
+            case SendSingleResult.Error:
+            default:
+                prepError = "Odeslání se nezdařilo. Zkus to znovu nebo zkontroluj log.";
+                break;
+        }
+    }
+
+    private static string GetPrepStatusLabel(CharacterPrepStatus? status) => status switch
+    {
+        CharacterPrepStatus.NotInvited => "Nezváno",
+        CharacterPrepStatus.Waiting => "Čeká",
+        CharacterPrepStatus.Done => "Hotovo",
+        _ => "—"
+    };
+
+    private static string GetPrepStatusBadgeClass(CharacterPrepStatus? status) => status switch
+    {
+        CharacterPrepStatus.NotInvited => "text-bg-secondary",
+        CharacterPrepStatus.Waiting => "text-bg-warning",
+        CharacterPrepStatus.Done => "text-bg-success",
+        _ => "text-bg-light"
+    };
 
     protected override void OnParametersSet()
     {

--- a/src/RegistraceOvcina.Web/Data/ApplicationDbContext.cs
+++ b/src/RegistraceOvcina.Web/Data/ApplicationDbContext.cs
@@ -31,6 +31,7 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
     public DbSet<Registration> Registrations => Set<Registration>();
     public DbSet<Room> Rooms => Set<Room>();
     public DbSet<RegistrationSubmission> RegistrationSubmissions => Set<RegistrationSubmission>();
+    public DbSet<StartingEquipmentOption> StartingEquipmentOptions => Set<StartingEquipmentOption>();
     public DbSet<Announcement> Announcements => Set<Announcement>();
     public DbSet<AnnouncementDismissal> AnnouncementDismissals => Set<AnnouncementDismissal>();
     public DbSet<ExternalContact> ExternalContacts => Set<ExternalContact>();
@@ -143,6 +144,10 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
                 .WithOne(x => x.Submission)
                 .HasForeignKey(x => x.SubmissionId)
                 .OnDelete(DeleteBehavior.Restrict);
+            entity.Property(x => x.CharacterPrepToken).HasMaxLength(64);
+            entity.HasIndex(x => x.CharacterPrepToken)
+                .IsUnique()
+                .HasFilter("\"CharacterPrepToken\" IS NOT NULL");
         });
 
         builder.Entity<Registration>(entity =>
@@ -174,6 +179,11 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
                 .WithOne(x => x.Registration)
                 .HasForeignKey(x => x.RegistrationId)
                 .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(x => x.CharacterPrepNote).HasMaxLength(4000);
+            entity.HasOne(x => x.StartingEquipmentOption)
+                .WithMany()
+                .HasForeignKey(x => x.StartingEquipmentOptionId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
 
         builder.Entity<Character>(entity =>
@@ -438,6 +448,19 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
             entity.HasOne(x => x.User)
                 .WithMany(x => x.AlternateEmails)
                 .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        builder.Entity<StartingEquipmentOption>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Key).HasMaxLength(50).IsRequired();
+            entity.Property(x => x.DisplayName).HasMaxLength(100).IsRequired();
+            entity.Property(x => x.Description).HasMaxLength(500);
+            entity.HasIndex(x => new { x.GameId, x.Key }).IsUnique();
+            entity.HasOne(x => x.Game)
+                .WithMany()
+                .HasForeignKey(x => x.GameId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
     }

--- a/src/RegistraceOvcina.Web/Data/ApplicationDbContext.cs
+++ b/src/RegistraceOvcina.Web/Data/ApplicationDbContext.cs
@@ -461,7 +461,7 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
             entity.HasOne(x => x.Game)
                 .WithMany()
                 .HasForeignKey(x => x.GameId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.Restrict);
         });
     }
 }

--- a/src/RegistraceOvcina.Web/Data/Models/Registration.cs
+++ b/src/RegistraceOvcina.Web/Data/Models/Registration.cs
@@ -25,5 +25,9 @@ public sealed class Registration
     public Kingdom? PreferredKingdom { get; set; }
     public int? AssignedGameRoomId { get; set; }
     public GameRoom? AssignedGameRoom { get; set; }
+    public int? StartingEquipmentOptionId { get; set; }
+    public StartingEquipmentOption? StartingEquipmentOption { get; set; }
+    public string? CharacterPrepNote { get; set; }
+    public DateTimeOffset? CharacterPrepUpdatedAtUtc { get; set; }
     public List<FoodOrder> FoodOrders { get; set; } = [];
 }

--- a/src/RegistraceOvcina.Web/Data/Models/RegistrationSubmission.cs
+++ b/src/RegistraceOvcina.Web/Data/Models/RegistrationSubmission.cs
@@ -17,6 +17,9 @@ public sealed class RegistrationSubmission
     public decimal VoluntaryDonation { get; set; }
     public bool IsDeleted { get; set; }
     public string? PaymentVariableSymbol { get; set; }
+    public string? CharacterPrepToken { get; set; }
+    public DateTimeOffset? CharacterPrepInvitedAtUtc { get; set; }
+    public DateTimeOffset? CharacterPrepReminderLastSentAtUtc { get; set; }
     public Game Game { get; set; } = default!;
     public List<Registration> Registrations { get; set; } = [];
     public List<Payment> Payments { get; set; } = [];

--- a/src/RegistraceOvcina.Web/Data/Models/StartingEquipmentOption.cs
+++ b/src/RegistraceOvcina.Web/Data/Models/StartingEquipmentOption.cs
@@ -1,0 +1,12 @@
+namespace RegistraceOvcina.Web.Data;
+
+public sealed class StartingEquipmentOption
+{
+    public int Id { get; set; }
+    public int GameId { get; set; }
+    public string Key { get; set; } = "";
+    public string DisplayName { get; set; } = "";
+    public string? Description { get; set; }
+    public int SortOrder { get; set; }
+    public Game Game { get; set; } = default!;
+}

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepEmailRenderer.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepEmailRenderer.cs
@@ -88,7 +88,12 @@ public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
     {
         var encodedUrl = UnicodeHtmlEncoder.Encode(model.PrepUrl);
         var encodedGame = UnicodeHtmlEncoder.Encode(model.GameName);
-        var encodedContact = UnicodeHtmlEncoder.Encode(model.OrganizerContactEmail);
+        // Contact is optional; when blank the "napiš nám" sentence is suppressed
+        // below so we never emit <a href="mailto:"></a>.
+        var hasContact = !string.IsNullOrWhiteSpace(model.OrganizerContactEmail);
+        var encodedContact = hasContact
+            ? UnicodeHtmlEncoder.Encode(model.OrganizerContactEmail)
+            : "";
 
         var sb = new StringBuilder(2048);
 
@@ -137,9 +142,13 @@ public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
         // Deadline
         sb.Append("<p>Prosíme do <b>").Append(deadline).Append("</b>.</p>");
 
-        // Organizer contact
-        sb.Append("<p>Když něco nefunguje, napiš nám na ")
-          .Append("<a href=\"mailto:").Append(encodedContact).Append("\">").Append(encodedContact).Append("</a>.</p>");
+        // Organizer contact — only render when we actually have an address, otherwise
+        // we'd emit <a href="mailto:"></a> which some clients render as a dead link.
+        if (hasContact)
+        {
+            sb.Append("<p>Když něco nefunguje, napiš nám na ")
+              .Append("<a href=\"mailto:").Append(encodedContact).Append("\">").Append(encodedContact).Append("</a>.</p>");
+        }
 
         sb.Append("<p>Díky!<br/>—Organizátoři</p>");
         sb.Append("</div>");
@@ -183,8 +192,11 @@ public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
         sb.AppendLine();
         sb.Append("Prosíme do ").Append(deadline).AppendLine(".");
         sb.AppendLine();
-        sb.Append("Když něco nefunguje, napiš nám na ").Append(model.OrganizerContactEmail).AppendLine(".");
-        sb.AppendLine();
+        if (!string.IsNullOrWhiteSpace(model.OrganizerContactEmail))
+        {
+            sb.Append("Když něco nefunguje, napiš nám na ").Append(model.OrganizerContactEmail).AppendLine(".");
+            sb.AppendLine();
+        }
         sb.AppendLine("Díky!");
         sb.Append("—Organizátoři");
 

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepEmailRenderer.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepEmailRenderer.cs
@@ -1,0 +1,193 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Unicode;
+
+namespace RegistraceOvcina.Web.Features.CharacterPrep;
+
+/// <summary>
+/// Immutable outcome of rendering a Character Prep email: both an HTML body (for mail clients
+/// that render it) and a plain-text fallback (for clients that don't).
+/// </summary>
+public sealed record RenderedEmail(string Subject, string HtmlBody, string PlainTextBody);
+
+/// <summary>
+/// Everything the renderer needs to produce a Pozvánka or Připomínka email. Kept as a flat
+/// record so the mail service can build it from the domain without the renderer touching EF.
+/// </summary>
+public sealed record CharacterPrepEmailModel(
+    string GameName,
+    DateTime GameStartDateUtc,
+    string PrepUrl,
+    IReadOnlyList<string> PlayerFullNames,
+    IReadOnlyList<StartingEquipmentOptionView> Options,
+    string OrganizerContactEmail);
+
+public interface ICharacterPrepEmailRenderer
+{
+    RenderedEmail RenderPozvanka(CharacterPrepEmailModel model);
+    RenderedEmail RenderPripominka(CharacterPrepEmailModel model);
+}
+
+/// <summary>
+/// String-interpolation email renderer. We intentionally avoid Razor/MJML here because the
+/// existing project email path (see <c>InvitationService</c> and <c>InboxService</c>) uses
+/// raw HTML over the Graph <c>sendMail</c> endpoint — keeping a single rendering style keeps
+/// debugging consistent with what already works.
+/// </summary>
+public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
+{
+    // Czech locale for date formatting in the deadline line.
+    private static readonly CultureInfo CzCulture = new("cs-CZ");
+
+    // HtmlEncoder.Default escapes every non-ASCII character as &#x...; numeric entities,
+    // which is safe but turns Czech diacritics ("Dvořák") into opaque soup in the message
+    // source. We only need to neutralize the HTML special chars; UTF-8 carries the rest.
+    private static readonly HtmlEncoder UnicodeHtmlEncoder =
+        HtmlEncoder.Create(UnicodeRanges.All);
+
+    public RenderedEmail RenderPozvanka(CharacterPrepEmailModel model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        var subject = $"Příprava postav pro {model.GameName} — vyber startovní výbavu";
+        // Deadline = 3 days before game start; formatted "d. M. yyyy" (Czech short date).
+        var deadline = model.GameStartDateUtc.AddDays(-3).ToString("d. M. yyyy", CzCulture);
+
+        var html = BuildPozvankaHtml(model, deadline);
+        var plain = BuildPozvankaPlain(model, deadline);
+
+        return new RenderedEmail(subject, html, plain);
+    }
+
+    public RenderedEmail RenderPripominka(CharacterPrepEmailModel model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        var subject = $"Připomínka: příprava postav pro {model.GameName}";
+
+        var encodedUrl = UnicodeHtmlEncoder.Encode(model.PrepUrl);
+        var html = new StringBuilder()
+            .Append("<p>Ahoj, neviděli jsme tě ještě na stránce s přípravou postav. ")
+            .Append("Odkaz je tady: ")
+            .Append("<a href=\"").Append(encodedUrl).Append("\">").Append(encodedUrl).Append("</a>. ")
+            .Append("Díky!<br/>—Organizátoři</p>")
+            .ToString();
+
+        var plain = new StringBuilder()
+            .AppendLine("Ahoj, neviděli jsme tě ještě na stránce s přípravou postav.")
+            .AppendLine($"Odkaz je tady: {model.PrepUrl}")
+            .AppendLine("Díky!")
+            .Append("—Organizátoři")
+            .ToString();
+
+        return new RenderedEmail(subject, html, plain);
+    }
+
+    private static string BuildPozvankaHtml(CharacterPrepEmailModel model, string deadline)
+    {
+        var encodedUrl = UnicodeHtmlEncoder.Encode(model.PrepUrl);
+        var encodedGame = UnicodeHtmlEncoder.Encode(model.GameName);
+        var encodedContact = UnicodeHtmlEncoder.Encode(model.OrganizerContactEmail);
+
+        var sb = new StringBuilder(2048);
+
+        sb.Append("<div style=\"font-family:Segoe UI,Arial,sans-serif;font-size:14px;line-height:1.5;color:#222;\">");
+
+        sb.Append("<p>Ahoj,</p>");
+        sb.Append("<p>chystáme <b>").Append(encodedGame).Append("</b> a potřebujeme od tebe krátkou přípravu postav. ")
+          .Append("Díky tomu si u vstupu na hru nezdržíme 30 minut startovní výbavou a hra může začít včas.</p>");
+
+        // Household player list
+        if (model.PlayerFullNames.Count > 0)
+        {
+            sb.Append("<p>Píšeme ti o těchto dětech:</p>");
+            sb.Append("<ul>");
+            foreach (var name in model.PlayerFullNames)
+            {
+                sb.Append("<li>").Append(UnicodeHtmlEncoder.Encode(name)).Append("</li>");
+            }
+            sb.Append("</ul>");
+        }
+
+        // Equipment options
+        sb.Append("<p>Vyber pro každé dítě jednu ze startovních výbav:</p>");
+        sb.Append("<ul>");
+        foreach (var option in model.Options)
+        {
+            sb.Append("<li><b>").Append(UnicodeHtmlEncoder.Encode(option.DisplayName)).Append("</b>");
+            if (!string.IsNullOrWhiteSpace(option.Description))
+            {
+                sb.Append(" — ").Append(UnicodeHtmlEncoder.Encode(option.Description));
+            }
+            sb.Append("</li>");
+        }
+        sb.Append("</ul>");
+
+        // CTA button + fallback plain URL
+        sb.Append("<p style=\"margin:24px 0;\">")
+          .Append("<a href=\"").Append(encodedUrl).Append("\" ")
+          .Append("style=\"background:#2b6cb0;color:#fff;padding:10px 18px;text-decoration:none;border-radius:4px;display:inline-block;\">")
+          .Append("Otevřít přípravu postav</a></p>");
+        sb.Append("<p style=\"font-size:12px;color:#666;\">")
+          .Append("Pokud tlačítko nefunguje, zkopíruj si tento odkaz do prohlížeče:<br/>")
+          .Append("<a href=\"").Append(encodedUrl).Append("\">").Append(encodedUrl).Append("</a>")
+          .Append("</p>");
+
+        // Deadline
+        sb.Append("<p>Prosíme do <b>").Append(deadline).Append("</b>.</p>");
+
+        // Organizer contact
+        sb.Append("<p>Když něco nefunguje, napiš nám na ")
+          .Append("<a href=\"mailto:").Append(encodedContact).Append("\">").Append(encodedContact).Append("</a>.</p>");
+
+        sb.Append("<p>Díky!<br/>—Organizátoři</p>");
+        sb.Append("</div>");
+
+        return sb.ToString();
+    }
+
+    private static string BuildPozvankaPlain(CharacterPrepEmailModel model, string deadline)
+    {
+        var sb = new StringBuilder(1024);
+
+        sb.AppendLine("Ahoj,");
+        sb.AppendLine();
+        sb.Append("chystáme ").Append(model.GameName).AppendLine(" a potřebujeme od tebe krátkou přípravu postav.");
+        sb.AppendLine("Díky tomu si u vstupu na hru nezdržíme 30 minut startovní výbavou a hra může začít včas.");
+        sb.AppendLine();
+
+        if (model.PlayerFullNames.Count > 0)
+        {
+            sb.AppendLine("Píšeme ti o těchto dětech:");
+            foreach (var name in model.PlayerFullNames)
+            {
+                sb.Append(" - ").AppendLine(name);
+            }
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("Vyber pro každé dítě jednu ze startovních výbav:");
+        foreach (var option in model.Options)
+        {
+            sb.Append(" - ").Append(option.DisplayName);
+            if (!string.IsNullOrWhiteSpace(option.Description))
+            {
+                sb.Append(" — ").Append(option.Description);
+            }
+            sb.AppendLine();
+        }
+        sb.AppendLine();
+
+        sb.Append("Odkaz na přípravu: ").AppendLine(model.PrepUrl);
+        sb.AppendLine();
+        sb.Append("Prosíme do ").Append(deadline).AppendLine(".");
+        sb.AppendLine();
+        sb.Append("Když něco nefunguje, napiš nám na ").Append(model.OrganizerContactEmail).AppendLine(".");
+        sb.AppendLine();
+        sb.AppendLine("Díky!");
+        sb.Append("—Organizátoři");
+
+        return sb.ToString();
+    }
+}

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepExportService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepExportService.cs
@@ -17,15 +17,8 @@ public sealed class CharacterPrepExportService(
     {
         await using var db = await dbContextFactory.CreateDbContextAsync(ct);
 
-        // Game is loaded primarily so the caller (endpoint) can use Name for
-        // the filename slug; keeping it out of the sheet keeps the layout
-        // simple and focused on one household per row.
-        _ = await db.Games
-            .AsNoTracking()
-            .Where(x => x.Id == gameId)
-            .Select(x => x.Name)
-            .FirstOrDefaultAsync(ct);
-
+        // Note: the game name is loaded by the HTTP endpoint (Program.cs) for the
+        // filename slug. This service focuses purely on building the sheet bytes.
         var rows = await db.Registrations
             .AsNoTracking()
             .Where(x => x.Submission.GameId == gameId && x.AttendeeType == AttendeeType.Player)

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepExportService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepExportService.cs
@@ -1,0 +1,110 @@
+using ClosedXML.Excel;
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Features.CharacterPrep;
+
+/// <summary>
+/// Builds an XLSX export of character-prep rows for an entire game. Mirrors
+/// the pattern established by <see cref="Kingdoms.KingdomExportService"/>:
+/// a single ClosedXML workbook returned as a byte array, with the HTTP
+/// endpoint (see Program.cs) wrapping it in <c>Results.File(...)</c>.
+/// </summary>
+public sealed class CharacterPrepExportService(
+    IDbContextFactory<ApplicationDbContext> dbContextFactory)
+{
+    public async Task<byte[]> BuildAsync(int gameId, CancellationToken ct)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
+        // Game is loaded primarily so the caller (endpoint) can use Name for
+        // the filename slug; keeping it out of the sheet keeps the layout
+        // simple and focused on one household per row.
+        _ = await db.Games
+            .AsNoTracking()
+            .Where(x => x.Id == gameId)
+            .Select(x => x.Name)
+            .FirstOrDefaultAsync(ct);
+
+        var rows = await db.Registrations
+            .AsNoTracking()
+            .Where(x => x.Submission.GameId == gameId && x.AttendeeType == AttendeeType.Player)
+            .OrderBy(x => x.Person.LastName)
+            .ThenBy(x => x.Person.FirstName)
+            .Select(x => new ExportRow(
+                x.Person.FirstName + " " + x.Person.LastName,
+                x.Person.BirthYear,
+                x.CharacterName,
+                x.StartingEquipmentOption != null ? x.StartingEquipmentOption.DisplayName : null,
+                x.CharacterPrepNote,
+                x.Submission.PrimaryContactName,
+                x.Submission.PrimaryEmail))
+            .ToListAsync(ct);
+
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Příprava postav");
+
+        string[] headers =
+        [
+            "Hráč",
+            "Rok narození",
+            "Jméno postavy",
+            "Startovní výbava",
+            "Poznámka",
+            "Domácnost",
+            "Email domácnosti",
+        ];
+
+        for (var h = 0; h < headers.Length; h++)
+        {
+            sheet.Cell(1, h + 1).Value = headers[h];
+            sheet.Cell(1, h + 1).Style.Font.Bold = true;
+        }
+
+        for (var r = 0; r < rows.Count; r++)
+        {
+            var row = rows[r];
+            var xlRow = r + 2;
+
+            sheet.Cell(xlRow, 1).Value = row.PersonFullName;
+            sheet.Cell(xlRow, 2).Value = row.BirthYear;
+
+            // Empty cells stay truly empty — do not write "" or "—" placeholders.
+            if (!string.IsNullOrEmpty(row.CharacterName))
+            {
+                sheet.Cell(xlRow, 3).Value = row.CharacterName;
+            }
+
+            if (!string.IsNullOrEmpty(row.EquipmentDisplayName))
+            {
+                sheet.Cell(xlRow, 4).Value = row.EquipmentDisplayName;
+            }
+
+            if (!string.IsNullOrEmpty(row.CharacterPrepNote))
+            {
+                sheet.Cell(xlRow, 5).Value = row.CharacterPrepNote;
+            }
+
+            sheet.Cell(xlRow, 6).Value = row.PrimaryContactName;
+            sheet.Cell(xlRow, 7).Value = row.PrimaryEmail;
+        }
+
+        // Formatting: frozen header, autofilter on header, auto-width capped at 40 chars.
+        sheet.SheetView.FreezeRows(1);
+        sheet.RangeUsed()!.SetAutoFilter();
+        sheet.Columns().AdjustToContents(1, rows.Count + 1, 8, 40);
+
+        using var stream = new MemoryStream();
+        workbook.SaveAs(stream);
+        return stream.ToArray();
+    }
+
+    private sealed record ExportRow(
+        string PersonFullName,
+        int BirthYear,
+        string? CharacterName,
+        string? EquipmentDisplayName,
+        string? CharacterPrepNote,
+        string PrimaryContactName,
+        string PrimaryEmail);
+}

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepMailService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepMailService.cs
@@ -86,7 +86,7 @@ public sealed class CharacterPrepMailService(
 
             return SendSingleResult.Sent;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "SendPozvankaAsync failed for submission {SubmissionId}", submissionId);
             return SendSingleResult.Error;
@@ -150,7 +150,7 @@ public sealed class CharacterPrepMailService(
 
             return SendSingleResult.Sent;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "SendPripominkaAsync failed for submission {SubmissionId}", submissionId);
             return SendSingleResult.Error;
@@ -265,9 +265,23 @@ public sealed class CharacterPrepMailService(
         }
 
         var prepUrl = $"{baseUrl}/postavy/{token}";
-        var organizerContact = options.OrganizerContactEmail
-            ?? mailboxOptions?.Value.SharedMailboxAddress
-            ?? "";
+
+        // OrganizerContactEmail is optional; fall back to the shared mailbox address.
+        // When both are blank, the renderer suppresses the contact sentence entirely
+        // so we never emit <a href="mailto:"> / empty mailto links in outbound mail.
+        var organizerContact =
+            !string.IsNullOrWhiteSpace(options.OrganizerContactEmail)
+                ? options.OrganizerContactEmail
+                : !string.IsNullOrWhiteSpace(mailboxOptions?.Value.SharedMailboxAddress)
+                    ? mailboxOptions.Value.SharedMailboxAddress
+                    : "";
+
+        if (string.IsNullOrWhiteSpace(organizerContact))
+        {
+            logger.LogWarning(
+                "CharacterPrep: no OrganizerContactEmail or SharedMailboxAddress configured; "
+                + "outbound mail will omit the organizer contact sentence.");
+        }
 
         return new CharacterPrepEmailModel(
             ctx.Game.Name,

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepMailService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepMailService.cs
@@ -1,0 +1,309 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.Email;
+
+namespace RegistraceOvcina.Web.Features.CharacterPrep;
+
+/// <summary>
+/// Outcome of a single-submission send attempt. Explicit enum (not throw-on-failure) so
+/// callers — especially the bulk organizer UI — can show per-row feedback without wrapping
+/// every call in a try/catch. <see cref="Error"/> is used for unexpected exceptions AND
+/// for the "reminder-before-invite" guard.
+/// </summary>
+public enum SendSingleResult
+{
+    Sent,
+    AlreadyInvited,
+    ThrottledSkipped,
+    MissingRecipient,
+    Error
+}
+
+public sealed record BulkSendResult(int Sent, int Failed, string? FirstError);
+
+/// <summary>
+/// Orchestrates the Character Prep outbound mail flow: token minting, rendering, Graph
+/// dispatch, outbox logging via <see cref="EmailMessage"/>, and timestamp marking on the
+/// submission. Single-send variants are idempotent and throttle-aware so the bulk variants
+/// can simply iterate targets from the Phase 2 filter methods.
+/// </summary>
+public sealed class CharacterPrepMailService(
+    IDbContextFactory<ApplicationDbContext> dbContextFactory,
+    ICharacterPrepEmailRenderer renderer,
+    CharacterPrepTokenService tokenService,
+    CharacterPrepService prepService,
+    ICharacterPrepEmailSender sender,
+    IOptions<CharacterPrepOptions> prepOptions,
+    ILogger<CharacterPrepMailService> logger,
+    IOptions<MailboxEmailOptions>? mailboxOptions = null)
+{
+    public async Task<SendSingleResult> SendPozvankaAsync(
+        int submissionId,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        var context = await LoadContextAsync(submissionId, cancellationToken);
+        if (context is null)
+        {
+            logger.LogWarning("SendPozvankaAsync: submission {SubmissionId} not found", submissionId);
+            return SendSingleResult.Error;
+        }
+
+        if (string.IsNullOrWhiteSpace(context.Submission.PrimaryEmail))
+        {
+            return SendSingleResult.MissingRecipient;
+        }
+
+        if (context.Submission.CharacterPrepInvitedAtUtc is not null)
+        {
+            // Re-send is an explicit no-op so organizers get clear "already done" feedback
+            // instead of accidentally spamming households.
+            return SendSingleResult.AlreadyInvited;
+        }
+
+        try
+        {
+            var token = await tokenService.EnsureTokenAsync(context.Submission.Id, cancellationToken);
+            var model = BuildEmailModel(context, token);
+            var email = renderer.RenderPozvanka(model);
+
+            await sender.SendAsync(
+                context.Submission.PrimaryEmail,
+                email.Subject,
+                email.HtmlBody,
+                cancellationToken);
+
+            await LogOutboxAsync(
+                submissionId: context.Submission.Id,
+                to: context.Submission.PrimaryEmail,
+                subject: email.Subject,
+                bodyText: email.PlainTextBody,
+                sentAtUtc: nowUtc,
+                cancellationToken);
+
+            await prepService.MarkInvitedAsync(context.Submission.Id, nowUtc, cancellationToken);
+
+            return SendSingleResult.Sent;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "SendPozvankaAsync failed for submission {SubmissionId}", submissionId);
+            return SendSingleResult.Error;
+        }
+    }
+
+    public async Task<SendSingleResult> SendPripominkaAsync(
+        int submissionId,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        var context = await LoadContextAsync(submissionId, cancellationToken);
+        if (context is null)
+        {
+            logger.LogWarning("SendPripominkaAsync: submission {SubmissionId} not found", submissionId);
+            return SendSingleResult.Error;
+        }
+
+        if (string.IsNullOrWhiteSpace(context.Submission.PrimaryEmail))
+        {
+            return SendSingleResult.MissingRecipient;
+        }
+
+        if (context.Submission.CharacterPrepInvitedAtUtc is null)
+        {
+            // Reminders only go to households that got a Pozvánka. Keeps the two flows
+            // separate so organizers can't accidentally send a reminder as a first contact.
+            logger.LogDebug(
+                "SendPripominkaAsync: submission {SubmissionId} has no prior invite — refusing", submissionId);
+            return SendSingleResult.Error;
+        }
+
+        var threshold = nowUtc.AddHours(-24);
+        if (context.Submission.CharacterPrepReminderLastSentAtUtc is { } last && last >= threshold)
+        {
+            return SendSingleResult.ThrottledSkipped;
+        }
+
+        try
+        {
+            // Token must exist post-Pozvánka, but guard defensively if someone wipes it.
+            var token = await tokenService.EnsureTokenAsync(context.Submission.Id, cancellationToken);
+            var model = BuildEmailModel(context, token);
+            var email = renderer.RenderPripominka(model);
+
+            await sender.SendAsync(
+                context.Submission.PrimaryEmail,
+                email.Subject,
+                email.HtmlBody,
+                cancellationToken);
+
+            await LogOutboxAsync(
+                submissionId: context.Submission.Id,
+                to: context.Submission.PrimaryEmail,
+                subject: email.Subject,
+                bodyText: email.PlainTextBody,
+                sentAtUtc: nowUtc,
+                cancellationToken);
+
+            await prepService.MarkReminderSentAsync(context.Submission.Id, nowUtc, cancellationToken);
+
+            return SendSingleResult.Sent;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "SendPripominkaAsync failed for submission {SubmissionId}", submissionId);
+            return SendSingleResult.Error;
+        }
+    }
+
+    public async Task<BulkSendResult> SendBulkPozvankaAsync(
+        int gameId,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        var targets = await prepService.ListInvitationTargetsAsync(gameId, cancellationToken);
+        return await RunBulkAsync(targets, submissionId =>
+            SendPozvankaAsync(submissionId, nowUtc, cancellationToken), cancellationToken);
+    }
+
+    public async Task<BulkSendResult> SendBulkPripominkaAsync(
+        int gameId,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        var targets = await prepService.ListReminderTargetsAsync(gameId, nowUtc, cancellationToken);
+        return await RunBulkAsync(targets, submissionId =>
+            SendPripominkaAsync(submissionId, nowUtc, cancellationToken), cancellationToken);
+    }
+
+    // ------------------------------------------------------------ helpers
+
+    private async Task<BulkSendResult> RunBulkAsync(
+        IReadOnlyList<RegistrationSubmission> targets,
+        Func<int, Task<SendSingleResult>> sendOne,
+        CancellationToken cancellationToken)
+    {
+        var sent = 0;
+        var failed = 0;
+        string? firstError = null;
+
+        foreach (var submission in targets)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            var result = await sendOne(submission.Id);
+            switch (result)
+            {
+                case SendSingleResult.Sent:
+                    sent++;
+                    break;
+                case SendSingleResult.Error:
+                case SendSingleResult.MissingRecipient:
+                    failed++;
+                    firstError ??= $"Submission {submission.Id}: {result}";
+                    break;
+                case SendSingleResult.AlreadyInvited:
+                case SendSingleResult.ThrottledSkipped:
+                    // no-op; intentionally not counted as failure
+                    break;
+            }
+        }
+
+        return new BulkSendResult(sent, failed, firstError);
+    }
+
+    private async Task<LoadedContext?> LoadContextAsync(int submissionId, CancellationToken ct)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var submission = await db.RegistrationSubmissions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == submissionId, ct);
+        if (submission is null)
+        {
+            return null;
+        }
+
+        var game = await db.Games
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == submission.GameId, ct);
+        if (game is null)
+        {
+            return null;
+        }
+
+        var players = await db.Registrations
+            .AsNoTracking()
+            .Where(x => x.SubmissionId == submissionId && x.AttendeeType == AttendeeType.Player)
+            .OrderBy(x => x.Person.LastName).ThenBy(x => x.Person.FirstName)
+            .Select(x => x.Person.FirstName + " " + x.Person.LastName)
+            .ToListAsync(ct);
+
+        var options = await db.StartingEquipmentOptions
+            .AsNoTracking()
+            .Where(x => x.GameId == submission.GameId)
+            .OrderBy(x => x.SortOrder).ThenBy(x => x.DisplayName)
+            .Select(x => new StartingEquipmentOptionView(
+                x.Id, x.Key, x.DisplayName, x.Description, x.SortOrder))
+            .ToListAsync(ct);
+
+        return new LoadedContext(submission, game, players, options);
+    }
+
+    private CharacterPrepEmailModel BuildEmailModel(LoadedContext ctx, string token)
+    {
+        var options = prepOptions.Value;
+        var baseUrl = (options.PublicBaseUrl ?? "").TrimEnd('/');
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new InvalidOperationException(
+                "CharacterPrep:PublicBaseUrl is not configured; cannot build prep URL.");
+        }
+
+        var prepUrl = $"{baseUrl}/postavy/{token}";
+        var organizerContact = options.OrganizerContactEmail
+            ?? mailboxOptions?.Value.SharedMailboxAddress
+            ?? "";
+
+        return new CharacterPrepEmailModel(
+            ctx.Game.Name,
+            DateTime.SpecifyKind(ctx.Game.StartsAtUtc, DateTimeKind.Utc),
+            prepUrl,
+            ctx.PlayerNames,
+            ctx.Options,
+            organizerContact);
+    }
+
+    private async Task LogOutboxAsync(
+        int submissionId,
+        string to,
+        string subject,
+        string bodyText,
+        DateTimeOffset sentAtUtc,
+        CancellationToken ct)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+        db.EmailMessages.Add(new EmailMessage
+        {
+            MailboxItemId = $"prep-{Guid.NewGuid()}",
+            Direction = EmailDirection.Outbound,
+            From = mailboxOptions?.Value.SharedMailboxAddress ?? "",
+            To = to,
+            Subject = subject,
+            BodyText = bodyText,
+            SentAtUtc = sentAtUtc.UtcDateTime,
+            LinkedSubmissionId = submissionId
+        });
+        await db.SaveChangesAsync(ct);
+    }
+
+    private sealed record LoadedContext(
+        RegistrationSubmission Submission,
+        Game Game,
+        IReadOnlyList<string> PlayerNames,
+        IReadOnlyList<StartingEquipmentOptionView> Options);
+}

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepOptions.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepOptions.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace RegistraceOvcina.Web.Features.CharacterPrep;
 
 /// <summary>
@@ -11,11 +13,16 @@ public sealed class CharacterPrepOptions
 
     /// <summary>
     /// Absolute base URL, no trailing slash — e.g. <c>https://registrace.ovcina.cz</c>.
+    /// Required: validated on startup so a missing value surfaces as a clear bind error
+    /// instead of an <see cref="InvalidOperationException"/> at the first send attempt.
     /// </summary>
+    [Required]
     public string? PublicBaseUrl { get; set; }
 
     /// <summary>
-    /// Address shown in email footers as "napiš nám". Usually the shared organizer inbox.
+    /// Address shown in email footers as "napiš nám". Optional — the mail service falls
+    /// back to the shared mailbox address, and the renderer omits the contact sentence
+    /// entirely when no address is available.
     /// </summary>
     public string? OrganizerContactEmail { get; set; }
 }

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepOptions.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepOptions.cs
@@ -1,0 +1,21 @@
+namespace RegistraceOvcina.Web.Features.CharacterPrep;
+
+/// <summary>
+/// Configuration for the Character Prep feature. <see cref="PublicBaseUrl"/> is the
+/// absolute origin to prefix every <c>/postavy/{token}</c> link in outbound mail, so we
+/// don't depend on whichever host actually served the request that triggered the send.
+/// </summary>
+public sealed class CharacterPrepOptions
+{
+    public const string SectionName = "CharacterPrep";
+
+    /// <summary>
+    /// Absolute base URL, no trailing slash — e.g. <c>https://registrace.ovcina.cz</c>.
+    /// </summary>
+    public string? PublicBaseUrl { get; set; }
+
+    /// <summary>
+    /// Address shown in email footers as "napiš nám". Usually the shared organizer inbox.
+    /// </summary>
+    public string? OrganizerContactEmail { get; set; }
+}

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepOptionsService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepOptionsService.cs
@@ -278,6 +278,59 @@ public sealed class CharacterPrepOptionsService(
         }
     }
 
+    /// <summary>
+    /// Seeds the 5 canonical Ovčina equipment options (Tesák, Dlouhý nůž,
+    /// Vrhací nůž, Dýka+svitky, Mince) into <paramref name="gameId"/> in a
+    /// single <see cref="ApplicationDbContext.SaveChangesAsync(CancellationToken)"/>
+    /// call. Refuses to run if the game already has at least one option to
+    /// avoid silently duplicating or corrupting operator-authored rows; the
+    /// admin page also hides the trigger button in that case.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the game already has ≥1 <see cref="StartingEquipmentOption"/>.
+    /// </exception>
+    public async Task SeedDefaultsAsync(int gameId, CancellationToken cancellationToken)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var alreadyHasAny = await db.StartingEquipmentOptions
+            .AsNoTracking()
+            .AnyAsync(x => x.GameId == gameId, cancellationToken);
+        if (alreadyHasAny)
+        {
+            throw new InvalidOperationException(
+                "Hra již má nějakou výbavu — vlož nové ručně.");
+        }
+
+        // Exact Czech strings confirmed by the user — do not paraphrase.
+        var defaults = new (string Key, string DisplayName, string Description, int SortOrder)[]
+        {
+            ("tesak",        "Tesák (3/1)",                     "Útok 3, obrana 1",                  10),
+            ("dlouhy-nuz",   "Dlouhý nůž (2/2)",                "Útok 2, obrana 2",                  20),
+            ("vrhaci-nuz",   "Vrhací nůž (3/0)",                "Útok 3, obrana 0",                  30),
+            ("dyka-svitky",  "Dýka (1/2), 4 svitky kouzel",     "Útok 1, obrana 2 + 4 svitky kouzel", 40),
+            ("mince",        "5 měďáků / grošů",                "Žádná zbraň, 5 mincí do začátku",    50),
+        };
+
+        foreach (var row in defaults)
+        {
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                GameId = gameId,
+                Key = row.Key,
+                DisplayName = row.DisplayName,
+                Description = row.Description,
+                SortOrder = row.SortOrder
+            });
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Seeded {Count} default StartingEquipmentOption rows for game {GameId}.",
+            defaults.Length, gameId);
+    }
+
     private static string NormalizeKey(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepOptionsService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepOptionsService.cs
@@ -1,0 +1,301 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Features.CharacterPrep;
+
+/// <summary>
+/// Read/write surface for <see cref="StartingEquipmentOption"/> rows that
+/// back the Character-Prep card picker. Used by the organizer admin page at
+/// <c>/organizace/hry/{gameId}/priprava-postav/vybava</c>.
+/// </summary>
+/// <remarks>
+/// <para><c>Key</c> is the stable identifier and is normalized (trimmed +
+/// lower-cased) on create. <see cref="UpdateAsync"/> intentionally does not
+/// change it — parents' card selections reference the option by ID, but the
+/// key is used for copy-across-games de-duplication and should stay valid once
+/// chosen.</para>
+/// <para><see cref="TryDeleteAsync"/> is reference-guarded: an option that is
+/// attached to any <see cref="Registration"/> cannot be removed. The DB-side
+/// FK is <c>DeleteBehavior.Restrict</c>, so attempting to delete such a row
+/// would fail at SaveChanges anyway — we surface it as a user-friendly
+/// <c>false</c> return here rather than a thrown exception.</para>
+/// </remarks>
+public sealed record StartingEquipmentOptionDto(
+    int Id,
+    int GameId,
+    string Key,
+    string DisplayName,
+    string? Description,
+    int SortOrder);
+
+public sealed class CharacterPrepOptionsService(
+    IDbContextFactory<ApplicationDbContext> dbFactory,
+    ILogger<CharacterPrepOptionsService> logger)
+{
+    private const int KeyMaxLength = 50;
+    private const int DisplayNameMaxLength = 100;
+
+    /// <summary>
+    /// Lists every option for <paramref name="gameId"/> ordered by SortOrder,
+    /// with DisplayName as a tiebreaker so the picker is deterministic when
+    /// operators leave SortOrder at its default (0).
+    /// </summary>
+    public async Task<IReadOnlyList<StartingEquipmentOptionDto>> ListAsync(
+        int gameId,
+        CancellationToken cancellationToken)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        return await db.StartingEquipmentOptions
+            .AsNoTracking()
+            .Where(x => x.GameId == gameId)
+            .OrderBy(x => x.SortOrder)
+            .ThenBy(x => x.DisplayName)
+            .Select(x => new StartingEquipmentOptionDto(
+                x.Id, x.GameId, x.Key, x.DisplayName, x.Description, x.SortOrder))
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a new option for <paramref name="gameId"/>. Throws
+    /// <see cref="ArgumentException"/> for empty or over-long input,
+    /// <see cref="InvalidOperationException"/> if the normalized key already
+    /// exists on that game.
+    /// </summary>
+    public async Task<StartingEquipmentOptionDto> CreateAsync(
+        int gameId,
+        string key,
+        string displayName,
+        string? description,
+        int sortOrder,
+        CancellationToken cancellationToken)
+    {
+        var normalizedKey = NormalizeKey(key);
+        var trimmedDisplayName = (displayName ?? string.Empty).Trim();
+        var trimmedDescription = NormalizeOptional(description);
+
+        if (string.IsNullOrEmpty(normalizedKey))
+        {
+            throw new ArgumentException("Key is required.", nameof(key));
+        }
+        if (normalizedKey.Length > KeyMaxLength)
+        {
+            throw new ArgumentException(
+                $"Key must be {KeyMaxLength} characters or fewer.", nameof(key));
+        }
+        if (string.IsNullOrEmpty(trimmedDisplayName))
+        {
+            throw new ArgumentException("DisplayName is required.", nameof(displayName));
+        }
+        if (trimmedDisplayName.Length > DisplayNameMaxLength)
+        {
+            throw new ArgumentException(
+                $"DisplayName must be {DisplayNameMaxLength} characters or fewer.",
+                nameof(displayName));
+        }
+        if (sortOrder < 0)
+        {
+            throw new ArgumentException("SortOrder must be non-negative.", nameof(sortOrder));
+        }
+
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var duplicate = await db.StartingEquipmentOptions
+            .AsNoTracking()
+            .AnyAsync(x => x.GameId == gameId && x.Key == normalizedKey, cancellationToken);
+        if (duplicate)
+        {
+            throw new InvalidOperationException(
+                $"Starting equipment option with key '{normalizedKey}' already exists for game {gameId}.");
+        }
+
+        var entity = new StartingEquipmentOption
+        {
+            GameId = gameId,
+            Key = normalizedKey,
+            DisplayName = trimmedDisplayName,
+            Description = trimmedDescription,
+            SortOrder = sortOrder
+        };
+        db.StartingEquipmentOptions.Add(entity);
+        await db.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Created StartingEquipmentOption {OptionId} (Key='{Key}') for game {GameId}.",
+            entity.Id, entity.Key, gameId);
+
+        return new StartingEquipmentOptionDto(
+            entity.Id, entity.GameId, entity.Key, entity.DisplayName, entity.Description, entity.SortOrder);
+    }
+
+    /// <summary>
+    /// Updates the display metadata and sort order of an existing option.
+    /// Key is intentionally immutable — parents' submissions reference the
+    /// option by Id, but the key is the stable cross-game identifier used by
+    /// <see cref="CopyFromGameAsync"/>.
+    /// </summary>
+    public async Task UpdateAsync(
+        int optionId,
+        string displayName,
+        string? description,
+        int sortOrder,
+        CancellationToken cancellationToken)
+    {
+        var trimmedDisplayName = (displayName ?? string.Empty).Trim();
+        var trimmedDescription = NormalizeOptional(description);
+
+        if (string.IsNullOrEmpty(trimmedDisplayName))
+        {
+            throw new ArgumentException("DisplayName is required.", nameof(displayName));
+        }
+        if (trimmedDisplayName.Length > DisplayNameMaxLength)
+        {
+            throw new ArgumentException(
+                $"DisplayName must be {DisplayNameMaxLength} characters or fewer.",
+                nameof(displayName));
+        }
+        if (sortOrder < 0)
+        {
+            throw new ArgumentException("SortOrder must be non-negative.", nameof(sortOrder));
+        }
+
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await db.StartingEquipmentOptions
+            .FirstOrDefaultAsync(x => x.Id == optionId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"StartingEquipmentOption {optionId} not found.");
+
+        entity.DisplayName = trimmedDisplayName;
+        entity.Description = trimmedDescription;
+        entity.SortOrder = sortOrder;
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Updated StartingEquipmentOption {OptionId} (Key='{Key}').", entity.Id, entity.Key);
+    }
+
+    /// <summary>
+    /// Attempts to delete an option. Returns <c>false</c> (without deleting)
+    /// if at least one <see cref="Registration"/> still references it, so the
+    /// caller can surface a friendly message. Returns <c>true</c> after a
+    /// successful delete.
+    /// </summary>
+    public async Task<bool> TryDeleteAsync(int optionId, CancellationToken cancellationToken)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await db.StartingEquipmentOptions
+            .FirstOrDefaultAsync(x => x.Id == optionId, cancellationToken);
+        if (entity is null)
+        {
+            return false;
+        }
+
+        var referenced = await db.Registrations
+            .AsNoTracking()
+            .AnyAsync(r => r.StartingEquipmentOptionId == optionId, cancellationToken);
+        if (referenced)
+        {
+            logger.LogInformation(
+                "Refused to delete StartingEquipmentOption {OptionId}: still referenced by at least one Registration.",
+                optionId);
+            return false;
+        }
+
+        db.StartingEquipmentOptions.Remove(entity);
+        await db.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Deleted StartingEquipmentOption {OptionId}.", optionId);
+        return true;
+    }
+
+    /// <summary>
+    /// Copies every option from <paramref name="sourceGameId"/> into
+    /// <paramref name="targetGameId"/>, skipping any (target-side) key that
+    /// already exists. Preserves DisplayName, Description and SortOrder.
+    /// Use this to bootstrap a new game's options from a previous year.
+    /// </summary>
+    public async Task CopyFromGameAsync(
+        int sourceGameId,
+        int targetGameId,
+        CancellationToken cancellationToken)
+    {
+        if (sourceGameId == targetGameId)
+        {
+            // No-op rather than a throw — the page UI already filters the
+            // current game out of the source dropdown, but being defensive is
+            // cheap.
+            return;
+        }
+
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var sourceRows = await db.StartingEquipmentOptions
+            .AsNoTracking()
+            .Where(x => x.GameId == sourceGameId)
+            .ToListAsync(cancellationToken);
+
+        if (sourceRows.Count == 0)
+        {
+            return;
+        }
+
+        var existingTargetKeys = await db.StartingEquipmentOptions
+            .AsNoTracking()
+            .Where(x => x.GameId == targetGameId)
+            .Select(x => x.Key)
+            .ToListAsync(cancellationToken);
+
+        var existingSet = new HashSet<string>(existingTargetKeys, StringComparer.Ordinal);
+
+        var copied = 0;
+        foreach (var row in sourceRows)
+        {
+            if (existingSet.Contains(row.Key))
+            {
+                continue;
+            }
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                GameId = targetGameId,
+                Key = row.Key,
+                DisplayName = row.DisplayName,
+                Description = row.Description,
+                SortOrder = row.SortOrder
+            });
+            copied++;
+        }
+
+        if (copied > 0)
+        {
+            await db.SaveChangesAsync(cancellationToken);
+            logger.LogInformation(
+                "Copied {Copied} StartingEquipmentOption rows from game {SourceId} to game {TargetId}.",
+                copied, sourceGameId, targetGameId);
+        }
+    }
+
+    private static string NormalizeKey(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        return value.Trim().ToLowerInvariant();
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepService.cs
@@ -283,6 +283,118 @@ public sealed class CharacterPrepService(
         return new CharacterPrepStats(total, invited, fullyFilled, pending);
     }
 
+    /// <summary>
+    /// Paginated, filterable, one-row-per-Player projection for the organizer dashboard.
+    /// Status is derived from (submission.CharacterPrepInvitedAtUtc, registration.CharacterName,
+    /// registration.StartingEquipmentOptionId):
+    ///   NotInvited → no invite sent
+    ///   Done       → invited AND CharacterName non-blank AND StartingEquipmentOptionId != null
+    ///   Waiting    → everything else
+    /// Results are sorted Status ascending (NotInvited first), then HouseholdName
+    /// (case-insensitive), then PersonFullName to keep the ordering stable.
+    /// </summary>
+    public async Task<PagedResult<CharacterPrepDashboardRow>> GetDashboardRowsAsync(
+        int gameId,
+        DashboardFilter filter,
+        int page = 1,
+        int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 20;
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        // Pull all Player rows for this game. A LARP-scale dashboard tops out at a few
+        // hundred kids so an in-memory pass keeps the LINQ legible and lets us push a
+        // three-valued derived Status into the order clause without fighting the
+        // provider.
+        var raw = await db.Registrations
+            .AsNoTracking()
+            .Where(x => x.Submission.GameId == gameId
+                && x.AttendeeType == AttendeeType.Player
+                && !x.Submission.IsDeleted)
+            .Select(x => new
+            {
+                x.Id,
+                x.SubmissionId,
+                HouseholdName = x.Submission.PrimaryContactName,
+                PersonFirst = x.Person.FirstName,
+                PersonLast = x.Person.LastName,
+                x.CharacterName,
+                x.StartingEquipmentOptionId,
+                EquipmentDisplayName = x.StartingEquipmentOption != null
+                    ? x.StartingEquipmentOption.DisplayName
+                    : null,
+                x.CharacterPrepNote,
+                x.CharacterPrepUpdatedAtUtc,
+                InvitedAtUtc = x.Submission.CharacterPrepInvitedAtUtc,
+                SubmissionToken = x.Submission.CharacterPrepToken,
+            })
+            .ToListAsync(cancellationToken);
+
+        var rows = raw
+            .Select(r => new CharacterPrepDashboardRow(
+                r.SubmissionId,
+                r.HouseholdName,
+                r.Id,
+                (r.PersonFirst + " " + r.PersonLast).Trim(),
+                r.CharacterName,
+                r.EquipmentDisplayName,
+                r.CharacterPrepNote,
+                DeriveStatus(r.InvitedAtUtc, r.CharacterName, r.StartingEquipmentOptionId),
+                r.CharacterPrepUpdatedAtUtc,
+                r.SubmissionToken))
+            .ToList();
+
+        if (filter.Status is CharacterPrepStatus wanted)
+        {
+            rows = rows.Where(r => r.Status == wanted).ToList();
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.Search))
+        {
+            var needle = filter.Search.Trim();
+            rows = rows
+                .Where(r =>
+                    (!string.IsNullOrEmpty(r.PersonFullName)
+                        && r.PersonFullName.Contains(needle, StringComparison.OrdinalIgnoreCase))
+                    || (!string.IsNullOrEmpty(r.CharacterName)
+                        && r.CharacterName!.Contains(needle, StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+        }
+
+        var total = rows.Count;
+
+        var ordered = rows
+            .OrderBy(r => (int)r.Status)
+            .ThenBy(r => r.HouseholdName, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(r => r.PersonFullName, StringComparer.CurrentCultureIgnoreCase)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        return new PagedResult<CharacterPrepDashboardRow>(ordered, total, page, pageSize);
+    }
+
+    private static CharacterPrepStatus DeriveStatus(
+        DateTimeOffset? invitedAtUtc,
+        string? characterName,
+        int? startingEquipmentOptionId)
+    {
+        if (invitedAtUtc is null)
+        {
+            return CharacterPrepStatus.NotInvited;
+        }
+
+        var nameFilled = !string.IsNullOrWhiteSpace(characterName);
+        var equipmentFilled = startingEquipmentOptionId.HasValue;
+        return nameFilled && equipmentFilled
+            ? CharacterPrepStatus.Done
+            : CharacterPrepStatus.Waiting;
+    }
+
     private static string? NormalizeOptional(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepService.cs
@@ -183,6 +183,9 @@ public sealed class CharacterPrepService(
     {
         await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
 
+        // Soft-deleted submissions are excluded by the global HasQueryFilter
+        // (!IsDeleted) on RegistrationSubmission — see ApplicationDbContext and
+        // Soft_deleted_submission_is_excluded_* tests that lock this in.
         return await db.RegistrationSubmissions
             .AsNoTracking()
             .Where(x => x.GameId == gameId
@@ -200,6 +203,8 @@ public sealed class CharacterPrepService(
 
         await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
 
+        // Soft-deleted submissions are excluded by the global HasQueryFilter
+        // (!IsDeleted) on RegistrationSubmission, same as ListInvitationTargetsAsync.
         return await db.RegistrationSubmissions
             .AsNoTracking()
             .Where(x => x.GameId == gameId
@@ -255,6 +260,9 @@ public sealed class CharacterPrepService(
 
         // Fetch per-submission player aggregates in a single query so we can compute
         // TotalHouseholds / Invited / FullyFilled without N round trips.
+        // Soft-deleted submissions are excluded by the global HasQueryFilter
+        // (!IsDeleted) on RegistrationSubmission — locked in by
+        // CharacterPrepServiceDashboardStatsTests.Soft_deleted_submission_is_excluded.
         var aggregates = await db.RegistrationSubmissions
             .AsNoTracking()
             .Where(x => x.GameId == gameId)

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepService.cs
@@ -8,14 +8,21 @@ public sealed class CharacterPrepService(
     IDbContextFactory<ApplicationDbContext> dbContextFactory,
     ILogger<CharacterPrepService>? logger = null)
 {
-    public async Task<CharacterPrepView> GetPrepViewAsync(
-        RegistrationSubmission submission,
+    public async Task<CharacterPrepView?> GetPrepViewAsync(
+        int submissionId,
         DateTimeOffset nowUtc,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(submission);
-
         await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var submission = await db.RegistrationSubmissions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == submissionId, cancellationToken);
+
+        if (submission is null)
+        {
+            return null;
+        }
 
         var game = await db.Games
             .AsNoTracking()

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepService.cs
@@ -1,0 +1,289 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Features.CharacterPrep;
+
+public sealed class CharacterPrepService(
+    IDbContextFactory<ApplicationDbContext> dbContextFactory,
+    ILogger<CharacterPrepService>? logger = null)
+{
+    public async Task<CharacterPrepView> GetPrepViewAsync(
+        RegistrationSubmission submission,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(submission);
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var game = await db.Games
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == submission.GameId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Game {submission.GameId} for submission {submission.Id} not found.");
+
+        var gameStart = new DateTimeOffset(
+            DateTime.SpecifyKind(game.StartsAtUtc, DateTimeKind.Utc));
+
+        var rows = await db.Registrations
+            .AsNoTracking()
+            .Where(x => x.SubmissionId == submission.Id && x.AttendeeType == AttendeeType.Player)
+            .OrderBy(x => x.Person.LastName)
+            .ThenBy(x => x.Person.FirstName)
+            .Select(x => new CharacterPrepRow(
+                x.Id,
+                x.Person.FirstName + " " + x.Person.LastName,
+                x.CharacterName,
+                x.StartingEquipmentOptionId,
+                x.CharacterPrepNote,
+                x.CharacterPrepUpdatedAtUtc))
+            .ToListAsync(cancellationToken);
+
+        var options = await db.StartingEquipmentOptions
+            .AsNoTracking()
+            .Where(x => x.GameId == submission.GameId)
+            .OrderBy(x => x.SortOrder)
+            .ThenBy(x => x.DisplayName)
+            .Select(x => new StartingEquipmentOptionView(
+                x.Id,
+                x.Key,
+                x.DisplayName,
+                x.Description,
+                x.SortOrder))
+            .ToListAsync(cancellationToken);
+
+        var isReadOnly = gameStart <= nowUtc;
+
+        return new CharacterPrepView(
+            submission.Id,
+            submission.GameId,
+            game.Name,
+            gameStart,
+            isReadOnly,
+            rows,
+            options);
+    }
+
+    public async Task SaveAsync(
+        int submissionId,
+        IEnumerable<CharacterPrepSaveRow> rows,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+
+        // Materialize once — the caller may pass a lazy IEnumerable and we iterate twice.
+        var rowList = rows as IReadOnlyList<CharacterPrepSaveRow> ?? rows.ToList();
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var submission = await db.RegistrationSubmissions
+            .FirstOrDefaultAsync(x => x.Id == submissionId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"RegistrationSubmission {submissionId} not found.");
+
+        var registrations = await db.Registrations
+            .Include(x => x.StartingEquipmentOption)
+            .Where(x => x.SubmissionId == submissionId)
+            .ToListAsync(cancellationToken);
+
+        var byId = registrations.ToDictionary(x => x.Id);
+
+        // Resolve all requested equipment options in one query so we can validate
+        // they belong to the submission's game (defense against cross-game spoofing).
+        var optionIds = rowList
+            .Where(r => r.StartingEquipmentOptionId.HasValue)
+            .Select(r => r.StartingEquipmentOptionId!.Value)
+            .Distinct()
+            .ToList();
+
+        var optionGameLookup = optionIds.Count == 0
+            ? new Dictionary<int, int>()
+            : await db.StartingEquipmentOptions
+                .AsNoTracking()
+                .Where(x => optionIds.Contains(x.Id))
+                .ToDictionaryAsync(x => x.Id, x => x.GameId, cancellationToken);
+
+        foreach (var row in rowList)
+        {
+            if (!byId.TryGetValue(row.RegistrationId, out var registration))
+            {
+                logger?.LogDebug(
+                    "Character prep save row for registration {RegistrationId} ignored: not part of submission {SubmissionId}.",
+                    row.RegistrationId, submissionId);
+                continue;
+            }
+
+            if (registration.SubmissionId != submissionId)
+            {
+                logger?.LogDebug(
+                    "Character prep save row for registration {RegistrationId} ignored: submission mismatch.",
+                    row.RegistrationId);
+                continue;
+            }
+
+            if (registration.AttendeeType != AttendeeType.Player)
+            {
+                logger?.LogDebug(
+                    "Character prep save row for registration {RegistrationId} ignored: not a Player.",
+                    row.RegistrationId);
+                continue;
+            }
+
+            if (row.StartingEquipmentOptionId.HasValue)
+            {
+                if (!optionGameLookup.TryGetValue(row.StartingEquipmentOptionId.Value, out var optionGameId))
+                {
+                    throw new ArgumentException(
+                        $"Starting equipment option {row.StartingEquipmentOptionId.Value} does not exist.",
+                        nameof(rows));
+                }
+
+                if (optionGameId != submission.GameId)
+                {
+                    throw new ArgumentException(
+                        $"Starting equipment option {row.StartingEquipmentOptionId.Value} belongs to game {optionGameId}, but submission {submissionId} is for game {submission.GameId}.",
+                        nameof(rows));
+                }
+            }
+
+            var newCharacterName = NormalizeOptional(row.CharacterName);
+            var newNote = NormalizeOptional(row.CharacterPrepNote);
+            var newOptionId = row.StartingEquipmentOptionId;
+
+            var changed = !string.Equals(registration.CharacterName, newCharacterName, StringComparison.Ordinal)
+                || registration.StartingEquipmentOptionId != newOptionId
+                || !string.Equals(registration.CharacterPrepNote, newNote, StringComparison.Ordinal);
+
+            if (!changed)
+            {
+                continue;
+            }
+
+            registration.CharacterName = newCharacterName;
+            registration.StartingEquipmentOptionId = newOptionId;
+            registration.CharacterPrepNote = newNote;
+            registration.CharacterPrepUpdatedAtUtc = nowUtc;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<RegistrationSubmission>> ListInvitationTargetsAsync(
+        int gameId,
+        CancellationToken cancellationToken)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await db.RegistrationSubmissions
+            .AsNoTracking()
+            .Where(x => x.GameId == gameId
+                && x.CharacterPrepInvitedAtUtc == null
+                && x.Registrations.Any(r => r.AttendeeType == AttendeeType.Player))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<RegistrationSubmission>> ListReminderTargetsAsync(
+        int gameId,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        var threshold = nowUtc.AddHours(-24);
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await db.RegistrationSubmissions
+            .AsNoTracking()
+            .Where(x => x.GameId == gameId
+                && x.CharacterPrepInvitedAtUtc != null
+                && x.Registrations.Any(r =>
+                    r.AttendeeType == AttendeeType.Player
+                    && r.StartingEquipmentOptionId == null)
+                && (x.CharacterPrepReminderLastSentAtUtc == null
+                    || x.CharacterPrepReminderLastSentAtUtc < threshold))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task MarkInvitedAsync(
+        int submissionId,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var submission = await db.RegistrationSubmissions
+            .FirstOrDefaultAsync(x => x.Id == submissionId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"RegistrationSubmission {submissionId} not found.");
+
+        if (submission.CharacterPrepInvitedAtUtc is null)
+        {
+            submission.CharacterPrepInvitedAtUtc = nowUtc;
+            await db.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    public async Task MarkReminderSentAsync(
+        int submissionId,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var submission = await db.RegistrationSubmissions
+            .FirstOrDefaultAsync(x => x.Id == submissionId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"RegistrationSubmission {submissionId} not found.");
+
+        submission.CharacterPrepReminderLastSentAtUtc = nowUtc;
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<CharacterPrepStats> GetDashboardStatsAsync(
+        int gameId,
+        CancellationToken cancellationToken)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        // Fetch per-submission player aggregates in a single query so we can compute
+        // TotalHouseholds / Invited / FullyFilled without N round trips.
+        var aggregates = await db.RegistrationSubmissions
+            .AsNoTracking()
+            .Where(x => x.GameId == gameId)
+            .Select(x => new
+            {
+                x.Id,
+                x.CharacterPrepInvitedAtUtc,
+                PlayerCount = x.Registrations.Count(r => r.AttendeeType == AttendeeType.Player),
+                PlayersWithoutEquipment = x.Registrations.Count(r =>
+                    r.AttendeeType == AttendeeType.Player
+                    && r.StartingEquipmentOptionId == null),
+                PlayersWithoutCharacterName = x.Registrations.Count(r =>
+                    r.AttendeeType == AttendeeType.Player
+                    && (r.CharacterName == null || r.CharacterName.Trim() == ""))
+            })
+            .ToListAsync(cancellationToken);
+
+        var households = aggregates.Where(x => x.PlayerCount > 0).ToList();
+
+        var total = households.Count;
+        var invited = households.Count(x => x.CharacterPrepInvitedAtUtc is not null);
+        var fullyFilled = households.Count(x =>
+            x.PlayersWithoutEquipment == 0 && x.PlayersWithoutCharacterName == 0);
+        var pending = total - fullyFilled;
+
+        return new CharacterPrepStats(total, invited, fullyFilled, pending);
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepService.cs
@@ -252,6 +252,55 @@ public sealed class CharacterPrepService(
         await db.SaveChangesAsync(cancellationToken);
     }
 
+    /// <summary>
+    /// Derived status of a single submission for the "Příprava postav" badge on the
+    /// organizer submission detail page. Reuses the same three-state truth table as the
+    /// dashboard so the badge the organizer sees on both pages always agrees:
+    ///   NotInvited → <see cref="RegistrationSubmission.CharacterPrepInvitedAtUtc"/> is null
+    ///   Done       → invited AND every Player registration has both CharacterName non-blank
+    ///                AND StartingEquipmentOptionId set
+    ///   Waiting    → invited but at least one Player row still missing name or equipment
+    /// A submission with zero Player rows still resolves to Done/NotInvited (Waiting
+    /// requires something to wait for), which matches the dashboard's "pending" notion.
+    /// Returns null if the submission does not exist (soft-deleted or unknown id).
+    /// </summary>
+    public async Task<CharacterPrepStatus?> GetSubmissionStatusAsync(
+        int submissionId,
+        CancellationToken cancellationToken)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var projection = await db.RegistrationSubmissions
+            .AsNoTracking()
+            .Where(x => x.Id == submissionId)
+            .Select(x => new
+            {
+                x.CharacterPrepInvitedAtUtc,
+                PlayersMissingName = x.Registrations.Count(r =>
+                    r.AttendeeType == AttendeeType.Player
+                    && (r.CharacterName == null || r.CharacterName.Trim() == "")),
+                PlayersMissingEquipment = x.Registrations.Count(r =>
+                    r.AttendeeType == AttendeeType.Player
+                    && r.StartingEquipmentOptionId == null),
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (projection is null)
+        {
+            return null;
+        }
+
+        if (projection.CharacterPrepInvitedAtUtc is null)
+        {
+            return CharacterPrepStatus.NotInvited;
+        }
+
+        var fullyFilled = projection.PlayersMissingName == 0
+            && projection.PlayersMissingEquipment == 0;
+
+        return fullyFilled ? CharacterPrepStatus.Done : CharacterPrepStatus.Waiting;
+    }
+
     public async Task<CharacterPrepStats> GetDashboardStatsAsync(
         int gameId,
         CancellationToken cancellationToken)

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepTokenService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepTokenService.cs
@@ -1,0 +1,61 @@
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Features.CharacterPrep;
+
+public sealed class CharacterPrepTokenService(
+    IDbContextFactory<ApplicationDbContext> dbContextFactory)
+{
+    public async Task<string> EnsureTokenAsync(int submissionId, CancellationToken cancellationToken)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var submission = await db.RegistrationSubmissions
+            .FirstOrDefaultAsync(x => x.Id == submissionId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"RegistrationSubmission {submissionId} not found.");
+
+        if (!string.IsNullOrEmpty(submission.CharacterPrepToken))
+        {
+            return submission.CharacterPrepToken;
+        }
+
+        submission.CharacterPrepToken = GenerateToken();
+        await db.SaveChangesAsync(cancellationToken);
+        return submission.CharacterPrepToken;
+    }
+
+    public async Task<string> RotateTokenAsync(int submissionId, CancellationToken cancellationToken)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var submission = await db.RegistrationSubmissions
+            .FirstOrDefaultAsync(x => x.Id == submissionId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"RegistrationSubmission {submissionId} not found.");
+
+        submission.CharacterPrepToken = GenerateToken();
+        await db.SaveChangesAsync(cancellationToken);
+        return submission.CharacterPrepToken;
+    }
+
+    public async Task<RegistrationSubmission?> FindBySubmissionTokenAsync(
+        string token,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return null;
+        }
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await db.RegistrationSubmissions
+            .FirstOrDefaultAsync(x => x.CharacterPrepToken == token, cancellationToken);
+    }
+
+    private static string GenerateToken() =>
+        Base64UrlTextEncoder.Encode(RandomNumberGenerator.GetBytes(32));
+}

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepViewModels.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepViewModels.cs
@@ -1,0 +1,37 @@
+namespace RegistraceOvcina.Web.Features.CharacterPrep;
+
+public sealed record CharacterPrepView(
+    int SubmissionId,
+    int GameId,
+    string GameName,
+    DateTimeOffset GameStartDateUtc,
+    bool IsReadOnly,
+    IReadOnlyList<CharacterPrepRow> Rows,
+    IReadOnlyList<StartingEquipmentOptionView> Options);
+
+public sealed record CharacterPrepRow(
+    int RegistrationId,
+    string PersonFullName,
+    string? CharacterName,
+    int? StartingEquipmentOptionId,
+    string? CharacterPrepNote,
+    DateTimeOffset? UpdatedAtUtc);
+
+public sealed record StartingEquipmentOptionView(
+    int Id,
+    string Key,
+    string DisplayName,
+    string? Description,
+    int SortOrder);
+
+public sealed record CharacterPrepSaveRow(
+    int RegistrationId,
+    string? CharacterName,
+    int? StartingEquipmentOptionId,
+    string? CharacterPrepNote);
+
+public sealed record CharacterPrepStats(
+    int TotalHouseholds,
+    int Invited,
+    int FullyFilled,
+    int Pending);

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepViewModels.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepViewModels.cs
@@ -35,3 +35,37 @@ public sealed record CharacterPrepStats(
     int Invited,
     int FullyFilled,
     int Pending);
+
+/// <summary>
+/// Derived status of a single Player registration on the organizer dashboard.
+/// Order is load-bearing: the dashboard sorts ascending so organizers see rows
+/// that need attention first (NotInvited → Waiting → Done).
+/// </summary>
+public enum CharacterPrepStatus
+{
+    NotInvited = 0,
+    Waiting = 1,
+    Done = 2,
+}
+
+public sealed record CharacterPrepDashboardRow(
+    int SubmissionId,
+    string HouseholdName,
+    int RegistrationId,
+    string PersonFullName,
+    string? CharacterName,
+    string? EquipmentDisplayName,
+    string? CharacterPrepNote,
+    CharacterPrepStatus Status,
+    DateTimeOffset? UpdatedAtUtc,
+    string? SubmissionToken);
+
+public sealed record DashboardFilter(
+    CharacterPrepStatus? Status,
+    string? Search);
+
+public sealed record PagedResult<T>(
+    IReadOnlyList<T> Rows,
+    int Total,
+    int Page,
+    int PageSize);

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/GraphCharacterPrepEmailSender.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/GraphCharacterPrepEmailSender.cs
@@ -1,0 +1,67 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Options;
+using RegistraceOvcina.Web.Features.Email;
+
+namespace RegistraceOvcina.Web.Features.CharacterPrep;
+
+/// <summary>
+/// Sends HTML mail through the shared mailbox via Microsoft Graph. Mirrors the exact pattern
+/// already used by <c>InvitationService.SendViaGraphAsync</c> and <c>InboxService.SendNewMessageAsync</c>
+/// so we don't fork the outbound pipeline. Only registered when <see cref="MailboxEmailOptions.IsConfigured"/>.
+/// </summary>
+public sealed class GraphCharacterPrepEmailSender(
+    IHttpClientFactory httpClientFactory,
+    IGraphAccessTokenProvider accessTokenProvider,
+    IOptions<MailboxEmailOptions> emailOptions,
+    ILogger<GraphCharacterPrepEmailSender> logger) : ICharacterPrepEmailSender
+{
+    public async Task SendAsync(
+        string recipientEmail,
+        string subject,
+        string htmlBody,
+        CancellationToken cancellationToken)
+    {
+        var options = emailOptions.Value;
+        if (!options.IsConfigured)
+        {
+            throw new InvalidOperationException(
+                "Character prep email sending requires Email:SharedMailboxAddress and Graph credentials.");
+        }
+
+        var sharedMailbox = options.SharedMailboxAddress!;
+        var accessToken = await accessTokenProvider.GetAccessTokenAsync(cancellationToken);
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"users/{Uri.EscapeDataString(sharedMailbox)}/sendMail");
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Content = JsonContent.Create(new
+        {
+            message = new
+            {
+                subject,
+                body = new { contentType = "HTML", content = htmlBody },
+                toRecipients = new[]
+                {
+                    new { emailAddress = new { address = recipientEmail } }
+                }
+            },
+            saveToSentItems = true
+        });
+
+        using var client = httpClientFactory.CreateClient(MicrosoftGraphMailboxEmailSender.GraphHttpClientName);
+        using var response = await client.SendAsync(request, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new InvalidOperationException(
+                $"Microsoft Graph sendMail failed ({(int)response.StatusCode}): {responseBody}");
+        }
+
+        logger.LogInformation(
+            "Character prep email sent from {SharedMailbox} to {Recipient}", sharedMailbox, recipientEmail);
+    }
+}

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/ICharacterPrepEmailSender.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/ICharacterPrepEmailSender.cs
@@ -1,0 +1,16 @@
+namespace RegistraceOvcina.Web.Features.CharacterPrep;
+
+/// <summary>
+/// Thin seam over the actual mail transport. The only purpose of this interface is to let
+/// tests swap in a capturing fake without touching the Microsoft Graph pipeline. The
+/// production implementation (<see cref="GraphCharacterPrepEmailSender"/>) uses the same
+/// Graph <c>sendMail</c> pattern as <c>InvitationService</c> / <c>InboxService</c>.
+/// </summary>
+public interface ICharacterPrepEmailSender
+{
+    Task SendAsync(
+        string recipientEmail,
+        string subject,
+        string htmlBody,
+        CancellationToken cancellationToken);
+}

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/UnconfiguredCharacterPrepEmailSender.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/UnconfiguredCharacterPrepEmailSender.cs
@@ -1,0 +1,22 @@
+namespace RegistraceOvcina.Web.Features.CharacterPrep;
+
+/// <summary>
+/// Registered when <c>Email:SharedMailboxAddress</c> / Graph credentials are missing.
+/// Throws on send so unconfigured environments surface the problem immediately instead
+/// of appearing to work while mail silently never leaves the process.
+/// </summary>
+internal sealed class UnconfiguredCharacterPrepEmailSender(
+    ILogger<UnconfiguredCharacterPrepEmailSender> logger) : ICharacterPrepEmailSender
+{
+    public Task SendAsync(string recipientEmail, string subject, string htmlBody, CancellationToken cancellationToken)
+    {
+        logger.LogError(
+            "Attempted to send Character Prep email to {Recipient} but outbound mail is not configured " +
+            "(Email:SharedMailboxAddress + Graph credentials). Configure them to enable sending.",
+            recipientEmail);
+
+        throw new InvalidOperationException(
+            "Character Prep email sending is not configured. Set Email:SharedMailboxAddress and the " +
+            "Microsoft Graph credentials (Email:Graph:TenantId/ClientId/ClientSecret) to enable outbound mail.");
+    }
+}

--- a/src/RegistraceOvcina.Web/Features/Email/MailboxSyncService.cs
+++ b/src/RegistraceOvcina.Web/Features/Email/MailboxSyncService.cs
@@ -157,12 +157,15 @@ internal sealed partial class MailboxSyncService(
             .ToDictionary(g => g.Key, g => g.First().Id, StringComparer.Ordinal);
 
         // Pre-load unreconciled local outbound rows (the ones created by InboxService
-        // with a "composed-*" / "reply-*" placeholder id). Sync will try to "claim"
-        // them by matching to+subject+body so Graph's next surfacing of the same
-        // message doesn't create a duplicate row.
+        // with a "composed-*" / "reply-*" placeholder id, or by CharacterPrepMailService
+        // with a "prep-*" placeholder id). Sync will try to "claim" them by matching
+        // to+subject+body so Graph's next surfacing of the same message doesn't create
+        // a duplicate row.
         var localPlaceholders = await dbContext.EmailMessages
             .Where(e => e.Direction == EmailDirection.Outbound
-                && (e.MailboxItemId.StartsWith("composed-") || e.MailboxItemId.StartsWith("reply-")))
+                && (e.MailboxItemId.StartsWith("composed-")
+                    || e.MailboxItemId.StartsWith("reply-")
+                    || e.MailboxItemId.StartsWith("prep-")))
             .OrderByDescending(e => e.SentAtUtc)
             .ToListAsync(cancellationToken);
 

--- a/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
+++ b/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
@@ -197,6 +197,15 @@ public sealed class GameStatsService(IDbContextFactory<ApplicationDbContext> dbC
             .Count(x => x.LodgingPreference == LodgingPreference.Indoor && !x.AssignedGameRoomId.HasValue);
         var playersWithoutKingdom = Math.Max(0, kingdomUnassigned);
 
+        // --- Character prep widget ---
+        // Total = every Player row; Filled = Players with BOTH a non-blank character name
+        // AND a chosen StartingEquipmentOptionId. Matches the dashboard's "Done" state
+        // so the widget and dashboard can't disagree.
+        var characterPrepTotal = players.Count;
+        var characterPrepFilled = players.Count(p =>
+            !string.IsNullOrWhiteSpace(p.CharacterName)
+            && p.StartingEquipmentOptionId.HasValue);
+
         return new GameStats
         {
             GameName = game.Name,
@@ -231,7 +240,9 @@ public sealed class GameStatsService(IDbContextFactory<ApplicationDbContext> dbC
             UnpaidSubmissionCount = unpaidSubmissionCount,
             Meals = meals,
             IndoorWithoutRoom = indoorWithoutRoom,
-            PlayersWithoutKingdom = playersWithoutKingdom
+            PlayersWithoutKingdom = playersWithoutKingdom,
+            CharacterPrepFilled = characterPrepFilled,
+            CharacterPrepTotal = characterPrepTotal
         };
     }
 
@@ -314,6 +325,10 @@ public sealed class GameStats
     // Action items
     public int IndoorWithoutRoom { get; set; }
     public int PlayersWithoutKingdom { get; set; }
+
+    // Character prep progress (widget on /statistiky links to dashboard)
+    public int CharacterPrepFilled { get; set; }
+    public int CharacterPrepTotal { get; set; }
 }
 
 public sealed record AgeBracket(string Label, int Count, int MaxCount);

--- a/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
+++ b/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
@@ -200,7 +200,10 @@ public sealed class GameStatsService(IDbContextFactory<ApplicationDbContext> dbC
         // --- Character prep widget ---
         // Total = every Player row; Filled = Players with BOTH a non-blank character name
         // AND a chosen StartingEquipmentOptionId. Matches the dashboard's "Done" state
-        // so the widget and dashboard can't disagree.
+        // so the widget and dashboard can't disagree. Soft-deleted submissions are
+        // excluded by the Registration.HasQueryFilter(!Submission.IsDeleted) that
+        // propagates through the db.Registrations query above — locked in by
+        // GameStatsCharacterPrepWidgetTests.Widget_excludes_soft_deleted_submissions.
         var characterPrepTotal = players.Count;
         var characterPrepFilled = players.Count(p =>
             !string.IsNullOrWhiteSpace(p.CharacterName)

--- a/src/RegistraceOvcina.Web/Migrations/20260420143015_AddCharacterPrepAndStartingEquipment.Designer.cs
+++ b/src/RegistraceOvcina.Web/Migrations/20260420143015_AddCharacterPrepAndStartingEquipment.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RegistraceOvcina.Web.Data;
@@ -11,9 +12,11 @@ using RegistraceOvcina.Web.Data;
 namespace RegistraceOvcina.Web.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260420143015_AddCharacterPrepAndStartingEquipment")]
+    partial class AddCharacterPrepAndStartingEquipment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/RegistraceOvcina.Web/Migrations/20260420143015_AddCharacterPrepAndStartingEquipment.cs
+++ b/src/RegistraceOvcina.Web/Migrations/20260420143015_AddCharacterPrepAndStartingEquipment.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace RegistraceOvcina.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCharacterPrepAndStartingEquipment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CharacterPrepInvitedAtUtc",
+                table: "RegistrationSubmissions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CharacterPrepReminderLastSentAtUtc",
+                table: "RegistrationSubmissions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CharacterPrepToken",
+                table: "RegistrationSubmissions",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CharacterPrepNote",
+                table: "Registrations",
+                type: "character varying(4000)",
+                maxLength: 4000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CharacterPrepUpdatedAtUtc",
+                table: "Registrations",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StartingEquipmentOptionId",
+                table: "Registrations",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "StartingEquipmentOptions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    GameId = table.Column<int>(type: "integer", nullable: false),
+                    Key = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StartingEquipmentOptions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_StartingEquipmentOptions_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RegistrationSubmissions_CharacterPrepToken",
+                table: "RegistrationSubmissions",
+                column: "CharacterPrepToken",
+                unique: true,
+                filter: "\"CharacterPrepToken\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Registrations_StartingEquipmentOptionId",
+                table: "Registrations",
+                column: "StartingEquipmentOptionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StartingEquipmentOptions_GameId_Key",
+                table: "StartingEquipmentOptions",
+                columns: new[] { "GameId", "Key" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Registrations_StartingEquipmentOptions_StartingEquipmentOpt~",
+                table: "Registrations",
+                column: "StartingEquipmentOptionId",
+                principalTable: "StartingEquipmentOptions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Registrations_StartingEquipmentOptions_StartingEquipmentOpt~",
+                table: "Registrations");
+
+            migrationBuilder.DropTable(
+                name: "StartingEquipmentOptions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RegistrationSubmissions_CharacterPrepToken",
+                table: "RegistrationSubmissions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Registrations_StartingEquipmentOptionId",
+                table: "Registrations");
+
+            migrationBuilder.DropColumn(
+                name: "CharacterPrepInvitedAtUtc",
+                table: "RegistrationSubmissions");
+
+            migrationBuilder.DropColumn(
+                name: "CharacterPrepReminderLastSentAtUtc",
+                table: "RegistrationSubmissions");
+
+            migrationBuilder.DropColumn(
+                name: "CharacterPrepToken",
+                table: "RegistrationSubmissions");
+
+            migrationBuilder.DropColumn(
+                name: "CharacterPrepNote",
+                table: "Registrations");
+
+            migrationBuilder.DropColumn(
+                name: "CharacterPrepUpdatedAtUtc",
+                table: "Registrations");
+
+            migrationBuilder.DropColumn(
+                name: "StartingEquipmentOptionId",
+                table: "Registrations");
+        }
+    }
+}

--- a/src/RegistraceOvcina.Web/Migrations/20260420144154_AddCharacterPrepAndStartingEquipment.Designer.cs
+++ b/src/RegistraceOvcina.Web/Migrations/20260420144154_AddCharacterPrepAndStartingEquipment.Designer.cs
@@ -12,7 +12,7 @@ using RegistraceOvcina.Web.Data;
 namespace RegistraceOvcina.Web.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20260420143015_AddCharacterPrepAndStartingEquipment")]
+    [Migration("20260420144154_AddCharacterPrepAndStartingEquipment")]
     partial class AddCharacterPrepAndStartingEquipment
     {
         /// <inheritdoc />
@@ -2080,7 +2080,7 @@ namespace RegistraceOvcina.Web.Migrations
                     b.HasOne("RegistraceOvcina.Web.Data.Game", "Game")
                         .WithMany()
                         .HasForeignKey("GameId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Game");

--- a/src/RegistraceOvcina.Web/Migrations/20260420144154_AddCharacterPrepAndStartingEquipment.cs
+++ b/src/RegistraceOvcina.Web/Migrations/20260420144154_AddCharacterPrepAndStartingEquipment.cs
@@ -70,7 +70,7 @@ namespace RegistraceOvcina.Web.Migrations
                         column: x => x.GameId,
                         principalTable: "Games",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateIndex(

--- a/src/RegistraceOvcina.Web/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/RegistraceOvcina.Web/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -2077,7 +2077,7 @@ namespace RegistraceOvcina.Web.Migrations
                     b.HasOne("RegistraceOvcina.Web.Data.Game", "Game")
                         .WithMany()
                         .HasForeignKey("GameId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Game");

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -249,6 +249,7 @@ public class Program
         builder.Services.AddScoped<SubmissionService>();
         builder.Services.AddScoped<CharacterPrepTokenService>();
         builder.Services.AddScoped<CharacterPrepService>();
+        builder.Services.AddScoped<CharacterPrepOptionsService>();
         builder.Services.AddOptions<CharacterPrepOptions>()
             .Bind(builder.Configuration.GetSection(CharacterPrepOptions.SectionName))
             .ValidateDataAnnotations()

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -249,6 +249,10 @@ public class Program
         builder.Services.AddScoped<SubmissionService>();
         builder.Services.AddScoped<CharacterPrepTokenService>();
         builder.Services.AddScoped<CharacterPrepService>();
+        builder.Services.Configure<CharacterPrepOptions>(
+            builder.Configuration.GetSection(CharacterPrepOptions.SectionName));
+        builder.Services.AddScoped<ICharacterPrepEmailRenderer, CharacterPrepEmailRenderer>();
+        builder.Services.AddScoped<CharacterPrepMailService>();
         builder.Services.AddScoped<OrganizerSubmissionService>();
         builder.Services.AddScoped<PaymentService>();
         builder.Services.Configure<AcsEmailOptions>(builder.Configuration.GetSection(AcsEmailOptions.SectionName));
@@ -270,6 +274,13 @@ public class Program
             builder.Services.AddScoped<MailboxSyncService>();
             builder.Services.AddScoped<InvitationService>();
             builder.Services.AddScoped<ExternalContactService>();
+            builder.Services.AddScoped<ICharacterPrepEmailSender, GraphCharacterPrepEmailSender>();
+        }
+        else
+        {
+            // Dev / unconfigured environments: fail fast with a clear message rather than
+            // silently dropping mail. A no-op would hide integration issues during testing.
+            builder.Services.AddScoped<ICharacterPrepEmailSender, UnconfiguredCharacterPrepEmailSender>();
         }
 
         var app = builder.Build();

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -249,8 +249,10 @@ public class Program
         builder.Services.AddScoped<SubmissionService>();
         builder.Services.AddScoped<CharacterPrepTokenService>();
         builder.Services.AddScoped<CharacterPrepService>();
-        builder.Services.Configure<CharacterPrepOptions>(
-            builder.Configuration.GetSection(CharacterPrepOptions.SectionName));
+        builder.Services.AddOptions<CharacterPrepOptions>()
+            .Bind(builder.Configuration.GetSection(CharacterPrepOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
         builder.Services.AddScoped<ICharacterPrepEmailRenderer, CharacterPrepEmailRenderer>();
         builder.Services.AddScoped<CharacterPrepMailService>();
         builder.Services.AddScoped<OrganizerSubmissionService>();

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -250,6 +250,7 @@ public class Program
         builder.Services.AddScoped<CharacterPrepTokenService>();
         builder.Services.AddScoped<CharacterPrepService>();
         builder.Services.AddScoped<CharacterPrepOptionsService>();
+        builder.Services.AddScoped<CharacterPrepExportService>();
         builder.Services.AddOptions<CharacterPrepOptions>()
             .Bind(builder.Configuration.GetSection(CharacterPrepOptions.SectionName))
             .ValidateDataAnnotations()
@@ -1273,6 +1274,59 @@ public class Program
                     return Results.File(xlsx,
                         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                         $"kralovstvi-{board.GameName.Replace(' ', '-')}.xlsx");
+                })
+            .RequireAuthorization(AuthorizationPolicies.StaffOnly);
+        app.MapGet(
+                "/organizace/hry/{gameId:int}/priprava-postav/export.xlsx",
+                async (int gameId, IDbContextFactory<ApplicationDbContext> dbFactory,
+                    CharacterPrepExportService exportService, CancellationToken ct) =>
+                {
+                    await using var db = await dbFactory.CreateDbContextAsync(ct);
+                    var gameName = await db.Games
+                        .AsNoTracking()
+                        .Where(x => x.Id == gameId)
+                        .Select(x => x.Name)
+                        .FirstOrDefaultAsync(ct);
+
+                    if (gameName is null)
+                    {
+                        return Results.NotFound();
+                    }
+
+                    var xlsx = await exportService.BuildAsync(gameId, ct);
+                    var slug = Slugify(gameName);
+                    var stamp = DateTime.UtcNow.ToString("yyyyMMdd");
+                    return Results.File(xlsx,
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                        $"priprava-postav-{slug}-{stamp}.xlsx");
+
+                    static string Slugify(string value)
+                    {
+                        var normalized = value.Normalize(System.Text.NormalizationForm.FormD);
+                        var sb = new System.Text.StringBuilder(normalized.Length);
+                        foreach (var ch in normalized)
+                        {
+                            var cat = System.Globalization.CharUnicodeInfo.GetUnicodeCategory(ch);
+                            if (cat == System.Globalization.UnicodeCategory.NonSpacingMark)
+                            {
+                                continue;
+                            }
+                            if (char.IsLetterOrDigit(ch))
+                            {
+                                sb.Append(char.ToLowerInvariant(ch));
+                            }
+                            else if (char.IsWhiteSpace(ch) || ch == '-' || ch == '_')
+                            {
+                                sb.Append('-');
+                            }
+                        }
+                        var slug = sb.ToString();
+                        while (slug.Contains("--", StringComparison.Ordinal))
+                        {
+                            slug = slug.Replace("--", "-", StringComparison.Ordinal);
+                        }
+                        return slug.Trim('-');
+                    }
                 })
             .RequireAuthorization(AuthorizationPolicies.StaffOnly);
         app.MapPost(

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using RegistraceOvcina.Web.Components;
 using RegistraceOvcina.Web.Components.Account;
 using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
 using RegistraceOvcina.Web.Features.Email;
 using RegistraceOvcina.Web.Features.Food;
 using RegistraceOvcina.Web.Features.Games;
@@ -246,6 +247,8 @@ public class Program
         builder.Services.AddScoped<LodgingAssignmentService>();
         builder.Services.AddScoped<PeopleReviewService>();
         builder.Services.AddScoped<SubmissionService>();
+        builder.Services.AddScoped<CharacterPrepTokenService>();
+        builder.Services.AddScoped<CharacterPrepService>();
         builder.Services.AddScoped<OrganizerSubmissionService>();
         builder.Services.AddScoped<PaymentService>();
         builder.Services.Configure<AcsEmailOptions>(builder.Configuration.GetSection(AcsEmailOptions.SectionName));

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.9</Version>
+    <Version>0.9.10</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/appsettings.Development.json
+++ b/src/RegistraceOvcina.Web/appsettings.Development.json
@@ -2,6 +2,10 @@
   "ConnectionStrings": {
     "DefaultConnection": "Host=127.0.0.1;Port=5433;Database=registrace_ovcina_development;Username=postgres;Password=postgres"
   },
+  "CharacterPrep": {
+    "PublicBaseUrl": "http://localhost:5000",
+    "OrganizerContactEmail": "organizatori@ovcina.test"
+  },
   "Database": {
     "ApplyMigrationsOnStartup": true
   },

--- a/src/RegistraceOvcina.Web/appsettings.Testing.json
+++ b/src/RegistraceOvcina.Web/appsettings.Testing.json
@@ -3,7 +3,7 @@
     "DefaultConnection": "Host=127.0.0.1;Port=5432;Database=registrace_ovcina_testing;Username=postgres;Password=postgres"
   },
   "CharacterPrep": {
-    "PublicBaseUrl": "http://127.0.0.1/testing",
+    "PublicBaseUrl": "http://127.0.0.1",
     "OrganizerContactEmail": "organizatori@ovcina.test"
   },
   "Database": {

--- a/src/RegistraceOvcina.Web/appsettings.Testing.json
+++ b/src/RegistraceOvcina.Web/appsettings.Testing.json
@@ -2,6 +2,10 @@
   "ConnectionStrings": {
     "DefaultConnection": "Host=127.0.0.1;Port=5432;Database=registrace_ovcina_testing;Username=postgres;Password=postgres"
   },
+  "CharacterPrep": {
+    "PublicBaseUrl": "http://127.0.0.1/testing",
+    "OrganizerContactEmail": "organizatori@ovcina.test"
+  },
   "Database": {
     "ApplyMigrationsOnStartup": true
   },

--- a/tests/RegistraceOvcina.E2E/CharacterPrepSmokeTests.cs
+++ b/tests/RegistraceOvcina.E2E/CharacterPrepSmokeTests.cs
@@ -1,0 +1,370 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Playwright;
+using RegistraceOvcina.Web.Data;
+using Xunit.Sdk;
+
+namespace RegistraceOvcina.E2E;
+
+/// <summary>
+/// End-to-end smoke test for the Character Prep feature (Phase 9a).
+///
+/// Golden path:
+///   1. Seed a game, a RegistrationSubmission with 2 Player attendees, 5 equipment options.
+///   2. Organizer logs in, opens the prep dashboard.
+///   3. Because the test host uses UnconfiguredCharacterPrepEmailSender (no Graph mailbox
+///      configured in Testing env), the "Poslat pozvánku" button would throw on send.
+///      Instead we directly mark the submission as invited in the DB — simulates a successful
+///      bulk send — and generate the prep token (same crypto shape the token service uses).
+///      This matches the "fallback" path documented in the Phase 9a task description.
+///   4. Parent opens /postavy/{token} in a fresh (anonymous) browser context, fills names and
+///      picks equipment for both rows, saves.
+///   5. Reload confirms pre-fill persistence.
+///   6. Organizer reloads dashboard; stats show 1 FullyFilled / 0 Pending and each row says
+///      "Hotovo".
+/// </summary>
+public sealed class CharacterPrepSmokeTests : IClassFixture<AppFixture>
+{
+    private const string AdminEmail = "admin@ovcina.test";
+    private const string RegistrantEmail = "registrant@ovcina.test";
+
+    private readonly AppFixture _fixture;
+
+    public CharacterPrepSmokeTests(AppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task CharacterPrep_GoldenPath_EndToEnd()
+    {
+        var seeded = await SeedCharacterPrepAsync();
+
+        // ───── 1. Organizer opens the dashboard and sees 0 invited, 0 FullyFilled, 1 Pending ─────
+        var organizerPage = await _fixture.Browser.NewPageAsync();
+        await LoginAsync(organizerPage, AdminEmail);
+        await organizerPage.GotoAsync(
+            $"{_fixture.BaseUrl}/organizace/hry/{seeded.GameId}/priprava-postav",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+        await WaitForInteractiveReadyAsync(organizerPage);
+
+        await organizerPage.GetByTestId("prep-stat-total-households").WaitForAsync(
+            new LocatorWaitForOptions { Timeout = 5000 });
+        Assert.Equal("1",
+            (await organizerPage.GetByTestId("prep-stat-total-households").TextContentAsync())?.Trim());
+        Assert.Equal("0",
+            (await organizerPage.GetByTestId("prep-stat-invited").TextContentAsync())?.Trim());
+        Assert.Equal("0",
+            (await organizerPage.GetByTestId("prep-stat-fully-filled").TextContentAsync())?.Trim());
+
+        await AssertNoBlazorErrorsAsync(organizerPage);
+
+        // ───── 2. Simulate "Poslat pozvánku" bulk send ─────
+        // The Testing environment doesn't have Microsoft Graph configured, so the registered
+        // ICharacterPrepEmailSender is UnconfiguredCharacterPrepEmailSender which would throw.
+        // The host is a separate process (not WebApplicationFactory), so we can't swap the DI
+        // registration at test time. Fallback pattern: stamp the invited timestamp directly and
+        // mint a prep token via the same token service the production code uses.
+        var token = await MarkInvitedAndGenerateTokenAsync(seeded.SubmissionId);
+
+        // ───── 3. Organizer reloads — Invited should now be 1 ─────
+        await organizerPage.ReloadAsync(new PageReloadOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle
+        });
+        await WaitForInteractiveReadyAsync(organizerPage);
+
+        Assert.Equal("1",
+            (await organizerPage.GetByTestId("prep-stat-invited").TextContentAsync())?.Trim());
+
+        // ───── 4. Parent opens /postavy/{token} in a fresh anonymous context ─────
+        // New browser context = no admin cookie, exactly like the parent in real life.
+        await using var parentContext = await _fixture.Browser.NewContextAsync();
+        var parentPage = await parentContext.NewPageAsync();
+
+        await parentPage.GotoAsync(
+            $"{_fixture.BaseUrl}/postavy/{token}",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+        await WaitForInteractiveReadyAsync(parentPage);
+
+        // Both cards visible
+        var cardOne = parentPage.GetByTestId($"prep-card-{seeded.RegistrationIdOne}");
+        var cardTwo = parentPage.GetByTestId($"prep-card-{seeded.RegistrationIdTwo}");
+        await cardOne.WaitForAsync(new LocatorWaitForOptions { Timeout = 5000 });
+        await cardTwo.WaitForAsync(new LocatorWaitForOptions { Timeout = 5000 });
+
+        // Fill child one
+        var nameOne = parentPage.GetByTestId($"character-name-{seeded.RegistrationIdOne}");
+        await FillAndCommitAsync(nameOne, "Aragorn");
+        await parentPage.Locator(
+            $"#equip-{seeded.RegistrationIdOne}-{seeded.EquipmentIds[0]}").CheckAsync();
+
+        // Fill child two
+        var nameTwo = parentPage.GetByTestId($"character-name-{seeded.RegistrationIdTwo}");
+        await FillAndCommitAsync(nameTwo, "Legolas");
+        await parentPage.Locator(
+            $"#equip-{seeded.RegistrationIdTwo}-{seeded.EquipmentIds[1]}").CheckAsync();
+
+        // Save
+        await parentPage.GetByTestId("character-prep-save").ClickAsync();
+
+        var statusLocator = parentPage.GetByTestId("character-prep-status");
+        try
+        {
+            await statusLocator.WaitForAsync(new LocatorWaitForOptions { Timeout = 5000 });
+        }
+        catch (TimeoutException)
+        {
+            var bodyText = await parentPage.Locator("body").InnerTextAsync();
+            throw new XunitException(
+                $"Character prep save did not produce a status message. Page body:{Environment.NewLine}{bodyText}");
+        }
+
+        var statusText = (await statusLocator.TextContentAsync())?.Trim();
+        Assert.Equal("Uloženo, díky.", statusText);
+
+        await AssertNoBlazorErrorsAsync(parentPage);
+
+        // ───── 5. Reload parent page — values pre-filled ─────
+        await parentPage.ReloadAsync(new PageReloadOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle
+        });
+        await WaitForInteractiveReadyAsync(parentPage);
+
+        Assert.Equal("Aragorn",
+            await parentPage.GetByTestId($"character-name-{seeded.RegistrationIdOne}").InputValueAsync());
+        Assert.Equal("Legolas",
+            await parentPage.GetByTestId($"character-name-{seeded.RegistrationIdTwo}").InputValueAsync());
+
+        var firstRadio = parentPage.Locator(
+            $"#equip-{seeded.RegistrationIdOne}-{seeded.EquipmentIds[0]}");
+        var secondRadio = parentPage.Locator(
+            $"#equip-{seeded.RegistrationIdTwo}-{seeded.EquipmentIds[1]}");
+        Assert.True(await firstRadio.IsCheckedAsync(),
+            "First child's equipment radio should be pre-filled after reload.");
+        Assert.True(await secondRadio.IsCheckedAsync(),
+            "Second child's equipment radio should be pre-filled after reload.");
+
+        await parentPage.CloseAsync();
+
+        // ───── 6. Organizer reloads dashboard — both rows Hotovo, 1 FullyFilled / 0 Pending ─────
+        await organizerPage.ReloadAsync(new PageReloadOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle
+        });
+        await WaitForInteractiveReadyAsync(organizerPage);
+
+        Assert.Equal("1",
+            (await organizerPage.GetByTestId("prep-stat-fully-filled").TextContentAsync())?.Trim());
+        Assert.Equal("0",
+            (await organizerPage.GetByTestId("prep-stat-pending").TextContentAsync())?.Trim());
+
+        var statusBadgeOne = organizerPage.GetByTestId($"prep-status-{seeded.RegistrationIdOne}");
+        var statusBadgeTwo = organizerPage.GetByTestId($"prep-status-{seeded.RegistrationIdTwo}");
+        await statusBadgeOne.WaitForAsync(new LocatorWaitForOptions { Timeout = 5000 });
+        await statusBadgeTwo.WaitForAsync(new LocatorWaitForOptions { Timeout = 5000 });
+        Assert.Equal("Hotovo", (await statusBadgeOne.TextContentAsync())?.Trim());
+        Assert.Equal("Hotovo", (await statusBadgeTwo.TextContentAsync())?.Trim());
+
+        await AssertNoBlazorErrorsAsync(organizerPage);
+        await organizerPage.CloseAsync();
+    }
+
+    private async Task<SeededCharacterPrepData> SeedCharacterPrepAsync()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_fixture.ConnectionString)
+            .Options;
+
+        await using var db = new ApplicationDbContext(options);
+        var registrant = await db.Users.SingleAsync(x => x.Email == RegistrantEmail);
+        var nowUtc = DateTime.UtcNow;
+        var startsAtUtc = DateTime.UtcNow.AddMonths(2);
+        var endsAtUtc = startsAtUtc.AddDays(2);
+        var gameName = $"PrepE2E {Guid.NewGuid():N}".Substring(0, 18);
+
+        var game = new Game
+        {
+            Name = gameName,
+            Description = "E2E character prep",
+            StartsAtUtc = startsAtUtc,
+            EndsAtUtc = endsAtUtc,
+            RegistrationClosesAtUtc = startsAtUtc.AddDays(-7),
+            MealOrderingClosesAtUtc = startsAtUtc.AddDays(-10),
+            PaymentDueAtUtc = startsAtUtc.AddDays(-5),
+            BankAccount = "CZ6508000000192000145399",
+            BankAccountName = "Ovčina z.s.",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            TargetPlayerCountTotal = 80,
+            IsPublished = true,
+            CreatedAtUtc = nowUtc,
+            UpdatedAtUtc = nowUtc
+        };
+
+        var equipmentSpecs = new (string Key, string DisplayName, string Description, int SortOrder)[]
+        {
+            ("tesak", "Tesák (3/1)", "Útok 3, obrana 1", 1),
+            ("dlouhy-nuz", "Dlouhý nůž (2/2)", "Útok 2, obrana 2", 2),
+            ("vrhaci-nuz", "Vrhací nůž (3/0)", "Útok 3, obrana 0", 3),
+            ("dyka-svitky", "Dýka (1/2), 4 svitky kouzel", "Útok 1, obrana 2 + 4 svitky kouzel", 4),
+            ("mince", "5 měďáků / grošů", "Žádná zbraň, 5 mincí do začátku", 5),
+        };
+
+        var equipmentOptions = equipmentSpecs.Select(spec => new StartingEquipmentOption
+        {
+            Game = game,
+            Key = spec.Key,
+            DisplayName = spec.DisplayName,
+            Description = spec.Description,
+            SortOrder = spec.SortOrder
+        }).ToList();
+
+        var submission = new RegistrationSubmission
+        {
+            Game = game,
+            RegistrantUserId = registrant.Id,
+            PrimaryContactName = "Rodina PrepTest",
+            PrimaryEmail = "preptest@example.cz",
+            PrimaryPhone = "+420777123456",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = nowUtc,
+            LastEditedAtUtc = nowUtc,
+            ExpectedTotalAmount = 0m
+        };
+
+        var personOne = new Person
+        {
+            FirstName = "Anna",
+            LastName = "PrepOvá",
+            BirthYear = 2014,
+            CreatedAtUtc = nowUtc,
+            UpdatedAtUtc = nowUtc
+        };
+        var personTwo = new Person
+        {
+            FirstName = "Petr",
+            LastName = "Prep",
+            BirthYear = 2012,
+            CreatedAtUtc = nowUtc,
+            UpdatedAtUtc = nowUtc
+        };
+
+        var registrationOne = new Registration
+        {
+            Submission = submission,
+            Person = personOne,
+            AttendeeType = AttendeeType.Player,
+            Status = RegistrationStatus.Active,
+            CreatedAtUtc = nowUtc,
+            UpdatedAtUtc = nowUtc
+        };
+        var registrationTwo = new Registration
+        {
+            Submission = submission,
+            Person = personTwo,
+            AttendeeType = AttendeeType.Player,
+            Status = RegistrationStatus.Active,
+            CreatedAtUtc = nowUtc,
+            UpdatedAtUtc = nowUtc
+        };
+
+        db.Add(game);
+        db.AddRange(equipmentOptions);
+        db.AddRange(submission, personOne, personTwo, registrationOne, registrationTwo);
+        await db.SaveChangesAsync();
+
+        return new SeededCharacterPrepData(
+            game.Id,
+            submission.Id,
+            registrationOne.Id,
+            registrationTwo.Id,
+            equipmentOptions.Select(x => x.Id).ToArray());
+    }
+
+    private async Task<string> MarkInvitedAndGenerateTokenAsync(int submissionId)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_fixture.ConnectionString)
+            .Options;
+
+        await using var db = new ApplicationDbContext(options);
+        var submission = await db.RegistrationSubmissions.SingleAsync(x => x.Id == submissionId);
+        submission.CharacterPrepInvitedAtUtc = DateTimeOffset.UtcNow;
+        if (string.IsNullOrEmpty(submission.CharacterPrepToken))
+        {
+            // Must match CharacterPrepTokenService generator semantics (URL-safe random string).
+            submission.CharacterPrepToken = GenerateToken();
+        }
+        await db.SaveChangesAsync();
+        return submission.CharacterPrepToken!;
+    }
+
+    /// <summary>
+    /// Mirrors CharacterPrepTokenService's token shape: 32 bytes of crypto randomness,
+    /// base64url encoded. Using our own generator (rather than resolving the service) keeps the
+    /// test host process loosely coupled — we only touch DB.
+    /// </summary>
+    private static string GenerateToken()
+    {
+        var bytes = System.Security.Cryptography.RandomNumberGenerator.GetBytes(32);
+        return Convert.ToBase64String(bytes)
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+    }
+
+    private async Task LoginAsync(IPage page, string email)
+    {
+        await page.GotoAsync(
+            $"{_fixture.BaseUrl}/testing/login?email={Uri.EscapeDataString(email)}&returnUrl=%2F",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+        await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+    }
+
+    private static async Task FillAndCommitAsync(ILocator locator, string value)
+    {
+        await locator.FillAsync(value);
+        await locator.DispatchEventAsync("change");
+    }
+
+    private static async Task WaitForInteractiveReadyAsync(IPage page)
+    {
+        await page.GetByTestId("interactive-ready").WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Attached,
+            Timeout = 5000
+        });
+
+        var overlay = page.Locator(".announcement-overlay");
+        if (await overlay.IsVisibleAsync())
+        {
+            await overlay.GetByText("Pokračovat").ClickAsync();
+            await overlay.WaitForAsync(new LocatorWaitForOptions
+            {
+                State = WaitForSelectorState.Hidden,
+                Timeout = 3000
+            });
+        }
+    }
+
+    private async Task AssertNoBlazorErrorsAsync(IPage page)
+    {
+        var errorUi = page.Locator("#blazor-error-ui");
+        if (await errorUi.IsVisibleAsync())
+        {
+            var text = await errorUi.InnerTextAsync();
+            var bodyText = await page.Locator("body").InnerTextAsync();
+            throw new XunitException(
+                $"Blazor error UI was visible: {text}{Environment.NewLine}"
+                + $"Page body:{Environment.NewLine}{bodyText}{Environment.NewLine}"
+                + $"Host diagnostics:{Environment.NewLine}{_fixture.GetDiagnostics()}");
+        }
+    }
+
+    private sealed record SeededCharacterPrepData(
+        int GameId,
+        int SubmissionId,
+        int RegistrationIdOne,
+        int RegistrationIdTwo,
+        int[] EquipmentIds);
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepDashboardActionsTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepDashboardActionsTests.cs
@@ -1,0 +1,300 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+/// <summary>
+/// Dashboard action-bar behavior exercised through the same service calls the page
+/// performs: bulk pozvánka/připomínka, per-row reminder logic, and the
+/// "hide bulk buttons once game started" guard.
+/// </summary>
+public sealed class CharacterPrepDashboardActionsTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset NowUtc = new(FixedUtc);
+    private const int GameId = 1;
+
+    [Fact]
+    public async Task Bulk_pozvanka_click_sends_to_all_targets()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, startsIn: TimeSpan.FromDays(30));
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, fullyEquipped: false);
+        await AddSubmissionAsync(options, submissionId: 2, invitedAtUtc: null, players: 1, fullyEquipped: false);
+        await AddSubmissionAsync(options, submissionId: 3, invitedAtUtc: null, players: 1, fullyEquipped: false);
+
+        var (mail, sender, prep) = Build(options);
+
+        var targets = await prep.ListInvitationTargetsAsync(GameId, CancellationToken.None);
+        Assert.Equal(3, targets.Count); // sanity: counter the page will show
+
+        var result = await mail.SendBulkPozvankaAsync(GameId, NowUtc, CancellationToken.None);
+
+        Assert.Equal(3, result.Sent);
+        Assert.Equal(0, result.Failed);
+        Assert.Equal(3, sender.Captured.Count);
+    }
+
+    [Fact]
+    public async Task Bulk_pripominka_click_sends_to_all_reminder_targets()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, startsIn: TimeSpan.FromDays(30));
+        // Already invited 2 days ago, still not equipped → eligible for reminder.
+        await AddSubmissionAsync(options,
+            submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-2),
+            players: 1,
+            fullyEquipped: false);
+        await AddSubmissionAsync(options,
+            submissionId: 2,
+            invitedAtUtc: NowUtc.AddDays(-2),
+            players: 1,
+            fullyEquipped: false);
+
+        var (mail, sender, prep) = Build(options);
+
+        var reminderTargets = await prep.ListReminderTargetsAsync(GameId, NowUtc, CancellationToken.None);
+        Assert.Equal(2, reminderTargets.Count);
+
+        var result = await mail.SendBulkPripominkaAsync(GameId, NowUtc, CancellationToken.None);
+
+        Assert.Equal(2, result.Sent);
+        Assert.Equal(0, result.Failed);
+        Assert.Equal(2, sender.Captured.Count);
+        Assert.All(sender.Captured, m => Assert.Contains("Připomínka", m.Subject));
+    }
+
+    [Fact]
+    public async Task Per_row_reminder_on_NotInvited_row_invokes_Pozvanka()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, startsIn: TimeSpan.FromDays(30));
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, fullyEquipped: false);
+
+        var (mail, sender, _) = Build(options);
+
+        // The dashboard decides which method to call based on the row's status.
+        // For a NotInvited row the action is pozvánka.
+        var result = await mail.SendPozvankaAsync(1, NowUtc, CancellationToken.None);
+
+        Assert.Equal(SendSingleResult.Sent, result);
+        Assert.Single(sender.Captured);
+
+        await using var verify = new ApplicationDbContext(options);
+        var submission = await verify.RegistrationSubmissions.SingleAsync();
+        Assert.NotNull(submission.CharacterPrepInvitedAtUtc);
+    }
+
+    [Fact]
+    public async Task Per_row_reminder_on_Waiting_row_invokes_Pripominka()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, startsIn: TimeSpan.FromDays(30));
+        await AddSubmissionAsync(options,
+            submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-3),
+            players: 1,
+            fullyEquipped: false);
+
+        var (mail, sender, _) = Build(options);
+
+        var result = await mail.SendPripominkaAsync(1, NowUtc, CancellationToken.None);
+
+        Assert.Equal(SendSingleResult.Sent, result);
+        Assert.Single(sender.Captured);
+        Assert.Contains("Připomínka", sender.Captured[0].Subject);
+    }
+
+    [Fact]
+    public async Task Bulk_buttons_are_disabled_when_game_already_started()
+    {
+        var options = CreateOptions();
+        // Game started yesterday.
+        await SeedGameAsync(options, startsIn: TimeSpan.FromDays(-1));
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, fullyEquipped: false);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        // Page computes the "game has started" flag from Game.StartsAtUtc <= now and
+        // disables bulk buttons. We assert the underlying condition rather than render
+        // HTML (no bUnit/WAF).
+        await using var db = new ApplicationDbContext(options);
+        var game = await db.Games.AsNoTracking().SingleAsync();
+        var hasStarted = game.StartsAtUtc <= NowUtc.UtcDateTime;
+        Assert.True(hasStarted);
+
+        // And the service still reports targets — the UI is what gates the call.
+        var targets = await service.ListInvitationTargetsAsync(GameId, CancellationToken.None);
+        Assert.Single(targets);
+    }
+
+    [Fact]
+    public async Task Bulk_send_result_counts_reflect_toast_message()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, startsIn: TimeSpan.FromDays(30));
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, fullyEquipped: false);
+        await AddSubmissionAsync(options, submissionId: 2, invitedAtUtc: null, players: 1, fullyEquipped: false);
+        await AddSubmissionAsync(options, submissionId: 3, invitedAtUtc: null, players: 1, fullyEquipped: false);
+
+        var (mail, sender, _) = Build(options);
+        sender.FailForRecipient = "u2@example.cz";
+
+        var result = await mail.SendBulkPozvankaAsync(GameId, NowUtc, CancellationToken.None);
+
+        Assert.Equal(2, result.Sent);
+        Assert.Equal(1, result.Failed);
+        // The page composes a toast like:
+        //   "Posláno: {Sent} pozvánek, {Failed} chyb"
+        var toast = $"Posláno: {result.Sent} pozvánek, {result.Failed} chyb";
+        Assert.Equal("Posláno: 2 pozvánek, 1 chyb", toast);
+    }
+
+    // ------------------------------------------------------------ helpers
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static (CharacterPrepMailService Mail, FakeCharacterPrepEmailSender Sender, CharacterPrepService Prep) Build(
+        DbContextOptions<ApplicationDbContext> options)
+    {
+        var factory = new TestDbContextFactory(options);
+        var prep = new CharacterPrepService(factory);
+        var token = new CharacterPrepTokenService(factory);
+        var renderer = new CharacterPrepEmailRenderer();
+        var sender = new FakeCharacterPrepEmailSender();
+        var prepOptions = Options.Create(new CharacterPrepOptions
+        {
+            PublicBaseUrl = "https://registrace.ovcina.cz",
+            OrganizerContactEmail = "organizatori@ovcina.cz"
+        });
+        var mail = new CharacterPrepMailService(
+            factory, renderer, token, prep, sender, prepOptions,
+            NullLogger<CharacterPrepMailService>.Instance);
+        return (mail, sender, prep);
+    }
+
+    private static async Task SeedGameAsync(DbContextOptions<ApplicationDbContext> options, TimeSpan startsIn)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = GameId, Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.Add(startsIn),
+            EndsAtUtc = FixedUtc.Add(startsIn).AddDays(2),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(-10),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(-10),
+            PaymentDueAtUtc = FixedUtc.AddDays(-5),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = 10, GameId = GameId, Key = "sword", DisplayName = "Meč", SortOrder = 1
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task AddSubmissionAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int submissionId,
+        DateTimeOffset? invitedAtUtc,
+        int players,
+        bool fullyEquipped)
+    {
+        await using var db = new ApplicationDbContext(options);
+        var userId = "user-" + submissionId;
+        db.Users.Add(new ApplicationUser
+        {
+            Id = userId,
+            DisplayName = "U" + submissionId,
+            Email = $"u{submissionId}@example.cz",
+            NormalizedEmail = $"U{submissionId}@EXAMPLE.CZ",
+            UserName = $"u{submissionId}@example.cz",
+            NormalizedUserName = $"U{submissionId}@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = submissionId,
+            GameId = GameId,
+            RegistrantUserId = userId,
+            PrimaryContactName = "HH " + submissionId,
+            PrimaryEmail = $"u{submissionId}@example.cz",
+            PrimaryPhone = "777000000",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200,
+            CharacterPrepInvitedAtUtc = invitedAtUtc
+        });
+        await db.SaveChangesAsync();
+
+        for (var i = 0; i < players; i++)
+        {
+            var pid = submissionId * 1000 + i + 1;
+            db.People.Add(new Person
+            {
+                Id = pid, FirstName = "Kid" + i, LastName = "S" + submissionId, BirthYear = 2015,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = pid,
+                SubmissionId = submissionId,
+                PersonId = pid,
+                AttendeeType = AttendeeType.Player,
+                Status = RegistrationStatus.Active,
+                CharacterName = fullyEquipped ? "Aragorn" + i : null,
+                StartingEquipmentOptionId = fullyEquipped ? 10 : null,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class FakeCharacterPrepEmailSender : ICharacterPrepEmailSender
+    {
+        public List<SentMessage> Captured { get; } = new();
+        public string? FailForRecipient { get; set; }
+
+        public Task SendAsync(string recipientEmail, string subject, string htmlBody, CancellationToken cancellationToken)
+        {
+            if (FailForRecipient is not null
+                && string.Equals(FailForRecipient, recipientEmail, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("simulated send failure");
+            }
+            Captured.Add(new SentMessage(recipientEmail, subject, htmlBody));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record SentMessage(string To, string Subject, string HtmlBody);
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepDashboardLinkTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepDashboardLinkTests.cs
@@ -1,0 +1,64 @@
+using System.Text.RegularExpressions;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+/// <summary>
+/// Lock-in test for the organizer-dashboard household link. Regression guard for
+/// a Copilot-flagged bug where the dashboard linked to <c>/organizace/prihlaska/…</c>
+/// (singular) while the real SubmissionDetail route is <c>/organizace/prihlasky/…</c>
+/// (plural), giving a 404. This test reads the two razor files from disk and asserts
+/// the dashboard href matches the plural route directive in SubmissionDetail.
+/// </summary>
+public sealed class CharacterPrepDashboardLinkTests
+{
+    // Walk up from the test binary to the repo root and then down to the razor files.
+    private static string FindWebRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "RegistraceOvcina.Web");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate src/RegistraceOvcina.Web relative to the test binary.");
+    }
+
+    [Fact]
+    public void Dashboard_household_link_uses_plural_prihlasky_matching_SubmissionDetail_route()
+    {
+        var webRoot = FindWebRoot();
+        var dashboardPath = Path.Combine(
+            webRoot, "Components", "Pages", "Organizer", "CharacterPrepDashboard.razor");
+        var detailPath = Path.Combine(
+            webRoot, "Components", "Pages", "Organizer", "SubmissionDetail.razor");
+
+        Assert.True(File.Exists(dashboardPath), $"Missing: {dashboardPath}");
+        Assert.True(File.Exists(detailPath), $"Missing: {detailPath}");
+
+        var dashboard = File.ReadAllText(dashboardPath);
+        var detail = File.ReadAllText(detailPath);
+
+        // 1. Extract the @page route from SubmissionDetail.razor — the source of truth.
+        var routeMatch = Regex.Match(
+            detail,
+            "@page\\s+\"(?<route>/organizace/prihlasky/\\{submissionId:int\\})\"",
+            RegexOptions.IgnoreCase);
+        Assert.True(
+            routeMatch.Success,
+            "SubmissionDetail.razor must declare @page \"/organizace/prihlasky/{submissionId:int}\". "
+            + "If the route changed, update CharacterPrepDashboard.razor and this test together.");
+
+        // 2. Dashboard row-link must target the plural segment.
+        Assert.Contains(
+            "href=\"/organizace/prihlasky/@row.SubmissionId\"",
+            dashboard);
+
+        // 3. Bug lock: the singular variant must never reappear anywhere in the dashboard.
+        Assert.DoesNotContain("/organizace/prihlaska/", dashboard);
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepDashboardRowsTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepDashboardRowsTests.cs
@@ -281,15 +281,46 @@ public sealed class CharacterPrepDashboardRowsTests
         await db.SaveChangesAsync();
     }
 
+    // --------------------------------------------------------------------- soft-delete
+
+    [Fact]
+    public async Task Soft_deleted_submission_is_excluded_from_rows()
+    {
+        // GetDashboardRowsAsync has an explicit .Where(x => !x.Submission.IsDeleted)
+        // filter on top of the global query filter. This test locks in that behaviour
+        // so a future refactor cannot regress it silently.
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        await AddSubmissionAsync(options, submissionId: 1, household: "Alive",
+            invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) });
+
+        await AddSubmissionAsync(options, submissionId: 2, household: "Ghost",
+            invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) },
+            isDeleted: true);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var page = await service.GetDashboardRowsAsync(GameId, new DashboardFilter(null, null));
+
+        var row = Assert.Single(page.Rows);
+        Assert.Equal("Alive", row.HouseholdName);
+        Assert.Equal(1, page.Total);
+    }
+
+    // --------------------------------------------------------------------- helpers
+
     private static async Task AddSubmissionAsync(
         DbContextOptions<ApplicationDbContext> options,
         int submissionId,
         string household,
         DateTimeOffset? invitedAtUtc,
-        IReadOnlyList<PlayerSpec> players)
+        IReadOnlyList<PlayerSpec> players,
+        bool isDeleted = false)
     {
         await using var db = new ApplicationDbContext(options);
-        AddUserAndSubmission(db, submissionId, household, invitedAtUtc);
+        AddUserAndSubmission(db, submissionId, household, invitedAtUtc, isDeleted);
         await db.SaveChangesAsync();
 
         for (var i = 0; i < players.Count; i++)
@@ -345,7 +376,8 @@ public sealed class CharacterPrepDashboardRowsTests
 
     private static void AddUserAndSubmission(
         ApplicationDbContext db,
-        int submissionId, string household, DateTimeOffset? invitedAtUtc)
+        int submissionId, string household, DateTimeOffset? invitedAtUtc,
+        bool isDeleted = false)
     {
         var userId = "user-" + submissionId;
         db.Users.Add(new ApplicationUser
@@ -374,7 +406,8 @@ public sealed class CharacterPrepDashboardRowsTests
             SubmittedAtUtc = FixedUtc,
             LastEditedAtUtc = FixedUtc,
             ExpectedTotalAmount = 1200,
-            CharacterPrepInvitedAtUtc = invitedAtUtc
+            CharacterPrepInvitedAtUtc = invitedAtUtc,
+            IsDeleted = isDeleted
         });
     }
 

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepDashboardRowsTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepDashboardRowsTests.cs
@@ -1,0 +1,389 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+/// <summary>
+/// Covers <see cref="CharacterPrepService.GetDashboardRowsAsync"/>: one row per Player
+/// registration, status derivation, status filter, full-text search (person + character
+/// name, case-insensitive), sort order (status asc → HouseholdName) and pagination.
+/// </summary>
+public sealed class CharacterPrepDashboardRowsTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset NowUtc = new(FixedUtc);
+    private const int GameId = 1;
+    private const int EquipmentId = 10;
+
+    // --------------------------------------------------------------------- status derivation
+
+    [Fact]
+    public async Task Status_is_NotInvited_when_submission_has_no_invite_timestamp()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, household: "Alpha",
+            invitedAtUtc: null,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) });
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var page = await service.GetDashboardRowsAsync(GameId, new DashboardFilter(null, null));
+
+        var row = Assert.Single(page.Rows);
+        Assert.Equal(CharacterPrepStatus.NotInvited, row.Status);
+    }
+
+    [Fact]
+    public async Task Status_is_Waiting_when_invited_but_missing_character_name_or_equipment()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, household: "Alpha",
+            invitedAtUtc: NowUtc,
+            players: new[]
+            {
+                new PlayerSpec(hasName: true, hasEquipment: false),
+                new PlayerSpec(hasName: false, hasEquipment: true),
+            });
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var page = await service.GetDashboardRowsAsync(GameId, new DashboardFilter(null, null));
+
+        Assert.All(page.Rows, r => Assert.Equal(CharacterPrepStatus.Waiting, r.Status));
+        Assert.Equal(2, page.Rows.Count);
+    }
+
+    [Fact]
+    public async Task Status_is_Done_when_invited_and_fully_populated()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, household: "Alpha",
+            invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) });
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var page = await service.GetDashboardRowsAsync(GameId, new DashboardFilter(null, null));
+
+        var row = Assert.Single(page.Rows);
+        Assert.Equal(CharacterPrepStatus.Done, row.Status);
+    }
+
+    [Fact]
+    public async Task Whitespace_only_character_name_counts_as_missing()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, household: "Alpha",
+            invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) });
+
+        // Force a blank character name directly to prove the status derivation trims.
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var reg = await db.Registrations.SingleAsync();
+            reg.CharacterName = "   ";
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var page = await service.GetDashboardRowsAsync(GameId, new DashboardFilter(null, null));
+
+        var row = Assert.Single(page.Rows);
+        Assert.Equal(CharacterPrepStatus.Waiting, row.Status);
+    }
+
+    // --------------------------------------------------------------------- sort order
+
+    [Fact]
+    public async Task Rows_sorted_NotInvited_then_Waiting_then_Done_then_household()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        // Done, household "Z"
+        await AddSubmissionAsync(options, submissionId: 1, household: "Zeta",
+            invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) });
+        // Waiting, household "B"
+        await AddSubmissionAsync(options, submissionId: 2, household: "Beta",
+            invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: false, hasEquipment: false) });
+        // NotInvited, household "M"
+        await AddSubmissionAsync(options, submissionId: 3, household: "Mu",
+            invitedAtUtc: null,
+            players: new[] { new PlayerSpec(hasName: false, hasEquipment: false) });
+        // NotInvited, household "A" (should come first)
+        await AddSubmissionAsync(options, submissionId: 4, household: "Alpha",
+            invitedAtUtc: null,
+            players: new[] { new PlayerSpec(hasName: false, hasEquipment: false) });
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var page = await service.GetDashboardRowsAsync(GameId, new DashboardFilter(null, null));
+
+        var statuses = page.Rows.Select(r => r.Status).ToArray();
+        Assert.Equal(new[]
+        {
+            CharacterPrepStatus.NotInvited,
+            CharacterPrepStatus.NotInvited,
+            CharacterPrepStatus.Waiting,
+            CharacterPrepStatus.Done
+        }, statuses);
+
+        // Within NotInvited, "Alpha" precedes "Mu".
+        Assert.Equal("Alpha", page.Rows[0].HouseholdName);
+        Assert.Equal("Mu", page.Rows[1].HouseholdName);
+    }
+
+    // --------------------------------------------------------------------- status filter
+
+    [Fact]
+    public async Task Status_filter_restricts_rows_to_requested_status()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, household: "A",
+            invitedAtUtc: null,
+            players: new[] { new PlayerSpec(hasName: false, hasEquipment: false) });
+        await AddSubmissionAsync(options, submissionId: 2, household: "B",
+            invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) });
+        await AddSubmissionAsync(options, submissionId: 3, household: "C",
+            invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: false, hasEquipment: false) });
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        var waiting = await service.GetDashboardRowsAsync(
+            GameId, new DashboardFilter(CharacterPrepStatus.Waiting, null));
+        Assert.Equal(1, waiting.Total);
+        Assert.All(waiting.Rows, r => Assert.Equal(CharacterPrepStatus.Waiting, r.Status));
+
+        var done = await service.GetDashboardRowsAsync(
+            GameId, new DashboardFilter(CharacterPrepStatus.Done, null));
+        Assert.Equal(1, done.Total);
+        Assert.All(done.Rows, r => Assert.Equal(CharacterPrepStatus.Done, r.Status));
+
+        var notInvited = await service.GetDashboardRowsAsync(
+            GameId, new DashboardFilter(CharacterPrepStatus.NotInvited, null));
+        Assert.Equal(1, notInvited.Total);
+        Assert.All(notInvited.Rows, r => Assert.Equal(CharacterPrepStatus.NotInvited, r.Status));
+    }
+
+    // --------------------------------------------------------------------- search
+
+    [Fact]
+    public async Task Search_matches_person_name_case_insensitive()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionWithNamedPersonAsync(options, submissionId: 1, household: "H1",
+            firstName: "Tomáš", lastName: "Pajonek", characterName: null);
+        await AddSubmissionWithNamedPersonAsync(options, submissionId: 2, household: "H2",
+            firstName: "Eva", lastName: "Dlouhá", characterName: null);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        var result = await service.GetDashboardRowsAsync(
+            GameId, new DashboardFilter(null, "PAJ"));
+
+        Assert.Equal(1, result.Total);
+        Assert.Contains("Pajonek", result.Rows[0].PersonFullName);
+    }
+
+    [Fact]
+    public async Task Search_matches_character_name_case_insensitive()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionWithNamedPersonAsync(options, submissionId: 1, household: "H1",
+            firstName: "Kid", lastName: "One", characterName: "Legolas");
+        await AddSubmissionWithNamedPersonAsync(options, submissionId: 2, household: "H2",
+            firstName: "Kid", lastName: "Two", characterName: "Gimli");
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        var result = await service.GetDashboardRowsAsync(
+            GameId, new DashboardFilter(null, "legol"));
+
+        Assert.Equal(1, result.Total);
+        Assert.Equal("Legolas", result.Rows[0].CharacterName);
+    }
+
+    // --------------------------------------------------------------------- pagination
+
+    [Fact]
+    public async Task Paging_respects_page_and_page_size()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        for (var i = 0; i < 7; i++)
+        {
+            await AddSubmissionAsync(options, submissionId: i + 1,
+                household: "H" + i.ToString("D2"),
+                invitedAtUtc: null,
+                players: new[] { new PlayerSpec(hasName: false, hasEquipment: false) });
+        }
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        var page1 = await service.GetDashboardRowsAsync(
+            GameId, new DashboardFilter(null, null), page: 1, pageSize: 3);
+        var page2 = await service.GetDashboardRowsAsync(
+            GameId, new DashboardFilter(null, null), page: 2, pageSize: 3);
+        var page3 = await service.GetDashboardRowsAsync(
+            GameId, new DashboardFilter(null, null), page: 3, pageSize: 3);
+
+        Assert.Equal(7, page1.Total);
+        Assert.Equal(3, page1.Rows.Count);
+        Assert.Equal(3, page2.Rows.Count);
+        Assert.Single(page3.Rows);
+
+        // No overlap across pages.
+        var ids = page1.Rows.Concat(page2.Rows).Concat(page3.Rows)
+            .Select(r => r.RegistrationId).ToArray();
+        Assert.Equal(ids.Distinct().Count(), ids.Length);
+    }
+
+    // --------------------------------------------------------------------- helpers
+
+    private sealed record PlayerSpec(bool hasName, bool hasEquipment);
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedGameAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = GameId, Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(15),
+            PaymentDueAtUtc = FixedUtc.AddDays(25),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = EquipmentId, GameId = GameId, Key = "sword", DisplayName = "Meč", SortOrder = 1
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task AddSubmissionAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int submissionId,
+        string household,
+        DateTimeOffset? invitedAtUtc,
+        IReadOnlyList<PlayerSpec> players)
+    {
+        await using var db = new ApplicationDbContext(options);
+        AddUserAndSubmission(db, submissionId, household, invitedAtUtc);
+        await db.SaveChangesAsync();
+
+        for (var i = 0; i < players.Count; i++)
+        {
+            var pid = submissionId * 100 + i + 1;
+            db.People.Add(new Person
+            {
+                Id = pid, FirstName = "Kid" + i, LastName = "S" + submissionId, BirthYear = 2015,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = pid,
+                SubmissionId = submissionId,
+                PersonId = pid,
+                AttendeeType = AttendeeType.Player,
+                Status = RegistrationStatus.Active,
+                CharacterName = players[i].hasName ? "Hero " + i : null,
+                StartingEquipmentOptionId = players[i].hasEquipment ? EquipmentId : null,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task AddSubmissionWithNamedPersonAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int submissionId, string household,
+        string firstName, string lastName, string? characterName)
+    {
+        await using var db = new ApplicationDbContext(options);
+        AddUserAndSubmission(db, submissionId, household, invitedAtUtc: NowUtc);
+        var pid = submissionId * 100 + 1;
+        db.People.Add(new Person
+        {
+            Id = pid, FirstName = firstName, LastName = lastName, BirthYear = 2015,
+            CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+        });
+        db.Registrations.Add(new Registration
+        {
+            Id = pid,
+            SubmissionId = submissionId,
+            PersonId = pid,
+            AttendeeType = AttendeeType.Player,
+            Status = RegistrationStatus.Active,
+            CharacterName = characterName,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static void AddUserAndSubmission(
+        ApplicationDbContext db,
+        int submissionId, string household, DateTimeOffset? invitedAtUtc)
+    {
+        var userId = "user-" + submissionId;
+        db.Users.Add(new ApplicationUser
+        {
+            Id = userId,
+            DisplayName = "U" + submissionId,
+            Email = $"u{submissionId}@example.cz",
+            NormalizedEmail = $"U{submissionId}@EXAMPLE.CZ",
+            UserName = $"u{submissionId}@example.cz",
+            NormalizedUserName = $"U{submissionId}@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = submissionId,
+            GameId = GameId,
+            RegistrantUserId = userId,
+            PrimaryContactName = household,
+            PrimaryEmail = $"u{submissionId}@example.cz",
+            PrimaryPhone = "777000000",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200,
+            CharacterPrepInvitedAtUtc = invitedAtUtc
+        });
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepDashboardStatsRouteTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepDashboardStatsRouteTests.cs
@@ -1,0 +1,189 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+/// <summary>
+/// Route-level coverage for the dashboard page. We don't have a WAF, so these exercise
+/// the exact service calls the page performs: GetDashboardStatsAsync + (in the
+/// "reflects current state" test) the save → re-read loop the page will drive.
+/// </summary>
+public sealed class CharacterPrepDashboardStatsRouteTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset NowUtc = new(FixedUtc);
+    private const int GameId = 1;
+    private const int EquipmentId = 10;
+
+    [Fact]
+    public async Task Dashboard_returns_stats_for_game()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1,
+            invitedAtUtc: NowUtc,
+            players: new[]
+            {
+                new PlayerSpec(hasName: true, hasEquipment: true),
+                new PlayerSpec(hasName: false, hasEquipment: false),
+            });
+        await AddSubmissionAsync(options, submissionId: 2,
+            invitedAtUtc: null,
+            players: new[] { new PlayerSpec(hasName: false, hasEquipment: false) });
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var stats = await service.GetDashboardStatsAsync(GameId, CancellationToken.None);
+
+        Assert.Equal(2, stats.TotalHouseholds);
+        Assert.Equal(1, stats.Invited);
+        // Submission 1 has one player without equipment, so not FullyFilled.
+        Assert.Equal(0, stats.FullyFilled);
+        // Pending = TotalHouseholds - FullyFilled (per service).
+        Assert.Equal(2, stats.Pending);
+    }
+
+    [Fact]
+    public async Task Stats_reflect_current_state_after_save()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1,
+            invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: false, hasEquipment: false) });
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        var before = await service.GetDashboardStatsAsync(GameId, CancellationToken.None);
+        Assert.Equal(1, before.Invited);
+        Assert.Equal(0, before.FullyFilled);
+        Assert.Equal(1, before.Pending);
+
+        // Get the single registration id and save name+equipment via the real service,
+        // exactly mirroring the organizer-override flow the dashboard is going to use.
+        int regId;
+        await using (var db = new ApplicationDbContext(options))
+        {
+            regId = await db.Registrations.Select(x => x.Id).SingleAsync();
+        }
+        await service.SaveAsync(
+            submissionId: 1,
+            new[] { new CharacterPrepSaveRow(regId, "Legolas", EquipmentId, null) },
+            NowUtc,
+            CancellationToken.None);
+
+        var after = await service.GetDashboardStatsAsync(GameId, CancellationToken.None);
+        Assert.Equal(1, after.Invited);
+        Assert.Equal(1, after.FullyFilled);
+        Assert.Equal(0, after.Pending);
+    }
+
+    // ------------------------------------------------------------ helpers (mirror of existing tests)
+
+    private sealed record PlayerSpec(bool hasName, bool hasEquipment);
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedGameAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = GameId,
+            Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(15),
+            PaymentDueAtUtc = FixedUtc.AddDays(25),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = EquipmentId, GameId = GameId, Key = "sword", DisplayName = "Meč", SortOrder = 1
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task AddSubmissionAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int submissionId,
+        DateTimeOffset? invitedAtUtc,
+        IReadOnlyList<PlayerSpec> players)
+    {
+        await using var db = new ApplicationDbContext(options);
+        var userId = "user-" + submissionId;
+        db.Users.Add(new ApplicationUser
+        {
+            Id = userId,
+            DisplayName = "U" + submissionId,
+            Email = $"u{submissionId}@example.cz",
+            NormalizedEmail = $"U{submissionId}@EXAMPLE.CZ",
+            UserName = $"u{submissionId}@example.cz",
+            NormalizedUserName = $"U{submissionId}@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = submissionId,
+            GameId = GameId,
+            RegistrantUserId = userId,
+            PrimaryContactName = "Household " + submissionId,
+            PrimaryEmail = $"u{submissionId}@example.cz",
+            PrimaryPhone = "777000000",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200,
+            CharacterPrepInvitedAtUtc = invitedAtUtc
+        });
+
+        for (var i = 0; i < players.Count; i++)
+        {
+            var spec = players[i];
+            var personId = submissionId * 100 + i + 1;
+            var regId = submissionId * 100 + i + 1;
+            db.People.Add(new Person
+            {
+                Id = personId, FirstName = "Kid" + i, LastName = "S" + submissionId, BirthYear = 2015,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = regId,
+                SubmissionId = submissionId,
+                PersonId = personId,
+                AttendeeType = AttendeeType.Player,
+                Status = RegistrationStatus.Active,
+                CharacterName = spec.hasName ? "Aragorn" + i : null,
+                StartingEquipmentOptionId = spec.hasEquipment ? EquipmentId : null,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepEmailRendererTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepEmailRendererTests.cs
@@ -136,6 +136,36 @@ public sealed class CharacterPrepEmailRendererTests
     }
 
     [Fact]
+    public void Pozvanka_with_blank_contact_email_omits_mailto_link_and_contact_sentence()
+    {
+        // When no OrganizerContactEmail is configured, the renderer must not
+        // emit a dead <a href="mailto:"></a> link. Cheapest insurance against
+        // the CharacterPrep options arriving empty in some dev environments.
+        var renderer = new CharacterPrepEmailRenderer();
+        var model = CreateModel(organizerContact: "");
+
+        var rendered = renderer.RenderPozvanka(model);
+
+        Assert.DoesNotContain("mailto:\"", rendered.HtmlBody);
+        Assert.DoesNotContain("href=\"mailto:\"", rendered.HtmlBody);
+        Assert.DoesNotContain("<a href=\"\"", rendered.HtmlBody);
+        Assert.DoesNotContain("napiš nám", rendered.HtmlBody);
+        Assert.DoesNotContain("napiš nám", rendered.PlainTextBody);
+    }
+
+    [Fact]
+    public void Pozvanka_with_whitespace_contact_email_omits_mailto_link()
+    {
+        var renderer = new CharacterPrepEmailRenderer();
+        var model = CreateModel(organizerContact: "   ");
+
+        var rendered = renderer.RenderPozvanka(model);
+
+        Assert.DoesNotContain("mailto:\"", rendered.HtmlBody);
+        Assert.DoesNotContain("href=\"mailto:", rendered.HtmlBody);
+    }
+
+    [Fact]
     public void Both_produce_nonempty_plaintext()
     {
         var renderer = new CharacterPrepEmailRenderer();

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepEmailRendererTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepEmailRendererTests.cs
@@ -1,0 +1,153 @@
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+public sealed class CharacterPrepEmailRendererTests
+{
+    private static readonly DateTime GameStart = new(2026, 6, 15, 10, 0, 0, DateTimeKind.Utc);
+
+    private static CharacterPrepEmailModel CreateModel(
+        string gameName = "Ovčina 2026",
+        string prepUrl = "https://registrace.ovcina.cz/postavy/abc123",
+        string[]? playerNames = null,
+        StartingEquipmentOptionView[]? options = null,
+        string organizerContact = "organizatori@ovcina.cz") =>
+        new(
+            gameName,
+            GameStart,
+            prepUrl,
+            playerNames ?? new[] { "Jan Novák", "Eva Nováková" },
+            options ?? new[]
+            {
+                new StartingEquipmentOptionView(1, "tesak", "Tesák", "Krátký meč", 1),
+                new StartingEquipmentOptionView(2, "luk", "Luk", "Lehký lovecký luk", 2),
+                new StartingEquipmentOptionView(3, "hul", "Hůl", "Dřevěná bojová hůl", 3),
+                new StartingEquipmentOptionView(4, "prak", "Prak", "Kožený prak", 4),
+                new StartingEquipmentOptionView(5, "nuz", "Nůž", "Obyčejný lovecký nůž", 5),
+            },
+            organizerContact);
+
+    [Fact]
+    public void Pozvanka_subject_contains_game_name()
+    {
+        var renderer = new CharacterPrepEmailRenderer();
+        var model = CreateModel(gameName: "Ovčina 2026 — Letní");
+
+        var rendered = renderer.RenderPozvanka(model);
+
+        Assert.Contains("Ovčina 2026 — Letní", rendered.Subject);
+        Assert.Contains("Příprava postav", rendered.Subject);
+    }
+
+    [Fact]
+    public void Pozvanka_html_contains_prep_url()
+    {
+        var renderer = new CharacterPrepEmailRenderer();
+        var model = CreateModel(prepUrl: "https://registrace.ovcina.cz/postavy/XYZ-token-42");
+
+        var rendered = renderer.RenderPozvanka(model);
+
+        Assert.Contains("https://registrace.ovcina.cz/postavy/XYZ-token-42", rendered.HtmlBody);
+    }
+
+    [Fact]
+    public void Pozvanka_html_lists_each_player_name()
+    {
+        var renderer = new CharacterPrepEmailRenderer();
+        var model = CreateModel(playerNames: new[] { "Petr Dvořák", "Anna Dvořáková", "Lukáš Dvořák" });
+
+        var rendered = renderer.RenderPozvanka(model);
+
+        Assert.Contains("Petr Dvořák", rendered.HtmlBody);
+        Assert.Contains("Anna Dvořáková", rendered.HtmlBody);
+        Assert.Contains("Lukáš Dvořák", rendered.HtmlBody);
+    }
+
+    [Fact]
+    public void Pozvanka_html_lists_each_equipment_option()
+    {
+        var renderer = new CharacterPrepEmailRenderer();
+        var options = new[]
+        {
+            new StartingEquipmentOptionView(1, "tesak", "Tesák", "Krátký meč", 1),
+            new StartingEquipmentOptionView(2, "luk", "Luk", "Lehký lovecký luk", 2),
+            new StartingEquipmentOptionView(3, "hul", "Hůl", "Dřevěná bojová hůl", 3),
+        };
+        var model = CreateModel(options: options);
+
+        var rendered = renderer.RenderPozvanka(model);
+
+        Assert.Contains("Tesák", rendered.HtmlBody);
+        Assert.Contains("Krátký meč", rendered.HtmlBody);
+        Assert.Contains("Luk", rendered.HtmlBody);
+        Assert.Contains("Lehký lovecký luk", rendered.HtmlBody);
+        Assert.Contains("Hůl", rendered.HtmlBody);
+        Assert.Contains("Dřevěná bojová hůl", rendered.HtmlBody);
+    }
+
+    [Fact]
+    public void Pozvanka_html_contains_deadline_3_days_before_game_start()
+    {
+        var renderer = new CharacterPrepEmailRenderer();
+        // Game starts 2026-06-15 — deadline line should contain 12. 6. 2026
+        var model = CreateModel();
+
+        var rendered = renderer.RenderPozvanka(model);
+
+        Assert.Contains("12. 6. 2026", rendered.HtmlBody);
+    }
+
+    [Fact]
+    public void Pripominka_subject_correct()
+    {
+        var renderer = new CharacterPrepEmailRenderer();
+        var model = CreateModel(gameName: "Ovčina 2026");
+
+        var rendered = renderer.RenderPripominka(model);
+
+        Assert.Contains("Připomínka", rendered.Subject);
+        Assert.Contains("Ovčina 2026", rendered.Subject);
+    }
+
+    [Fact]
+    public void Pripominka_html_contains_prep_url_link()
+    {
+        var renderer = new CharacterPrepEmailRenderer();
+        var model = CreateModel(prepUrl: "https://registrace.ovcina.cz/postavy/abc-xyz");
+
+        var rendered = renderer.RenderPripominka(model);
+
+        // must be rendered as a clickable <a href="..."> link
+        Assert.Contains("href=\"https://registrace.ovcina.cz/postavy/abc-xyz\"", rendered.HtmlBody);
+    }
+
+    [Fact]
+    public void Pripominka_plaintext_contains_url_inline()
+    {
+        var renderer = new CharacterPrepEmailRenderer();
+        var model = CreateModel(prepUrl: "https://registrace.ovcina.cz/postavy/reminder-token");
+
+        var rendered = renderer.RenderPripominka(model);
+
+        Assert.Contains("https://registrace.ovcina.cz/postavy/reminder-token", rendered.PlainTextBody);
+        // plain text body must have no HTML tags
+        Assert.DoesNotContain("<a ", rendered.PlainTextBody);
+        Assert.DoesNotContain("<br", rendered.PlainTextBody);
+    }
+
+    [Fact]
+    public void Both_produce_nonempty_plaintext()
+    {
+        var renderer = new CharacterPrepEmailRenderer();
+        var model = CreateModel();
+
+        var pozvanka = renderer.RenderPozvanka(model);
+        var pripominka = renderer.RenderPripominka(model);
+
+        Assert.False(string.IsNullOrWhiteSpace(pozvanka.PlainTextBody));
+        Assert.False(string.IsNullOrWhiteSpace(pripominka.PlainTextBody));
+        // plaintext bodies must not contain HTML tags
+        Assert.DoesNotContain("<", pozvanka.PlainTextBody);
+        Assert.DoesNotContain("<", pripominka.PlainTextBody);
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepExportServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepExportServiceTests.cs
@@ -1,0 +1,350 @@
+using ClosedXML.Excel;
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+public sealed class CharacterPrepExportServiceTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private const int GameId = 1;
+    private const int EquipmentId = 10;
+
+    [Fact]
+    public async Task BuildAsync_returns_non_empty_bytes()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+
+        var service = new CharacterPrepExportService(new TestDbContextFactory(options));
+
+        var bytes = await service.BuildAsync(GameId, CancellationToken.None);
+
+        Assert.NotNull(bytes);
+        Assert.NotEmpty(bytes);
+    }
+
+    [Fact]
+    public async Task BuildAsync_returns_valid_xlsx()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+
+        var service = new CharacterPrepExportService(new TestDbContextFactory(options));
+
+        var bytes = await service.BuildAsync(GameId, CancellationToken.None);
+
+        // Roundtrip open — should not throw.
+        using var stream = new MemoryStream(bytes);
+        using var workbook = new XLWorkbook(stream);
+        Assert.True(workbook.Worksheets.Any());
+    }
+
+    [Fact]
+    public async Task BuildAsync_header_row_has_7_columns_in_correct_order()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+
+        var service = new CharacterPrepExportService(new TestDbContextFactory(options));
+
+        var bytes = await service.BuildAsync(GameId, CancellationToken.None);
+
+        using var stream = new MemoryStream(bytes);
+        using var workbook = new XLWorkbook(stream);
+        var sheet = workbook.Worksheet("Příprava postav");
+
+        Assert.Equal("Hráč", sheet.Cell(1, 1).GetString());
+        Assert.Equal("Rok narození", sheet.Cell(1, 2).GetString());
+        Assert.Equal("Jméno postavy", sheet.Cell(1, 3).GetString());
+        Assert.Equal("Startovní výbava", sheet.Cell(1, 4).GetString());
+        Assert.Equal("Poznámka", sheet.Cell(1, 5).GetString());
+        Assert.Equal("Domácnost", sheet.Cell(1, 6).GetString());
+        Assert.Equal("Email domácnosti", sheet.Cell(1, 7).GetString());
+        Assert.Equal("", sheet.Cell(1, 8).GetString());
+        Assert.True(sheet.Cell(1, 1).Style.Font.Bold);
+    }
+
+    [Fact]
+    public async Task BuildAsync_row_count_matches_Player_attendee_count()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+
+        var service = new CharacterPrepExportService(new TestDbContextFactory(options));
+
+        var bytes = await service.BuildAsync(GameId, CancellationToken.None);
+
+        using var stream = new MemoryStream(bytes);
+        using var workbook = new XLWorkbook(stream);
+        var sheet = workbook.Worksheet("Příprava postav");
+
+        // 3 Player registrations seeded → rows 2, 3, 4. Row 5 should be empty.
+        Assert.NotEqual("", sheet.Cell(2, 1).GetString());
+        Assert.NotEqual("", sheet.Cell(3, 1).GetString());
+        Assert.NotEqual("", sheet.Cell(4, 1).GetString());
+        Assert.Equal("", sheet.Cell(5, 1).GetString());
+    }
+
+    [Fact]
+    public async Task BuildAsync_excludes_non_Player_attendees()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+
+        var service = new CharacterPrepExportService(new TestDbContextFactory(options));
+
+        var bytes = await service.BuildAsync(GameId, CancellationToken.None);
+
+        using var stream = new MemoryStream(bytes);
+        using var workbook = new XLWorkbook(stream);
+        var sheet = workbook.Worksheet("Příprava postav");
+
+        // The Adult helper (seeded with name "Dospělák Pomocník") must not appear.
+        var allValues = Enumerable.Range(2, 10)
+            .Select(r => sheet.Cell(r, 1).GetString())
+            .ToList();
+        Assert.DoesNotContain(allValues, v => v.Contains("Dospělák", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task BuildAsync_empty_cells_stay_empty_not_placeholder()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+
+        var service = new CharacterPrepExportService(new TestDbContextFactory(options));
+
+        var bytes = await service.BuildAsync(GameId, CancellationToken.None);
+
+        using var stream = new MemoryStream(bytes);
+        using var workbook = new XLWorkbook(stream);
+        var sheet = workbook.Worksheet("Příprava postav");
+
+        // Anna Adamová (row 2) has no character name, equipment, or note.
+        Assert.Equal("Anna Adamová", sheet.Cell(2, 1).GetString());
+        Assert.Equal("", sheet.Cell(2, 3).GetString()); // Jméno postavy
+        Assert.Equal("", sheet.Cell(2, 4).GetString()); // Startovní výbava
+        Assert.Equal("", sheet.Cell(2, 5).GetString()); // Poznámka
+    }
+
+    [Fact]
+    public async Task BuildAsync_Czech_characters_encode_correctly()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+
+        var service = new CharacterPrepExportService(new TestDbContextFactory(options));
+
+        var bytes = await service.BuildAsync(GameId, CancellationToken.None);
+
+        using var stream = new MemoryStream(bytes);
+        using var workbook = new XLWorkbook(stream);
+        var sheet = workbook.Worksheet("Příprava postav");
+
+        // Šárka Černá was seeded with diacritics intact; bytes must roundtrip exactly.
+        var found = false;
+        for (var r = 2; r <= 10; r++)
+        {
+            if (sheet.Cell(r, 1).GetString() == "Šárka Černá")
+            {
+                found = true;
+                break;
+            }
+        }
+        Assert.True(found, "Expected a row with name 'Šárka Černá' (diacritics preserved).");
+    }
+
+    [Fact]
+    public async Task BuildAsync_orders_by_lastname_firstname()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+
+        var service = new CharacterPrepExportService(new TestDbContextFactory(options));
+
+        var bytes = await service.BuildAsync(GameId, CancellationToken.None);
+
+        using var stream = new MemoryStream(bytes);
+        using var workbook = new XLWorkbook(stream);
+        var sheet = workbook.Worksheet("Příprava postav");
+
+        // Players sorted by LastName, then FirstName:
+        //   Anna Adamová (Adamová, Anna)
+        //   Bořek Adamů (Adamů, Bořek)
+        //   Šárka Černá (Černá, Šárka)
+        Assert.Equal("Anna Adamová", sheet.Cell(2, 1).GetString());
+        Assert.Equal("Bořek Adamů", sheet.Cell(3, 1).GetString());
+        Assert.Equal("Šárka Černá", sheet.Cell(4, 1).GetString());
+    }
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+
+        db.Games.Add(new Game
+        {
+            Id = GameId,
+            Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(15),
+            PaymentDueAtUtc = FixedUtc.AddDays(25),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc,
+        });
+
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = EquipmentId,
+            GameId = GameId,
+            Key = "sword",
+            DisplayName = "Meč (3/1)",
+            SortOrder = 1,
+        });
+
+        db.Users.Add(new ApplicationUser
+        {
+            Id = "user-1",
+            DisplayName = "Parent 1",
+            Email = "p1@example.cz",
+            NormalizedEmail = "P1@EXAMPLE.CZ",
+            UserName = "p1@example.cz",
+            NormalizedUserName = "P1@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc,
+        });
+        db.Users.Add(new ApplicationUser
+        {
+            Id = "user-2",
+            DisplayName = "Parent 2",
+            Email = "p2@example.cz",
+            NormalizedEmail = "P2@EXAMPLE.CZ",
+            UserName = "p2@example.cz",
+            NormalizedUserName = "P2@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc,
+        });
+
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = 1,
+            GameId = GameId,
+            RegistrantUserId = "user-1",
+            PrimaryContactName = "Adamovi",
+            PrimaryEmail = "adamovi@example.cz",
+            PrimaryPhone = "777111222",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200,
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = 2,
+            GameId = GameId,
+            RegistrantUserId = "user-2",
+            PrimaryContactName = "Černí",
+            PrimaryEmail = "cerni@example.cz",
+            PrimaryPhone = "777333444",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200,
+        });
+
+        db.People.Add(MakePerson(101, "Anna", "Adamová", 2015));
+        db.People.Add(MakePerson(102, "Bořek", "Adamů", 2014));
+        db.People.Add(MakePerson(103, "Dospělák", "Pomocník", 1990));
+        db.People.Add(MakePerson(201, "Šárka", "Černá", 2013));
+
+        // Submission 1: Anna (no prep), Bořek (with prep), adult helper (excluded).
+        db.Registrations.Add(new Registration
+        {
+            Id = 1001,
+            SubmissionId = 1,
+            PersonId = 101,
+            AttendeeType = AttendeeType.Player,
+            Status = RegistrationStatus.Active,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc,
+        });
+        db.Registrations.Add(new Registration
+        {
+            Id = 1002,
+            SubmissionId = 1,
+            PersonId = 102,
+            AttendeeType = AttendeeType.Player,
+            Status = RegistrationStatus.Active,
+            CharacterName = "Elrond",
+            StartingEquipmentOptionId = EquipmentId,
+            CharacterPrepNote = "preferuje luk",
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc,
+        });
+        db.Registrations.Add(new Registration
+        {
+            Id = 1003,
+            SubmissionId = 1,
+            PersonId = 103,
+            AttendeeType = AttendeeType.Adult,
+            Status = RegistrationStatus.Active,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc,
+        });
+
+        // Submission 2: Šárka Černá (Player, Czech diacritics).
+        db.Registrations.Add(new Registration
+        {
+            Id = 2001,
+            SubmissionId = 2,
+            PersonId = 201,
+            AttendeeType = AttendeeType.Player,
+            Status = RegistrationStatus.Active,
+            CharacterName = "Galadriel",
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc,
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    private static Person MakePerson(int id, string first, string last, int birthYear) =>
+        new()
+        {
+            Id = id,
+            FirstName = first,
+            LastName = last,
+            BirthYear = birthYear,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc,
+        };
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepMailServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepMailServiceTests.cs
@@ -1,0 +1,395 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+public sealed class CharacterPrepMailServiceTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset NowUtc = new(FixedUtc);
+    private const int GameId = 1;
+    private const int EquipmentId = 10;
+
+    [Fact]
+    public async Task SendPozvankaAsync_first_time_sends_email_and_marks_invited()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, adults: 0);
+
+        var (service, sender) = CreateService(options);
+
+        var result = await service.SendPozvankaAsync(1, NowUtc, CancellationToken.None);
+
+        Assert.Equal(SendSingleResult.Sent, result);
+        Assert.Single(sender.Captured);
+        Assert.Equal("u1@example.cz", sender.Captured[0].To);
+
+        await using var verify = new ApplicationDbContext(options);
+        var submission = await verify.RegistrationSubmissions.SingleAsync(x => x.Id == 1);
+        Assert.NotNull(submission.CharacterPrepInvitedAtUtc);
+        Assert.False(string.IsNullOrEmpty(submission.CharacterPrepToken));
+    }
+
+    [Fact]
+    public async Task SendPozvankaAsync_second_time_returns_AlreadyInvited_no_duplicate_sends()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-2),
+            players: 1, adults: 0);
+
+        var (service, sender) = CreateService(options);
+
+        var result = await service.SendPozvankaAsync(1, NowUtc, CancellationToken.None);
+
+        Assert.Equal(SendSingleResult.AlreadyInvited, result);
+        Assert.Empty(sender.Captured);
+    }
+
+    [Fact]
+    public async Task SendPozvankaAsync_writes_EmailMessage_outbox_row_with_LinkedSubmissionId()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, adults: 0);
+
+        var (service, _) = CreateService(options);
+
+        await service.SendPozvankaAsync(1, NowUtc, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var outbox = await verify.EmailMessages.Where(x => x.LinkedSubmissionId == 1).ToListAsync();
+        Assert.Single(outbox);
+        Assert.Equal(EmailDirection.Outbound, outbox[0].Direction);
+        Assert.Equal("u1@example.cz", outbox[0].To);
+        Assert.Contains("Ovčina 2026", outbox[0].Subject);
+        Assert.False(string.IsNullOrEmpty(outbox[0].BodyText));
+    }
+
+    [Fact]
+    public async Task SendPozvankaAsync_missing_recipient_email_returns_MissingRecipient()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: null,
+            players: 1, adults: 0,
+            primaryEmail: "");
+
+        var (service, sender) = CreateService(options);
+
+        var result = await service.SendPozvankaAsync(1, NowUtc, CancellationToken.None);
+
+        Assert.Equal(SendSingleResult.MissingRecipient, result);
+        Assert.Empty(sender.Captured);
+    }
+
+    [Fact]
+    public async Task SendPripominkaAsync_without_prior_invite_returns_Error()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, adults: 0);
+
+        var (service, sender) = CreateService(options);
+
+        var result = await service.SendPripominkaAsync(1, NowUtc, CancellationToken.None);
+
+        Assert.Equal(SendSingleResult.Error, result);
+        Assert.Empty(sender.Captured);
+    }
+
+    [Fact]
+    public async Task SendPripominkaAsync_within_24h_returns_ThrottledSkipped_no_send()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-3),
+            players: 1, adults: 0,
+            reminderLastSentAtUtc: NowUtc.AddHours(-23));
+
+        var (service, sender) = CreateService(options);
+
+        var result = await service.SendPripominkaAsync(1, NowUtc, CancellationToken.None);
+
+        Assert.Equal(SendSingleResult.ThrottledSkipped, result);
+        Assert.Empty(sender.Captured);
+    }
+
+    [Fact]
+    public async Task SendPripominkaAsync_after_24h_sends_and_marks_reminder()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-3),
+            players: 1, adults: 0,
+            reminderLastSentAtUtc: NowUtc.AddHours(-25));
+
+        var (service, sender) = CreateService(options);
+
+        var result = await service.SendPripominkaAsync(1, NowUtc, CancellationToken.None);
+
+        Assert.Equal(SendSingleResult.Sent, result);
+        Assert.Single(sender.Captured);
+        Assert.Contains("Připomínka", sender.Captured[0].Subject);
+
+        await using var verify = new ApplicationDbContext(options);
+        var submission = await verify.RegistrationSubmissions.SingleAsync(x => x.Id == 1);
+        Assert.Equal(NowUtc, submission.CharacterPrepReminderLastSentAtUtc);
+    }
+
+    [Fact]
+    public async Task SendBulkPozvankaAsync_iterates_all_targets_and_counts_sent_and_failed()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, adults: 0);
+        await AddSubmissionAsync(options, submissionId: 2, invitedAtUtc: null, players: 1, adults: 0);
+        await AddSubmissionAsync(options, submissionId: 3, invitedAtUtc: null, players: 1, adults: 0);
+
+        var (service, sender) = CreateService(options);
+        // Fail the second recipient only — other two should still go through.
+        sender.FailForRecipient = "u2@example.cz";
+
+        var result = await service.SendBulkPozvankaAsync(GameId, NowUtc, CancellationToken.None);
+
+        Assert.Equal(2, result.Sent);
+        Assert.Equal(1, result.Failed);
+        Assert.NotNull(result.FirstError);
+
+        await using var verify = new ApplicationDbContext(options);
+        var invited = await verify.RegistrationSubmissions
+            .Where(x => x.CharacterPrepInvitedAtUtc != null).CountAsync();
+        Assert.Equal(2, invited);
+    }
+
+    [Fact]
+    public async Task SendBulkPripominkaAsync_skips_submissions_without_empty_equipment()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        // Already fully equipped — not a reminder target.
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-3),
+            players: 1, adults: 0,
+            allPlayersEquipped: true,
+            reminderLastSentAtUtc: null);
+        // Unequipped + invited + past 24h — should receive reminder.
+        await AddSubmissionAsync(
+            options, submissionId: 2,
+            invitedAtUtc: NowUtc.AddDays(-3),
+            players: 1, adults: 0,
+            allPlayersEquipped: false,
+            reminderLastSentAtUtc: NowUtc.AddHours(-25));
+
+        var (service, sender) = CreateService(options);
+
+        var result = await service.SendBulkPripominkaAsync(GameId, NowUtc, CancellationToken.None);
+
+        Assert.Equal(1, result.Sent);
+        Assert.Equal(0, result.Failed);
+        Assert.Single(sender.Captured);
+        Assert.Equal("u2@example.cz", sender.Captured[0].To);
+    }
+
+    // ------------------------------------------------------------ helpers
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static (CharacterPrepMailService Service, FakeCharacterPrepEmailSender Sender) CreateService(
+        DbContextOptions<ApplicationDbContext> options)
+    {
+        var factory = new TestDbContextFactory(options);
+        var prepService = new CharacterPrepService(factory);
+        var tokenService = new CharacterPrepTokenService(factory);
+        var renderer = new CharacterPrepEmailRenderer();
+        var sender = new FakeCharacterPrepEmailSender();
+        var mailOptions = Options.Create(new CharacterPrepOptions
+        {
+            PublicBaseUrl = "https://registrace.ovcina.cz",
+            OrganizerContactEmail = "organizatori@ovcina.cz"
+        });
+        var mailService = new CharacterPrepMailService(
+            factory,
+            renderer,
+            tokenService,
+            prepService,
+            sender,
+            mailOptions,
+            NullLogger<CharacterPrepMailService>.Instance);
+        return (mailService, sender);
+    }
+
+    private static async Task SeedGameAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = GameId,
+            Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(15),
+            PaymentDueAtUtc = FixedUtc.AddDays(25),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = EquipmentId,
+            GameId = GameId,
+            Key = "tesak",
+            DisplayName = "Tesák",
+            SortOrder = 1
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task AddSubmissionAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int submissionId,
+        DateTimeOffset? invitedAtUtc,
+        int players,
+        int adults,
+        bool allPlayersEquipped = false,
+        DateTimeOffset? reminderLastSentAtUtc = null,
+        string? primaryEmail = null)
+    {
+        await using var db = new ApplicationDbContext(options);
+        var userId = "user-" + submissionId;
+        db.Users.Add(new ApplicationUser
+        {
+            Id = userId,
+            DisplayName = "U" + submissionId,
+            Email = $"u{submissionId}@example.cz",
+            NormalizedEmail = $"U{submissionId}@EXAMPLE.CZ",
+            UserName = $"u{submissionId}@example.cz",
+            NormalizedUserName = $"U{submissionId}@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = submissionId,
+            GameId = GameId,
+            RegistrantUserId = userId,
+            PrimaryContactName = "Contact " + submissionId,
+            PrimaryEmail = primaryEmail ?? $"u{submissionId}@example.cz",
+            PrimaryPhone = "777000000",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200,
+            CharacterPrepInvitedAtUtc = invitedAtUtc,
+            CharacterPrepReminderLastSentAtUtc = reminderLastSentAtUtc
+        });
+        var personBaseId = submissionId * 1000;
+        var regBaseId = submissionId * 1000;
+        for (var i = 0; i < players; i++)
+        {
+            var pid = personBaseId + i + 1;
+            db.People.Add(new Person
+            {
+                Id = pid,
+                FirstName = "Player" + i,
+                LastName = "S" + submissionId,
+                BirthYear = 2015,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = regBaseId + i + 1,
+                SubmissionId = submissionId,
+                PersonId = pid,
+                AttendeeType = AttendeeType.Player,
+                Status = RegistrationStatus.Active,
+                CharacterName = allPlayersEquipped ? "Hero " + i : null,
+                StartingEquipmentOptionId = allPlayersEquipped ? EquipmentId : null,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        for (var i = 0; i < adults; i++)
+        {
+            var pid = personBaseId + 500 + i + 1;
+            db.People.Add(new Person
+            {
+                Id = pid,
+                FirstName = "Adult" + i,
+                LastName = "S" + submissionId,
+                BirthYear = 1985,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = regBaseId + 500 + i + 1,
+                SubmissionId = submissionId,
+                PersonId = pid,
+                AttendeeType = AttendeeType.Adult,
+                Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+
+    /// <summary>
+    /// Captures calls; never touches the network. When <see cref="FailForRecipient"/>
+    /// matches, throws so we can exercise the bulk error-tolerance path.
+    /// </summary>
+    private sealed class FakeCharacterPrepEmailSender : ICharacterPrepEmailSender
+    {
+        public List<SentMessage> Captured { get; } = new();
+        public string? FailForRecipient { get; set; }
+
+        public Task SendAsync(string recipientEmail, string subject, string htmlBody, CancellationToken cancellationToken)
+        {
+            if (FailForRecipient is not null
+                && string.Equals(FailForRecipient, recipientEmail, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("simulated send failure");
+            }
+            Captured.Add(new SentMessage(recipientEmail, subject, htmlBody));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record SentMessage(string To, string Subject, string HtmlBody);
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepMailServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepMailServiceTests.cs
@@ -204,6 +204,26 @@ public sealed class CharacterPrepMailServiceTests
         Assert.Equal("u2@example.cz", sender.Captured[0].To);
     }
 
+    [Fact]
+    public async Task SendPozvankaAsync_cancelled_token_propagates_OperationCanceledException()
+    {
+        // Cancellation must NOT be swallowed by the generic catch — if it were,
+        // a bulk send couldn't be aborted cleanly and callers couldn't honour
+        // shutdown requests.
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, adults: 0);
+
+        var (service, sender) = CreateService(options);
+        sender.ThrowCancelledOnSend = true;
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => service.SendPozvankaAsync(1, NowUtc, cts.Token));
+    }
+
     // ------------------------------------------------------------ helpers
 
     private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
@@ -378,9 +398,15 @@ public sealed class CharacterPrepMailServiceTests
     {
         public List<SentMessage> Captured { get; } = new();
         public string? FailForRecipient { get; set; }
+        public bool ThrowCancelledOnSend { get; set; }
 
         public Task SendAsync(string recipientEmail, string subject, string htmlBody, CancellationToken cancellationToken)
         {
+            if (ThrowCancelledOnSend)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                throw new OperationCanceledException("simulated cancelled send");
+            }
             if (FailForRecipient is not null
                 && string.Equals(FailForRecipient, recipientEmail, StringComparison.OrdinalIgnoreCase))
             {

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepOptionsPageFlowTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepOptionsPageFlowTests.cs
@@ -1,0 +1,174 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+/// <summary>
+/// Service-level flow tests that mirror what the
+/// <c>/organizace/hry/{GameId}/priprava-postav/vybava</c> page does through
+/// CharacterPrepOptionsService (Phase 6 / Task 19). Covers list → add → edit →
+/// delete plus the delete-blocked-by-reference path and copy-from-another-game.
+/// Kept at the service layer because the project has no bUnit/WebApplicationFactory
+/// harness yet.
+/// </summary>
+public sealed class CharacterPrepOptionsPageFlowTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task Happy_path_list_add_edit_delete()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, 1);
+
+        var service = new CharacterPrepOptionsService(
+            new TestDbContextFactory(options),
+            NullLogger<CharacterPrepOptionsService>.Instance);
+
+        // 1. List — starts empty.
+        Assert.Empty(await service.ListAsync(1, CancellationToken.None));
+
+        // 2. Add.
+        var created = await service.CreateAsync(1, "tesak", "Tesák", "3/1", 10, CancellationToken.None);
+        var listAfterAdd = await service.ListAsync(1, CancellationToken.None);
+        Assert.Single(listAfterAdd);
+        Assert.Equal("tesak", listAfterAdd[0].Key);
+
+        // 3. Edit — DisplayName/Description/SortOrder change, Key stable.
+        await service.UpdateAsync(created.Id, "Krátký tesák", "3/2", 20, CancellationToken.None);
+        var listAfterEdit = await service.ListAsync(1, CancellationToken.None);
+        Assert.Equal("tesak", listAfterEdit[0].Key);
+        Assert.Equal("Krátký tesák", listAfterEdit[0].DisplayName);
+        Assert.Equal("3/2", listAfterEdit[0].Description);
+        Assert.Equal(20, listAfterEdit[0].SortOrder);
+
+        // 4. Delete — succeeds because not referenced.
+        Assert.True(await service.TryDeleteAsync(created.Id, CancellationToken.None));
+        Assert.Empty(await service.ListAsync(1, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Delete_is_blocked_when_option_is_in_use()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, 1);
+        int optionId;
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var opt = new StartingEquipmentOption
+            {
+                GameId = 1, Key = "tesak", DisplayName = "Tesák", SortOrder = 1
+            };
+            db.StartingEquipmentOptions.Add(opt);
+            await db.SaveChangesAsync();
+            optionId = opt.Id;
+
+            db.People.Add(new Person
+            {
+                Id = 1, FirstName = "Kid", LastName = "One", BirthYear = 2015,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            db.RegistrationSubmissions.Add(new RegistrationSubmission
+            {
+                Id = 1,
+                GameId = 1,
+                RegistrantUserId = "user-1",
+                PrimaryContactName = "Parent",
+                PrimaryEmail = "p@example.cz",
+                PrimaryPhone = "+420000000000",
+                Status = SubmissionStatus.Submitted,
+                SubmittedAtUtc = FixedUtc,
+                LastEditedAtUtc = FixedUtc,
+                ExpectedTotalAmount = 0
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = 1, SubmissionId = 1, PersonId = 1,
+                AttendeeType = AttendeeType.Player,
+                Status = RegistrationStatus.Active,
+                StartingEquipmentOptionId = optionId,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepOptionsService(
+            new TestDbContextFactory(options),
+            NullLogger<CharacterPrepOptionsService>.Instance);
+
+        var deleted = await service.TryDeleteAsync(optionId, CancellationToken.None);
+
+        Assert.False(deleted);
+        // Still there.
+        Assert.Single(await service.ListAsync(1, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Copy_from_another_game_preserves_existing_and_imports_rest()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, 1);
+        await SeedGameAsync(options, 2);
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.StartingEquipmentOptions.AddRange(
+                new StartingEquipmentOption { GameId = 1, Key = "tesak", DisplayName = "Tesák", SortOrder = 1 },
+                new StartingEquipmentOption { GameId = 1, Key = "luk", DisplayName = "Luk", SortOrder = 2 },
+                new StartingEquipmentOption { GameId = 2, Key = "tesak", DisplayName = "Already here", SortOrder = 9 });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepOptionsService(
+            new TestDbContextFactory(options),
+            NullLogger<CharacterPrepOptionsService>.Instance);
+
+        await service.CopyFromGameAsync(sourceGameId: 1, targetGameId: 2, CancellationToken.None);
+
+        var target = await service.ListAsync(2, CancellationToken.None);
+        Assert.Equal(2, target.Count);
+        Assert.Equal("Already here", target.Single(x => x.Key == "tesak").DisplayName);
+        Assert.Equal("Luk", target.Single(x => x.Key == "luk").DisplayName);
+    }
+
+    // ---------- helpers ----------
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedGameAsync(DbContextOptions<ApplicationDbContext> options, int gameId)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = gameId,
+            Name = $"Hra {gameId}",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(25),
+            PaymentDueAtUtc = FixedUtc.AddDays(20),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+            => new(CreateDbContext());
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepOptionsServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepOptionsServiceTests.cs
@@ -1,0 +1,382 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+/// <summary>
+/// Covers the organizer-facing CRUD service for StartingEquipmentOption rows
+/// (Phase 6 / Task 19). The service wraps validation, duplicate-key handling,
+/// a reference guard on delete, and a cross-game copy helper.
+/// </summary>
+public sealed class CharacterPrepOptionsServiceTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task ListAsync_returns_options_ordered_by_SortOrder()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 1, GameId = 1, Key = "luk", DisplayName = "Luk", SortOrder = 20
+            });
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 2, GameId = 1, Key = "tesak", DisplayName = "Tesák", SortOrder = 10
+            });
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 3, GameId = 1, Key = "mec", DisplayName = "Meč", SortOrder = 30
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        var list = await service.ListAsync(1, CancellationToken.None);
+
+        Assert.Equal(new[] { "tesak", "luk", "mec" }, list.Select(x => x.Key).ToArray());
+    }
+
+    [Fact]
+    public async Task CreateAsync_persists_option()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        var created = await service.CreateAsync(1, "tesak", "Tesák", "3/1", 5, CancellationToken.None);
+
+        Assert.True(created.Id > 0);
+        Assert.Equal(1, created.GameId);
+        Assert.Equal("tesak", created.Key);
+        Assert.Equal("Tesák", created.DisplayName);
+        Assert.Equal("3/1", created.Description);
+        Assert.Equal(5, created.SortOrder);
+
+        await using var verify = new ApplicationDbContext(options);
+        Assert.Single(await verify.StartingEquipmentOptions.ToListAsync());
+    }
+
+    [Fact]
+    public async Task CreateAsync_trims_and_lowercases_Key()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        var created = await service.CreateAsync(1, "  TESAK  ", "Tesák", null, 0, CancellationToken.None);
+
+        Assert.Equal("tesak", created.Key);
+    }
+
+    [Fact]
+    public async Task CreateAsync_rejects_duplicate_key_in_same_game()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await service.CreateAsync(1, "tesak", "Tesák", null, 0, CancellationToken.None);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CreateAsync(1, "TESAK", "Druhý tesák", null, 1, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task CreateAsync_allows_same_key_in_different_game()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+        await SeedGameAsync(options, gameId: 2);
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await service.CreateAsync(1, "tesak", "Tesák", null, 0, CancellationToken.None);
+        var second = await service.CreateAsync(2, "tesak", "Tesák v druhé hře", null, 0, CancellationToken.None);
+
+        Assert.Equal(2, second.GameId);
+        Assert.Equal("tesak", second.Key);
+    }
+
+    [Fact]
+    public async Task CreateAsync_rejects_empty_key()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.CreateAsync(1, "   ", "Displej", null, 0, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task CreateAsync_rejects_empty_displayName()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.CreateAsync(1, "tesak", "   ", null, 0, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_modifies_DisplayName_Description_SortOrder()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 1, GameId = 1, Key = "tesak", DisplayName = "Tesák", Description = "3/1", SortOrder = 5
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await service.UpdateAsync(1, "Krátký tesák", "3/2", 10, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var row = await verify.StartingEquipmentOptions.SingleAsync(x => x.Id == 1);
+        Assert.Equal("Krátký tesák", row.DisplayName);
+        Assert.Equal("3/2", row.Description);
+        Assert.Equal(10, row.SortOrder);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_does_not_modify_Key()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 1, GameId = 1, Key = "tesak", DisplayName = "Tesák", SortOrder = 5
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await service.UpdateAsync(1, "Nový display", null, 99, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var row = await verify.StartingEquipmentOptions.SingleAsync(x => x.Id == 1);
+        Assert.Equal("tesak", row.Key);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_throws_if_option_missing()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UpdateAsync(9999, "Neco", null, 0, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task TryDeleteAsync_returns_false_when_referenced()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 1, GameId = 1, Key = "tesak", DisplayName = "Tesák", SortOrder = 5
+            });
+            db.People.Add(new Person
+            {
+                Id = 1, FirstName = "Kid", LastName = "One", BirthYear = 2015,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            db.RegistrationSubmissions.Add(new RegistrationSubmission
+            {
+                Id = 1,
+                GameId = 1,
+                RegistrantUserId = "user-1",
+                PrimaryContactName = "Parent One",
+                PrimaryEmail = "p@example.cz",
+                PrimaryPhone = "+420000000000",
+                Status = SubmissionStatus.Submitted,
+                SubmittedAtUtc = FixedUtc,
+                LastEditedAtUtc = FixedUtc,
+                ExpectedTotalAmount = 0
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = 1, SubmissionId = 1, PersonId = 1,
+                AttendeeType = AttendeeType.Player,
+                Status = RegistrationStatus.Active,
+                StartingEquipmentOptionId = 1,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        var deleted = await service.TryDeleteAsync(1, CancellationToken.None);
+
+        Assert.False(deleted);
+        await using var verify = new ApplicationDbContext(options);
+        Assert.True(await verify.StartingEquipmentOptions.AnyAsync(x => x.Id == 1));
+    }
+
+    [Fact]
+    public async Task TryDeleteAsync_returns_true_and_deletes_when_unreferenced()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 1, GameId = 1, Key = "tesak", DisplayName = "Tesák", SortOrder = 5
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        var deleted = await service.TryDeleteAsync(1, CancellationToken.None);
+
+        Assert.True(deleted);
+        await using var verify = new ApplicationDbContext(options);
+        Assert.False(await verify.StartingEquipmentOptions.AnyAsync(x => x.Id == 1));
+    }
+
+    [Fact]
+    public async Task CopyFromGameAsync_copies_all_options_to_empty_target()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+        await SeedGameAsync(options, gameId: 2);
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 1, GameId = 1, Key = "tesak", DisplayName = "Tesák", Description = "3/1", SortOrder = 10
+            });
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 2, GameId = 1, Key = "luk", DisplayName = "Luk", Description = null, SortOrder = 20
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await service.CopyFromGameAsync(sourceGameId: 1, targetGameId: 2, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var copied = await verify.StartingEquipmentOptions
+            .Where(x => x.GameId == 2)
+            .OrderBy(x => x.SortOrder)
+            .ToListAsync();
+        Assert.Equal(2, copied.Count);
+        Assert.Equal("tesak", copied[0].Key);
+        Assert.Equal("Tesák", copied[0].DisplayName);
+        Assert.Equal("3/1", copied[0].Description);
+        Assert.Equal(10, copied[0].SortOrder);
+        Assert.Equal("luk", copied[1].Key);
+    }
+
+    [Fact]
+    public async Task CopyFromGameAsync_skips_keys_that_exist_on_target()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+        await SeedGameAsync(options, gameId: 2);
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 1, GameId = 1, Key = "tesak", DisplayName = "Tesák (1)", SortOrder = 10
+            });
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 2, GameId = 1, Key = "luk", DisplayName = "Luk", SortOrder = 20
+            });
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 10, GameId = 2, Key = "tesak", DisplayName = "Tesák already here", SortOrder = 5
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await service.CopyFromGameAsync(sourceGameId: 1, targetGameId: 2, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var target = await verify.StartingEquipmentOptions
+            .Where(x => x.GameId == 2)
+            .OrderBy(x => x.Key)
+            .ToListAsync();
+        Assert.Equal(2, target.Count);
+        // pre-existing "tesak" must be untouched
+        Assert.Equal("Tesák already here", target.Single(x => x.Key == "tesak").DisplayName);
+        // "luk" should have been copied in
+        Assert.Equal("Luk", target.Single(x => x.Key == "luk").DisplayName);
+    }
+
+    // ---------- helpers ----------
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedGameAsync(DbContextOptions<ApplicationDbContext> options, int gameId)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = gameId,
+            Name = $"Hra {gameId}",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(25),
+            PaymentDueAtUtc = FixedUtc.AddDays(20),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static Microsoft.Extensions.Logging.ILogger<CharacterPrepOptionsService> NullLogger() =>
+        Microsoft.Extensions.Logging.Abstractions.NullLogger<CharacterPrepOptionsService>.Instance;
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+            => new(CreateDbContext());
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepOptionsServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepOptionsServiceTests.cs
@@ -337,6 +337,108 @@ public sealed class CharacterPrepOptionsServiceTests
         Assert.Equal("Luk", target.Single(x => x.Key == "luk").DisplayName);
     }
 
+    [Fact]
+    public async Task SeedDefaultsAsync_inserts_exactly_5_rows_with_expected_keys()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await service.SeedDefaultsAsync(1, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var rows = await verify.StartingEquipmentOptions
+            .Where(x => x.GameId == 1)
+            .OrderBy(x => x.SortOrder)
+            .ToListAsync();
+
+        Assert.Equal(5, rows.Count);
+        Assert.Equal(
+            new[] { "tesak", "dlouhy-nuz", "vrhaci-nuz", "dyka-svitky", "mince" },
+            rows.Select(x => x.Key).ToArray());
+    }
+
+    [Fact]
+    public async Task SeedDefaultsAsync_sets_correct_displayname_and_description_per_row()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await service.SeedDefaultsAsync(1, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var byKey = (await verify.StartingEquipmentOptions
+            .Where(x => x.GameId == 1)
+            .ToListAsync())
+            .ToDictionary(x => x.Key, x => x);
+
+        Assert.Equal("Tesák (3/1)", byKey["tesak"].DisplayName);
+        Assert.Equal("Útok 3, obrana 1", byKey["tesak"].Description);
+
+        Assert.Equal("Dlouhý nůž (2/2)", byKey["dlouhy-nuz"].DisplayName);
+        Assert.Equal("Útok 2, obrana 2", byKey["dlouhy-nuz"].Description);
+
+        Assert.Equal("Vrhací nůž (3/0)", byKey["vrhaci-nuz"].DisplayName);
+        Assert.Equal("Útok 3, obrana 0", byKey["vrhaci-nuz"].Description);
+
+        Assert.Equal("Dýka (1/2), 4 svitky kouzel", byKey["dyka-svitky"].DisplayName);
+        Assert.Equal("Útok 1, obrana 2 + 4 svitky kouzel", byKey["dyka-svitky"].Description);
+
+        Assert.Equal("5 měďáků / grošů", byKey["mince"].DisplayName);
+        Assert.Equal("Žádná zbraň, 5 mincí do začátku", byKey["mince"].Description);
+    }
+
+    [Fact]
+    public async Task SeedDefaultsAsync_throws_when_game_already_has_options()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 1, GameId = 1, Key = "existing", DisplayName = "Existing", SortOrder = 0
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SeedDefaultsAsync(1, CancellationToken.None));
+        Assert.Equal("Hra již má nějakou výbavu — vlož nové ručně.", ex.Message);
+
+        // Confirm nothing was added beyond the pre-existing row.
+        await using var verify = new ApplicationDbContext(options);
+        var count = await verify.StartingEquipmentOptions
+            .Where(x => x.GameId == 1)
+            .CountAsync();
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task SeedDefaultsAsync_rows_have_ascending_sort_order_starting_at_10()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options, gameId: 1);
+
+        var service = new CharacterPrepOptionsService(new TestDbContextFactory(options), NullLogger());
+
+        await service.SeedDefaultsAsync(1, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var sortOrders = await verify.StartingEquipmentOptions
+            .Where(x => x.GameId == 1)
+            .OrderBy(x => x.SortOrder)
+            .Select(x => x.SortOrder)
+            .ToListAsync();
+
+        Assert.Equal(new[] { 10, 20, 30, 40, 50 }, sortOrders.ToArray());
+    }
+
     // ---------- helpers ----------
 
     private static DbContextOptions<ApplicationDbContext> CreateOptions() =>

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepPageFlowTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepPageFlowTests.cs
@@ -1,0 +1,248 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+/// <summary>
+/// Tests that cover the data-resolution flow used by the parent-facing
+/// <c>/postavy/{token}</c> page (Task 11–14). The page itself is a thin
+/// Razor wrapper around the two services exercised here, so verifying the
+/// service contracts end-to-end is the cheapest reliable way to lock in
+/// the page behaviour without introducing a new test harness (no
+/// WebApplicationFactory / bUnit are configured in this test project).
+/// </summary>
+public sealed class CharacterPrepPageFlowTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset NowUtc = new(FixedUtc);
+
+    // ----- Task 11: token resolution path -----
+
+    [Fact]
+    public async Task Unknown_token_resolves_to_null_so_page_renders_not_found()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options, token: "known-token");
+
+        var tokens = new CharacterPrepTokenService(new TestDbContextFactory(options));
+
+        var submission = await tokens.FindBySubmissionTokenAsync("not-the-token", CancellationToken.None);
+
+        Assert.Null(submission);
+    }
+
+    [Fact]
+    public async Task Valid_token_resolves_submission_and_view_has_player_rows()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options, token: "happy-path-token");
+
+        var tokens = new CharacterPrepTokenService(new TestDbContextFactory(options));
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        var submission = await tokens.FindBySubmissionTokenAsync("happy-path-token", CancellationToken.None);
+        Assert.NotNull(submission);
+
+        var view = await service.GetPrepViewAsync(submission!.Id, NowUtc, CancellationToken.None);
+
+        Assert.NotNull(view);
+        Assert.Equal("Ovčina 2026", view!.GameName);
+        Assert.Single(view.Rows);
+        Assert.Equal("Kid One", view.Rows[0].PersonFullName);
+        Assert.False(view.IsReadOnly);
+    }
+
+    [Fact]
+    public async Task Empty_token_resolves_to_null()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options, token: "anything");
+
+        var tokens = new CharacterPrepTokenService(new TestDbContextFactory(options));
+
+        Assert.Null(await tokens.FindBySubmissionTokenAsync("", CancellationToken.None));
+        Assert.Null(await tokens.FindBySubmissionTokenAsync("   ", CancellationToken.None));
+    }
+
+    // ----- Task 12: card pre-fill (existing values surface through GetPrepViewAsync) -----
+
+    [Fact]
+    public async Task Prefill_values_appear_on_row_when_previously_saved()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options, token: "t");
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var reg = await db.Registrations.SingleAsync();
+            reg.CharacterName = "Aragorn";
+            reg.StartingEquipmentOptionId = 10;
+            reg.CharacterPrepNote = "chce luk";
+            reg.CharacterPrepUpdatedAtUtc = NowUtc.AddHours(-2);
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var view = await service.GetPrepViewAsync(submissionId: 1, NowUtc, CancellationToken.None);
+
+        Assert.NotNull(view);
+        var row = Assert.Single(view!.Rows);
+        Assert.Equal("Aragorn", row.CharacterName);
+        Assert.Equal(10, row.StartingEquipmentOptionId);
+        Assert.Equal("chce luk", row.CharacterPrepNote);
+        Assert.NotNull(row.UpdatedAtUtc);
+    }
+
+    // ----- Task 13: save round-trip -----
+
+    [Fact]
+    public async Task Save_roundtrip_updates_registration_and_view_reflects_changes()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options, token: "t");
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        // Act — simulate the page's save handler projecting editable rows into CharacterPrepSaveRow.
+        await service.SaveAsync(
+            submissionId: 1,
+            new[] { new CharacterPrepSaveRow(RegistrationId: 1, CharacterName: "Legolas", StartingEquipmentOptionId: 10, CharacterPrepNote: "preferuje luk") },
+            NowUtc,
+            CancellationToken.None);
+
+        // Assert database persistence.
+        await using (var verify = new ApplicationDbContext(options))
+        {
+            var reg = await verify.Registrations.SingleAsync(r => r.Id == 1);
+            Assert.Equal("Legolas", reg.CharacterName);
+            Assert.Equal(10, reg.StartingEquipmentOptionId);
+            Assert.Equal("preferuje luk", reg.CharacterPrepNote);
+            Assert.Equal(NowUtc, reg.CharacterPrepUpdatedAtUtc);
+        }
+
+        // Assert that a second GET of the page would show the pre-filled values.
+        var view = await service.GetPrepViewAsync(submissionId: 1, NowUtc, CancellationToken.None);
+        Assert.NotNull(view);
+        var row = Assert.Single(view!.Rows);
+        Assert.Equal("Legolas", row.CharacterName);
+        Assert.Equal(10, row.StartingEquipmentOptionId);
+        Assert.Equal("preferuje luk", row.CharacterPrepNote);
+        Assert.NotNull(row.UpdatedAtUtc);
+    }
+
+    // ----- Task 14: read-only after game start -----
+
+    [Fact]
+    public async Task View_is_readonly_when_game_started()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options, token: "t", gameStartDaysFromNow: -1); // started yesterday
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var view = await service.GetPrepViewAsync(submissionId: 1, NowUtc, CancellationToken.None);
+
+        Assert.NotNull(view);
+        Assert.True(view!.IsReadOnly);
+    }
+
+    [Fact]
+    public async Task View_is_editable_when_game_not_yet_started()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options, token: "t", gameStartDaysFromNow: 30);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var view = await service.GetPrepViewAsync(submissionId: 1, NowUtc, CancellationToken.None);
+
+        Assert.NotNull(view);
+        Assert.False(view!.IsReadOnly);
+    }
+
+    // ----- Shared fixture -----
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        string? token,
+        int gameStartDaysFromNow = 30)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Users.Add(new ApplicationUser
+        {
+            Id = "user-1",
+            DisplayName = "Parent",
+            Email = "parent@example.cz",
+            NormalizedEmail = "PARENT@EXAMPLE.CZ",
+            UserName = "parent@example.cz",
+            NormalizedUserName = "PARENT@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.Games.Add(new Game
+        {
+            Id = 1,
+            Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(gameStartDaysFromNow),
+            EndsAtUtc = FixedUtc.AddDays(gameStartDaysFromNow + 2),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(Math.Max(1, gameStartDaysFromNow - 10)),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(Math.Max(1, gameStartDaysFromNow - 15)),
+            PaymentDueAtUtc = FixedUtc.AddDays(Math.Max(1, gameStartDaysFromNow - 5)),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = 10, GameId = 1, Key = "tesak", DisplayName = "Tesák", Description = "3/1", SortOrder = 1
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = 1,
+            GameId = 1,
+            RegistrantUserId = "user-1",
+            PrimaryContactName = "Parent",
+            PrimaryEmail = "parent@example.cz",
+            PrimaryPhone = "777111222",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200,
+            CharacterPrepToken = token
+        });
+        db.People.Add(new Person
+        {
+            Id = 1, FirstName = "Kid", LastName = "One", BirthYear = 2015,
+            CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+        });
+        db.Registrations.Add(new Registration
+        {
+            Id = 1, SubmissionId = 1, PersonId = 1,
+            AttendeeType = AttendeeType.Player,
+            Status = RegistrationStatus.Active,
+            CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceBulkFiltersTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceBulkFiltersTests.cs
@@ -1,0 +1,310 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+public sealed class CharacterPrepServiceBulkFiltersTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset NowUtc = new(FixedUtc);
+    private const int GameId = 1;
+    private const int EquipmentId = 10;
+
+    [Fact]
+    public async Task Invitation_targets_include_uninvited_submissions_with_Player()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        // S1: uninvited, 1 Player  → included
+        // S2: invited, 1 Player    → excluded (already invited)
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, adults: 0);
+        await AddSubmissionAsync(options, submissionId: 2, invitedAtUtc: NowUtc.AddDays(-5), players: 1, adults: 0);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var targets = await service.ListInvitationTargetsAsync(GameId, CancellationToken.None);
+
+        Assert.Single(targets);
+        Assert.Equal(1, targets[0].Id);
+    }
+
+    [Fact]
+    public async Task Invitation_targets_exclude_submissions_with_no_Players()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 0, adults: 2);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var targets = await service.ListInvitationTargetsAsync(GameId, CancellationToken.None);
+
+        Assert.Empty(targets);
+    }
+
+    [Fact]
+    public async Task Reminder_targets_include_invited_with_empty_equipment_Player_row()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        // Invited 3 days ago, 1 Player without equipment  → included
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-3),
+            players: 1, adults: 0);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var targets = await service.ListReminderTargetsAsync(GameId, NowUtc, CancellationToken.None);
+
+        Assert.Single(targets);
+        Assert.Equal(1, targets[0].Id);
+    }
+
+    [Fact]
+    public async Task Reminder_targets_exclude_fully_filled_submissions()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        // Submission invited, both Players have equipment → excluded
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-3),
+            players: 2, adults: 0,
+            allPlayersEquipped: true);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var targets = await service.ListReminderTargetsAsync(GameId, NowUtc, CancellationToken.None);
+
+        Assert.Empty(targets);
+    }
+
+    [Fact]
+    public async Task Reminder_throttle_excludes_within_last_24h()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-5),
+            players: 1, adults: 0,
+            reminderLastSentAtUtc: NowUtc.AddHours(-2));
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var targets = await service.ListReminderTargetsAsync(GameId, NowUtc, CancellationToken.None);
+
+        Assert.Empty(targets);
+    }
+
+    [Fact]
+    public async Task Reminder_throttle_boundary_includes_slightly_past_24h()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-5),
+            players: 1, adults: 0,
+            reminderLastSentAtUtc: NowUtc.AddHours(-24).AddSeconds(-1));
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var targets = await service.ListReminderTargetsAsync(GameId, NowUtc, CancellationToken.None);
+
+        Assert.Single(targets);
+    }
+
+    [Fact]
+    public async Task MarkInvitedAsync_is_idempotent()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        var originalInvited = NowUtc.AddDays(-3);
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: originalInvited,
+            players: 1, adults: 0);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        await service.MarkInvitedAsync(1, NowUtc, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var submission = await verify.RegistrationSubmissions.SingleAsync(x => x.Id == 1);
+        Assert.Equal(originalInvited, submission.CharacterPrepInvitedAtUtc);
+    }
+
+    [Fact]
+    public async Task MarkReminderSentAsync_overwrites_existing_timestamp()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-3),
+            players: 1, adults: 0,
+            reminderLastSentAtUtc: NowUtc.AddDays(-2));
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        await service.MarkReminderSentAsync(1, NowUtc, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var submission = await verify.RegistrationSubmissions.SingleAsync(x => x.Id == 1);
+        Assert.Equal(NowUtc, submission.CharacterPrepReminderLastSentAtUtc);
+    }
+
+    [Fact]
+    public async Task Dashboard_stats_count_correctly_across_mixed_statuses()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        // S1: uninvited, 1 Player without equipment           → Pending, not Invited, not Filled
+        // S2: invited, 1 Player without equipment             → Pending, Invited
+        // S3: invited, 1 Player fully equipped + named        → Invited, Filled
+        // S4: 0 Player (2 Adults only)                        → excluded entirely
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, adults: 0);
+        await AddSubmissionAsync(options, submissionId: 2, invitedAtUtc: NowUtc, players: 1, adults: 0);
+        await AddSubmissionAsync(options, submissionId: 3, invitedAtUtc: NowUtc, players: 1, adults: 0, allPlayersEquipped: true);
+        await AddSubmissionAsync(options, submissionId: 4, invitedAtUtc: null, players: 0, adults: 2);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var stats = await service.GetDashboardStatsAsync(GameId, CancellationToken.None);
+
+        Assert.Equal(3, stats.TotalHouseholds);
+        Assert.Equal(2, stats.Invited);
+        Assert.Equal(1, stats.FullyFilled);
+        Assert.Equal(2, stats.Pending);
+    }
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedGameAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = GameId,
+            Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(15),
+            PaymentDueAtUtc = FixedUtc.AddDays(25),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = EquipmentId, GameId = GameId, Key = "tesak", DisplayName = "Tesák", SortOrder = 1
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task AddSubmissionAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int submissionId,
+        DateTimeOffset? invitedAtUtc,
+        int players,
+        int adults,
+        bool allPlayersEquipped = false,
+        DateTimeOffset? reminderLastSentAtUtc = null)
+    {
+        await using var db = new ApplicationDbContext(options);
+        var userId = "user-" + submissionId;
+        db.Users.Add(new ApplicationUser
+        {
+            Id = userId,
+            DisplayName = "U" + submissionId,
+            Email = $"u{submissionId}@example.cz",
+            NormalizedEmail = $"U{submissionId}@EXAMPLE.CZ",
+            UserName = $"u{submissionId}@example.cz",
+            NormalizedUserName = $"U{submissionId}@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = submissionId,
+            GameId = GameId,
+            RegistrantUserId = userId,
+            PrimaryContactName = "Contact " + submissionId,
+            PrimaryEmail = $"u{submissionId}@example.cz",
+            PrimaryPhone = "777000000",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200,
+            CharacterPrepInvitedAtUtc = invitedAtUtc,
+            CharacterPrepReminderLastSentAtUtc = reminderLastSentAtUtc
+        });
+        await db.SaveChangesAsync();
+
+        var personBaseId = submissionId * 1000;
+        var regBaseId = submissionId * 1000;
+        for (var i = 0; i < players; i++)
+        {
+            var pid = personBaseId + i + 1;
+            db.People.Add(new Person
+            {
+                Id = pid, FirstName = "Player" + i, LastName = "S" + submissionId, BirthYear = 2015,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = regBaseId + i + 1,
+                SubmissionId = submissionId,
+                PersonId = pid,
+                AttendeeType = AttendeeType.Player,
+                Status = RegistrationStatus.Active,
+                CharacterName = allPlayersEquipped ? "Hero " + i : null,
+                StartingEquipmentOptionId = allPlayersEquipped ? EquipmentId : null,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        for (var i = 0; i < adults; i++)
+        {
+            var pid = personBaseId + 500 + i + 1;
+            db.People.Add(new Person
+            {
+                Id = pid, FirstName = "Adult" + i, LastName = "S" + submissionId, BirthYear = 1985,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = regBaseId + 500 + i + 1,
+                SubmissionId = submissionId,
+                PersonId = pid,
+                AttendeeType = AttendeeType.Adult,
+                Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceBulkFiltersTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceBulkFiltersTests.cs
@@ -156,6 +156,49 @@ public sealed class CharacterPrepServiceBulkFiltersTests
     }
 
     [Fact]
+    public async Task Invitation_targets_exclude_soft_deleted_submissions()
+    {
+        // Locks in that the global HasQueryFilter(x => !x.IsDeleted) on
+        // RegistrationSubmission hides soft-deleted rows from
+        // ListInvitationTargetsAsync. If this test ever fails, ListInvitationTargetsAsync
+        // must be updated with an explicit .Where(x => !x.IsDeleted).
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, adults: 0);
+        await AddSubmissionAsync(options, submissionId: 2, invitedAtUtc: null, players: 1, adults: 0,
+            isDeleted: true);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var targets = await service.ListInvitationTargetsAsync(GameId, CancellationToken.None);
+
+        Assert.Single(targets);
+        Assert.Equal(1, targets[0].Id);
+    }
+
+    [Fact]
+    public async Task Reminder_targets_exclude_soft_deleted_submissions()
+    {
+        // Locks in the same soft-delete guarantee for ListReminderTargetsAsync.
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-3), players: 1, adults: 0);
+        await AddSubmissionAsync(
+            options, submissionId: 2,
+            invitedAtUtc: NowUtc.AddDays(-3), players: 1, adults: 0,
+            isDeleted: true);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var targets = await service.ListReminderTargetsAsync(GameId, NowUtc, CancellationToken.None);
+
+        Assert.Single(targets);
+        Assert.Equal(1, targets[0].Id);
+    }
+
+    [Fact]
     public async Task Dashboard_stats_count_correctly_across_mixed_statuses()
     {
         var options = CreateOptions();
@@ -219,7 +262,8 @@ public sealed class CharacterPrepServiceBulkFiltersTests
         int players,
         int adults,
         bool allPlayersEquipped = false,
-        DateTimeOffset? reminderLastSentAtUtc = null)
+        DateTimeOffset? reminderLastSentAtUtc = null,
+        bool isDeleted = false)
     {
         await using var db = new ApplicationDbContext(options);
         var userId = "user-" + submissionId;
@@ -250,7 +294,8 @@ public sealed class CharacterPrepServiceBulkFiltersTests
             LastEditedAtUtc = FixedUtc,
             ExpectedTotalAmount = 1200,
             CharacterPrepInvitedAtUtc = invitedAtUtc,
-            CharacterPrepReminderLastSentAtUtc = reminderLastSentAtUtc
+            CharacterPrepReminderLastSentAtUtc = reminderLastSentAtUtc,
+            IsDeleted = isDeleted
         });
         await db.SaveChangesAsync();
 

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceDashboardStatsTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceDashboardStatsTests.cs
@@ -1,0 +1,288 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+public sealed class CharacterPrepServiceDashboardStatsTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset NowUtc = new(FixedUtc);
+    private const int GameId = 1;
+    private const int OtherGameId = 2;
+    private const int EquipmentId = 100;
+    private const int OtherEquipmentId = 200;
+
+    [Fact]
+    public async Task Empty_game_returns_all_zero_stats()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var stats = await service.GetDashboardStatsAsync(GameId, CancellationToken.None);
+
+        Assert.Equal(0, stats.TotalHouseholds);
+        Assert.Equal(0, stats.Invited);
+        Assert.Equal(0, stats.FullyFilled);
+        Assert.Equal(0, stats.Pending);
+    }
+
+    [Fact]
+    public async Task Mixed_states_produce_correct_counts()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        // S1: 2 Player attendees, both fully filled, invited → FullyFilled
+        await AddSubmissionAsync(options, GameId, submissionId: 1, invitedAtUtc: NowUtc,
+            players: new[]
+            {
+                new PlayerSpec(hasName: true, hasEquipment: true),
+                new PlayerSpec(hasName: true, hasEquipment: true)
+            });
+
+        // S2: 2 Player attendees, only one has equipment, invited → Invited but not Filled
+        await AddSubmissionAsync(options, GameId, submissionId: 2, invitedAtUtc: NowUtc,
+            players: new[]
+            {
+                new PlayerSpec(hasName: true, hasEquipment: true),
+                new PlayerSpec(hasName: true, hasEquipment: false)
+            });
+
+        // S3: 1 Player attendee, empty fields, not invited → TotalHouseholds only
+        await AddSubmissionAsync(options, GameId, submissionId: 3, invitedAtUtc: null,
+            players: new[] { new PlayerSpec(hasName: false, hasEquipment: false) });
+
+        // S4: 1 Player + 1 Adult, all Player fields filled, invited → FullyFilled (Adult ignored)
+        await AddSubmissionAsync(options, GameId, submissionId: 4, invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) },
+            adults: 1);
+
+        // S5: only Adults (no Players) → excluded from TotalHouseholds
+        await AddSubmissionAsync(options, GameId, submissionId: 5, invitedAtUtc: NowUtc,
+            players: Array.Empty<PlayerSpec>(),
+            adults: 2);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var stats = await service.GetDashboardStatsAsync(GameId, CancellationToken.None);
+
+        Assert.Equal(4, stats.TotalHouseholds);
+        Assert.Equal(3, stats.Invited);
+        Assert.Equal(2, stats.FullyFilled);
+        Assert.Equal(2, stats.Pending);
+    }
+
+    [Fact]
+    public async Task Submissions_for_another_game_are_not_counted()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await SeedOtherGameAsync(options);
+
+        // GameId household
+        await AddSubmissionAsync(options, GameId, submissionId: 1, invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) });
+
+        // OtherGameId household — should be ignored by the GameId stats query
+        await AddSubmissionAsync(options, OtherGameId, submissionId: 2, invitedAtUtc: NowUtc,
+            players: new[]
+            {
+                new PlayerSpec(hasName: true, hasEquipment: true),
+                new PlayerSpec(hasName: false, hasEquipment: false)
+            },
+            equipmentId: OtherEquipmentId);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var stats = await service.GetDashboardStatsAsync(GameId, CancellationToken.None);
+
+        Assert.Equal(1, stats.TotalHouseholds);
+        Assert.Equal(1, stats.Invited);
+        Assert.Equal(1, stats.FullyFilled);
+        Assert.Equal(0, stats.Pending);
+    }
+
+    [Fact]
+    public async Task Soft_deleted_submission_is_excluded()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        // Active submission counting toward stats
+        await AddSubmissionAsync(options, GameId, submissionId: 1, invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) });
+
+        // Soft-deleted submission — must be excluded via the query filter
+        await AddSubmissionAsync(options, GameId, submissionId: 2, invitedAtUtc: NowUtc,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) },
+            isDeleted: true);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var stats = await service.GetDashboardStatsAsync(GameId, CancellationToken.None);
+
+        Assert.Equal(1, stats.TotalHouseholds);
+        Assert.Equal(1, stats.Invited);
+        Assert.Equal(1, stats.FullyFilled);
+        Assert.Equal(0, stats.Pending);
+    }
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedGameAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = GameId,
+            Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(15),
+            PaymentDueAtUtc = FixedUtc.AddDays(25),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = EquipmentId, GameId = GameId, Key = "tesak", DisplayName = "Tesák", SortOrder = 1
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task SeedOtherGameAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = OtherGameId,
+            Name = "Ovčina 2027",
+            StartsAtUtc = FixedUtc.AddDays(400),
+            EndsAtUtc = FixedUtc.AddDays(402),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(390),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(385),
+            PaymentDueAtUtc = FixedUtc.AddDays(395),
+            PlayerBasePrice = 1300,
+            AdultHelperBasePrice = 900,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = OtherEquipmentId, GameId = OtherGameId, Key = "luk", DisplayName = "Luk", SortOrder = 1
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private sealed record PlayerSpec(bool hasName, bool hasEquipment);
+
+    private static async Task AddSubmissionAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int gameId,
+        int submissionId,
+        DateTimeOffset? invitedAtUtc,
+        IReadOnlyList<PlayerSpec> players,
+        int adults = 0,
+        bool isDeleted = false,
+        int equipmentId = EquipmentId)
+    {
+        await using var db = new ApplicationDbContext(options);
+        var userId = "user-" + submissionId;
+        db.Users.Add(new ApplicationUser
+        {
+            Id = userId,
+            DisplayName = "U" + submissionId,
+            Email = $"u{submissionId}@example.cz",
+            NormalizedEmail = $"U{submissionId}@EXAMPLE.CZ",
+            UserName = $"u{submissionId}@example.cz",
+            NormalizedUserName = $"U{submissionId}@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = submissionId,
+            GameId = gameId,
+            RegistrantUserId = userId,
+            PrimaryContactName = "Contact " + submissionId,
+            PrimaryEmail = $"u{submissionId}@example.cz",
+            PrimaryPhone = "777000000",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200,
+            CharacterPrepInvitedAtUtc = invitedAtUtc,
+            IsDeleted = isDeleted
+        });
+        await db.SaveChangesAsync();
+
+        var personBaseId = submissionId * 1000;
+        var regBaseId = submissionId * 1000;
+        for (var i = 0; i < players.Count; i++)
+        {
+            var pid = personBaseId + i + 1;
+            db.People.Add(new Person
+            {
+                Id = pid, FirstName = "Player" + i, LastName = "S" + submissionId, BirthYear = 2015,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = regBaseId + i + 1,
+                SubmissionId = submissionId,
+                PersonId = pid,
+                AttendeeType = AttendeeType.Player,
+                Status = RegistrationStatus.Active,
+                CharacterName = players[i].hasName ? "Hero " + i : null,
+                StartingEquipmentOptionId = players[i].hasEquipment ? equipmentId : null,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        for (var i = 0; i < adults; i++)
+        {
+            var pid = personBaseId + 500 + i + 1;
+            db.People.Add(new Person
+            {
+                Id = pid, FirstName = "Adult" + i, LastName = "S" + submissionId, BirthYear = 1985,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = regBaseId + 500 + i + 1,
+                SubmissionId = submissionId,
+                PersonId = pid,
+                AttendeeType = AttendeeType.Adult,
+                Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceGetViewTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceGetViewTests.cs
@@ -16,10 +16,10 @@ public sealed class CharacterPrepServiceGetViewTests
         var submissionId = await SeedMixedAttendeesAsync(options);
 
         var service = new CharacterPrepService(new TestDbContextFactory(options));
-        var submission = await LoadSubmissionAsync(options, submissionId);
 
-        var view = await service.GetPrepViewAsync(submission, NowUtc, CancellationToken.None);
+        var view = await service.GetPrepViewAsync(submissionId, NowUtc, CancellationToken.None);
 
+        Assert.NotNull(view);
         Assert.All(view.Rows, r => Assert.DoesNotContain("Adult", r.PersonFullName));
         Assert.Equal(2, view.Rows.Count);
         Assert.Contains(view.Rows, r => r.PersonFullName == "Adam Player");
@@ -33,10 +33,10 @@ public sealed class CharacterPrepServiceGetViewTests
         var submissionId = await SeedUnsortedPlayersAsync(options);
 
         var service = new CharacterPrepService(new TestDbContextFactory(options));
-        var submission = await LoadSubmissionAsync(options, submissionId);
 
-        var view = await service.GetPrepViewAsync(submission, NowUtc, CancellationToken.None);
+        var view = await service.GetPrepViewAsync(submissionId, NowUtc, CancellationToken.None);
 
+        Assert.NotNull(view);
         var names = view.Rows.Select(r => r.PersonFullName).ToList();
         Assert.Equal(new[] { "Anna Adamová", "Bořek Adamů", "Cyril Bárta" }, names);
     }
@@ -48,10 +48,10 @@ public sealed class CharacterPrepServiceGetViewTests
         var submissionId = await SeedSimplePlayerAsync(options, gameStartOffsetDays: -1);
 
         var service = new CharacterPrepService(new TestDbContextFactory(options));
-        var submission = await LoadSubmissionAsync(options, submissionId);
 
-        var view = await service.GetPrepViewAsync(submission, NowUtc, CancellationToken.None);
+        var view = await service.GetPrepViewAsync(submissionId, NowUtc, CancellationToken.None);
 
+        Assert.NotNull(view);
         Assert.True(view.IsReadOnly);
     }
 
@@ -71,10 +71,10 @@ public sealed class CharacterPrepServiceGetViewTests
         }
 
         var service = new CharacterPrepService(new TestDbContextFactory(options));
-        var submission = await LoadSubmissionAsync(options, submissionId);
 
-        var view = await service.GetPrepViewAsync(submission, NowUtc, CancellationToken.None);
+        var view = await service.GetPrepViewAsync(submissionId, NowUtc, CancellationToken.None);
 
+        Assert.NotNull(view);
         Assert.Equal(new[] { "A", "M", "Z" }, view.Options.Select(x => x.DisplayName));
     }
 
@@ -100,10 +100,10 @@ public sealed class CharacterPrepServiceGetViewTests
         }
 
         var service = new CharacterPrepService(new TestDbContextFactory(options));
-        var submission = await LoadSubmissionAsync(options, submissionId);
 
-        var view = await service.GetPrepViewAsync(submission, NowUtc, CancellationToken.None);
+        var view = await service.GetPrepViewAsync(submissionId, NowUtc, CancellationToken.None);
 
+        Assert.NotNull(view);
         var row = Assert.Single(view.Rows);
         Assert.Equal("Elrond", row.CharacterName);
         Assert.Equal(10, row.StartingEquipmentOptionId);
@@ -111,12 +111,18 @@ public sealed class CharacterPrepServiceGetViewTests
         Assert.NotNull(row.UpdatedAtUtc);
     }
 
-    private static async Task<RegistrationSubmission> LoadSubmissionAsync(
-        DbContextOptions<ApplicationDbContext> options,
-        int submissionId)
+    [Fact]
+    public async Task GetPrepViewAsync_returns_null_for_unknown_submission_id()
     {
-        await using var db = new ApplicationDbContext(options);
-        return await db.RegistrationSubmissions.SingleAsync(x => x.Id == submissionId);
+        var options = CreateOptions();
+        // Seed a submission with Id=1 so the database has unrelated data.
+        await SeedSimplePlayerAsync(options, gameStartOffsetDays: 30);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        var view = await service.GetPrepViewAsync(submissionId: 9999, NowUtc, CancellationToken.None);
+
+        Assert.Null(view);
     }
 
     private static DbContextOptions<ApplicationDbContext> CreateOptions() =>

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceGetViewTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceGetViewTests.cs
@@ -1,0 +1,264 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+public sealed class CharacterPrepServiceGetViewTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset NowUtc = new(FixedUtc);
+
+    [Fact]
+    public async Task Returns_only_Player_attendees()
+    {
+        var options = CreateOptions();
+        var submissionId = await SeedMixedAttendeesAsync(options);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var submission = await LoadSubmissionAsync(options, submissionId);
+
+        var view = await service.GetPrepViewAsync(submission, NowUtc, CancellationToken.None);
+
+        Assert.All(view.Rows, r => Assert.DoesNotContain("Adult", r.PersonFullName));
+        Assert.Equal(2, view.Rows.Count);
+        Assert.Contains(view.Rows, r => r.PersonFullName == "Adam Player");
+        Assert.Contains(view.Rows, r => r.PersonFullName == "Bea Player");
+    }
+
+    [Fact]
+    public async Task Rows_are_ordered_by_LastName_then_FirstName()
+    {
+        var options = CreateOptions();
+        var submissionId = await SeedUnsortedPlayersAsync(options);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var submission = await LoadSubmissionAsync(options, submissionId);
+
+        var view = await service.GetPrepViewAsync(submission, NowUtc, CancellationToken.None);
+
+        var names = view.Rows.Select(r => r.PersonFullName).ToList();
+        Assert.Equal(new[] { "Anna Adamová", "Bořek Adamů", "Cyril Bárta" }, names);
+    }
+
+    [Fact]
+    public async Task IsReadOnly_is_true_when_game_has_started()
+    {
+        var options = CreateOptions();
+        var submissionId = await SeedSimplePlayerAsync(options, gameStartOffsetDays: -1);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var submission = await LoadSubmissionAsync(options, submissionId);
+
+        var view = await service.GetPrepViewAsync(submission, NowUtc, CancellationToken.None);
+
+        Assert.True(view.IsReadOnly);
+    }
+
+    [Fact]
+    public async Task Options_are_ordered_by_SortOrder()
+    {
+        var options = CreateOptions();
+        var submissionId = await SeedSimplePlayerAsync(options, gameStartOffsetDays: 30);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.StartingEquipmentOptions.AddRange(
+                new StartingEquipmentOption { Id = 1, GameId = 1, Key = "z", DisplayName = "Z", SortOrder = 20 },
+                new StartingEquipmentOption { Id = 2, GameId = 1, Key = "a", DisplayName = "A", SortOrder = 10 },
+                new StartingEquipmentOption { Id = 3, GameId = 1, Key = "m", DisplayName = "M", SortOrder = 15 });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var submission = await LoadSubmissionAsync(options, submissionId);
+
+        var view = await service.GetPrepViewAsync(submission, NowUtc, CancellationToken.None);
+
+        Assert.Equal(new[] { "A", "M", "Z" }, view.Options.Select(x => x.DisplayName));
+    }
+
+    [Fact]
+    public async Task Preexisting_values_roundtrip_into_view()
+    {
+        var options = CreateOptions();
+        var submissionId = await SeedSimplePlayerAsync(options, gameStartOffsetDays: 30);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var option = new StartingEquipmentOption
+            {
+                Id = 10, GameId = 1, Key = "tesak", DisplayName = "Tesák (3/1)", SortOrder = 1
+            };
+            db.StartingEquipmentOptions.Add(option);
+            var registration = await db.Registrations.SingleAsync();
+            registration.CharacterName = "Elrond";
+            registration.StartingEquipmentOptionId = option.Id;
+            registration.CharacterPrepNote = "preferuje luk";
+            registration.CharacterPrepUpdatedAtUtc = NowUtc.AddMinutes(-5);
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        var submission = await LoadSubmissionAsync(options, submissionId);
+
+        var view = await service.GetPrepViewAsync(submission, NowUtc, CancellationToken.None);
+
+        var row = Assert.Single(view.Rows);
+        Assert.Equal("Elrond", row.CharacterName);
+        Assert.Equal(10, row.StartingEquipmentOptionId);
+        Assert.Equal("preferuje luk", row.CharacterPrepNote);
+        Assert.NotNull(row.UpdatedAtUtc);
+    }
+
+    private static async Task<RegistrationSubmission> LoadSubmissionAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int submissionId)
+    {
+        await using var db = new ApplicationDbContext(options);
+        return await db.RegistrationSubmissions.SingleAsync(x => x.Id == submissionId);
+    }
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task<int> SeedMixedAttendeesAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        SeedBase(db, gameStartOffsetDays: 30);
+
+        db.People.AddRange(
+            MakePerson(1, "Adam", "Player"),
+            MakePerson(2, "Bea", "Player"),
+            MakePerson(3, "Cíla", "Adult"));
+        await db.SaveChangesAsync();
+
+        db.Registrations.AddRange(
+            MakeReg(1, personId: 1, AttendeeType.Player),
+            MakeReg(2, personId: 2, AttendeeType.Player),
+            MakeReg(3, personId: 3, AttendeeType.Adult));
+        await db.SaveChangesAsync();
+        return 1;
+    }
+
+    private static async Task<int> SeedUnsortedPlayersAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        SeedBase(db, gameStartOffsetDays: 30);
+
+        db.People.AddRange(
+            MakePerson(1, "Cyril", "Bárta"),
+            MakePerson(2, "Anna", "Adamová"),
+            MakePerson(3, "Bořek", "Adamů"));
+        await db.SaveChangesAsync();
+
+        db.Registrations.AddRange(
+            MakeReg(1, personId: 1, AttendeeType.Player),
+            MakeReg(2, personId: 2, AttendeeType.Player),
+            MakeReg(3, personId: 3, AttendeeType.Player));
+        await db.SaveChangesAsync();
+        return 1;
+    }
+
+    private static async Task<int> SeedSimplePlayerAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int gameStartOffsetDays)
+    {
+        await using var db = new ApplicationDbContext(options);
+        SeedBase(db, gameStartOffsetDays);
+
+        db.People.Add(MakePerson(1, "Player", "Zero"));
+        await db.SaveChangesAsync();
+
+        db.Registrations.Add(MakeReg(1, personId: 1, AttendeeType.Player));
+        await db.SaveChangesAsync();
+        return 1;
+    }
+
+    private static void SeedBase(ApplicationDbContext db, int gameStartOffsetDays)
+    {
+        var user = new ApplicationUser
+        {
+            Id = "user-1",
+            DisplayName = "Parent",
+            Email = "parent@example.cz",
+            NormalizedEmail = "PARENT@EXAMPLE.CZ",
+            UserName = "parent@example.cz",
+            NormalizedUserName = "PARENT@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        };
+        var game = new Game
+        {
+            Id = 1,
+            Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(gameStartOffsetDays),
+            EndsAtUtc = FixedUtc.AddDays(gameStartOffsetDays + 2),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(gameStartOffsetDays - 10),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(gameStartOffsetDays - 15),
+            PaymentDueAtUtc = FixedUtc.AddDays(gameStartOffsetDays - 5),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "123/0100",
+            BankAccountName = "Ovčina",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        };
+        var submission = new RegistrationSubmission
+        {
+            Id = 1,
+            GameId = 1,
+            RegistrantUserId = user.Id,
+            PrimaryContactName = "Parent",
+            PrimaryEmail = "parent@example.cz",
+            PrimaryPhone = "777111222",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200
+        };
+        db.Users.Add(user);
+        db.Games.Add(game);
+        db.RegistrationSubmissions.Add(submission);
+        db.SaveChanges();
+    }
+
+    private static Person MakePerson(int id, string first, string last) =>
+        new()
+        {
+            Id = id,
+            FirstName = first,
+            LastName = last,
+            BirthYear = 2015,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        };
+
+    private static Registration MakeReg(int id, int personId, AttendeeType type) =>
+        new()
+        {
+            Id = id,
+            SubmissionId = 1,
+            PersonId = personId,
+            AttendeeType = type,
+            Status = RegistrationStatus.Active,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        };
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceSaveTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepServiceSaveTests.cs
@@ -1,0 +1,340 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+public sealed class CharacterPrepServiceSaveTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset NowUtc = new(FixedUtc);
+
+    [Fact]
+    public async Task Saves_character_name_equipment_and_note()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        await service.SaveAsync(
+            submissionId: 1,
+            new[] { new CharacterPrepSaveRow(1, "Elrond", 10, "preferuje luk") },
+            NowUtc,
+            CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var reg = await verify.Registrations.SingleAsync(x => x.Id == 1);
+        Assert.Equal("Elrond", reg.CharacterName);
+        Assert.Equal(10, reg.StartingEquipmentOptionId);
+        Assert.Equal("preferuje luk", reg.CharacterPrepNote);
+        Assert.Equal(NowUtc, reg.CharacterPrepUpdatedAtUtc);
+    }
+
+    [Fact]
+    public async Task Stamps_UpdatedAtUtc_only_when_something_changed()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+        var firstStamp = NowUtc.AddHours(-5);
+
+        // First save establishes the fields and stamp.
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        await service.SaveAsync(
+            submissionId: 1,
+            new[] { new CharacterPrepSaveRow(1, "Elrond", 10, "pozn.") },
+            firstStamp,
+            CancellationToken.None);
+
+        // Second save with identical values should NOT re-stamp.
+        await service.SaveAsync(
+            submissionId: 1,
+            new[] { new CharacterPrepSaveRow(1, "Elrond", 10, "pozn.") },
+            NowUtc,
+            CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var reg = await verify.Registrations.SingleAsync(x => x.Id == 1);
+        Assert.Equal(firstStamp, reg.CharacterPrepUpdatedAtUtc);
+    }
+
+    [Fact]
+    public async Task Trims_and_nulls_empty_strings()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        await service.SaveAsync(
+            submissionId: 1,
+            new[] { new CharacterPrepSaveRow(1, "   Elrond   ", null, "    ") },
+            NowUtc,
+            CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var reg = await verify.Registrations.SingleAsync(x => x.Id == 1);
+        Assert.Equal("Elrond", reg.CharacterName);
+        Assert.Null(reg.CharacterPrepNote);
+    }
+
+    [Fact]
+    public async Task Ignores_rows_for_foreign_submissions()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+        await SeedSecondSubmissionAsync(options);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        // Registration 99 belongs to submission 2, passing it in a save for submission 1 must be ignored.
+        await service.SaveAsync(
+            submissionId: 1,
+            new[] { new CharacterPrepSaveRow(99, "ShouldNotApply", null, null) },
+            NowUtc,
+            CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var foreign = await verify.Registrations.SingleAsync(x => x.Id == 99);
+        Assert.Null(foreign.CharacterName);
+        Assert.Null(foreign.CharacterPrepUpdatedAtUtc);
+    }
+
+    [Fact]
+    public async Task Ignores_rows_for_non_Player_attendees()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+        await SeedAdultRegistrationAsync(options);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        // Registration 2 is an Adult on submission 1; save must silently skip it.
+        await service.SaveAsync(
+            submissionId: 1,
+            new[] { new CharacterPrepSaveRow(2, "ShouldNotApply", null, null) },
+            NowUtc,
+            CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var adult = await verify.Registrations.SingleAsync(x => x.Id == 2);
+        Assert.Null(adult.CharacterName);
+        Assert.Null(adult.CharacterPrepUpdatedAtUtc);
+    }
+
+    [Fact]
+    public async Task Rejects_equipment_option_from_different_game()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+
+        // Equipment option 900 belongs to game 2, submission 1 is for game 1.
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Games.Add(new Game
+            {
+                Id = 2,
+                Name = "Other game",
+                StartsAtUtc = FixedUtc.AddDays(30),
+                EndsAtUtc = FixedUtc.AddDays(32),
+                RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+                MealOrderingClosesAtUtc = FixedUtc.AddDays(15),
+                PaymentDueAtUtc = FixedUtc.AddDays(25),
+                PlayerBasePrice = 1200,
+                AdultHelperBasePrice = 800,
+                BankAccount = "x",
+                BankAccountName = "y",
+                VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+                IsPublished = true,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+            db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+            {
+                Id = 900, GameId = 2, Key = "foreign", DisplayName = "Foreign", SortOrder = 1
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await service.SaveAsync(
+                submissionId: 1,
+                new[] { new CharacterPrepSaveRow(1, "x", 900, null) },
+                NowUtc,
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Clearing_all_fields_is_allowed_and_stamps_UpdatedAtUtc()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options);
+        var firstStamp = NowUtc.AddHours(-5);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+        await service.SaveAsync(
+            submissionId: 1,
+            new[] { new CharacterPrepSaveRow(1, "Elrond", 10, "pozn.") },
+            firstStamp,
+            CancellationToken.None);
+
+        // Now clear every field.
+        await service.SaveAsync(
+            submissionId: 1,
+            new[] { new CharacterPrepSaveRow(1, null, null, null) },
+            NowUtc,
+            CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var reg = await verify.Registrations.SingleAsync(x => x.Id == 1);
+        Assert.Null(reg.CharacterName);
+        Assert.Null(reg.StartingEquipmentOptionId);
+        Assert.Null(reg.CharacterPrepNote);
+        Assert.Equal(NowUtc, reg.CharacterPrepUpdatedAtUtc);
+    }
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Users.Add(new ApplicationUser
+        {
+            Id = "user-1",
+            DisplayName = "Parent",
+            Email = "parent@example.cz",
+            NormalizedEmail = "PARENT@EXAMPLE.CZ",
+            UserName = "parent@example.cz",
+            NormalizedUserName = "PARENT@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.Games.Add(new Game
+        {
+            Id = 1,
+            Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(15),
+            PaymentDueAtUtc = FixedUtc.AddDays(25),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = 10, GameId = 1, Key = "tesak", DisplayName = "Tesák", SortOrder = 1
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = 1,
+            GameId = 1,
+            RegistrantUserId = "user-1",
+            PrimaryContactName = "Parent",
+            PrimaryEmail = "parent@example.cz",
+            PrimaryPhone = "777111222",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200
+        });
+        db.People.Add(new Person
+        {
+            Id = 1, FirstName = "Kid", LastName = "One", BirthYear = 2015,
+            CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+        });
+        db.Registrations.Add(new Registration
+        {
+            Id = 1, SubmissionId = 1, PersonId = 1,
+            AttendeeType = AttendeeType.Player,
+            Status = RegistrationStatus.Active,
+            CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task SeedAdultRegistrationAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.People.Add(new Person
+        {
+            Id = 2, FirstName = "Parent", LastName = "One", BirthYear = 1985,
+            CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+        });
+        db.Registrations.Add(new Registration
+        {
+            Id = 2, SubmissionId = 1, PersonId = 2,
+            AttendeeType = AttendeeType.Adult,
+            Status = RegistrationStatus.Active,
+            CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task SeedSecondSubmissionAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Users.Add(new ApplicationUser
+        {
+            Id = "user-2",
+            DisplayName = "Other",
+            Email = "other@example.cz",
+            NormalizedEmail = "OTHER@EXAMPLE.CZ",
+            UserName = "other@example.cz",
+            NormalizedUserName = "OTHER@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = 2,
+            GameId = 1,
+            RegistrantUserId = "user-2",
+            PrimaryContactName = "Other",
+            PrimaryEmail = "other@example.cz",
+            PrimaryPhone = "777222333",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200
+        });
+        db.People.Add(new Person
+        {
+            Id = 99, FirstName = "Other", LastName = "Kid", BirthYear = 2015,
+            CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+        });
+        db.Registrations.Add(new Registration
+        {
+            Id = 99, SubmissionId = 2, PersonId = 99,
+            AttendeeType = AttendeeType.Player,
+            Status = RegistrationStatus.Active,
+            CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepTokenServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepTokenServiceTests.cs
@@ -1,0 +1,177 @@
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+public sealed class CharacterPrepTokenServiceTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly Regex Base64UrlPattern = new("^[A-Za-z0-9_-]+$", RegexOptions.Compiled);
+
+    [Fact]
+    public async Task EnsureTokenAsync_generates_token_on_first_call()
+    {
+        var options = CreateOptions();
+        var submissionId = await SeedSubmissionAsync(options, existingToken: null);
+
+        var service = new CharacterPrepTokenService(new TestDbContextFactory(options));
+
+        var token = await service.EnsureTokenAsync(submissionId, CancellationToken.None);
+
+        Assert.False(string.IsNullOrWhiteSpace(token));
+        Assert.InRange(token.Length, 40, 48);
+        Assert.Matches(Base64UrlPattern, token);
+
+        await using var verify = new ApplicationDbContext(options);
+        var persisted = await verify.RegistrationSubmissions.SingleAsync(x => x.Id == submissionId);
+        Assert.Equal(token, persisted.CharacterPrepToken);
+    }
+
+    [Fact]
+    public async Task EnsureTokenAsync_is_idempotent()
+    {
+        var options = CreateOptions();
+        var submissionId = await SeedSubmissionAsync(options, existingToken: null);
+
+        var service = new CharacterPrepTokenService(new TestDbContextFactory(options));
+
+        var first = await service.EnsureTokenAsync(submissionId, CancellationToken.None);
+        var second = await service.EnsureTokenAsync(submissionId, CancellationToken.None);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public async Task RotateTokenAsync_replaces_existing_token()
+    {
+        var options = CreateOptions();
+        var submissionId = await SeedSubmissionAsync(options, existingToken: null);
+
+        var service = new CharacterPrepTokenService(new TestDbContextFactory(options));
+
+        var original = await service.EnsureTokenAsync(submissionId, CancellationToken.None);
+        var rotated = await service.RotateTokenAsync(submissionId, CancellationToken.None);
+
+        Assert.NotEqual(original, rotated);
+        Assert.Matches(Base64UrlPattern, rotated);
+
+        var lookupOld = await service.FindBySubmissionTokenAsync(original, CancellationToken.None);
+        Assert.Null(lookupOld);
+
+        var lookupNew = await service.FindBySubmissionTokenAsync(rotated, CancellationToken.None);
+        Assert.NotNull(lookupNew);
+        Assert.Equal(submissionId, lookupNew!.Id);
+    }
+
+    [Fact]
+    public async Task FindBySubmissionTokenAsync_returns_null_for_unknown()
+    {
+        var options = CreateOptions();
+        await SeedSubmissionAsync(options, existingToken: "some-real-token");
+
+        var service = new CharacterPrepTokenService(new TestDbContextFactory(options));
+
+        var result = await service.FindBySubmissionTokenAsync("does-not-exist", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindBySubmissionTokenAsync_returns_null_for_soft_deleted_submission()
+    {
+        var options = CreateOptions();
+        const string token = "active-token-value";
+        var submissionId = await SeedSubmissionAsync(options, existingToken: token);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var submission = await db.RegistrationSubmissions.SingleAsync(x => x.Id == submissionId);
+            submission.IsDeleted = true;
+            await db.SaveChangesAsync();
+        }
+
+        var service = new CharacterPrepTokenService(new TestDbContextFactory(options));
+
+        var result = await service.FindBySubmissionTokenAsync(token, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task<int> SeedSubmissionAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        string? existingToken)
+    {
+        var user = new ApplicationUser
+        {
+            Id = "user-" + Guid.NewGuid().ToString("N"),
+            DisplayName = "Parent",
+            Email = "parent@example.cz",
+            NormalizedEmail = "PARENT@EXAMPLE.CZ",
+            UserName = "parent@example.cz",
+            NormalizedUserName = "PARENT@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        };
+
+        var game = new Game
+        {
+            Id = 1,
+            Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(15),
+            PaymentDueAtUtc = FixedUtc.AddDays(25),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "123/0100",
+            BankAccountName = "Ovčina",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        };
+
+        var submission = new RegistrationSubmission
+        {
+            Id = 1,
+            GameId = game.Id,
+            RegistrantUserId = user.Id,
+            PrimaryContactName = "Parent",
+            PrimaryEmail = "parent@example.cz",
+            PrimaryPhone = "777111222",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200,
+            CharacterPrepToken = existingToken
+        };
+
+        await using var db = new ApplicationDbContext(options);
+        db.Users.Add(user);
+        db.Games.Add(game);
+        db.RegistrationSubmissions.Add(submission);
+        await db.SaveChangesAsync();
+
+        return submission.Id;
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/GameStatsCharacterPrepWidgetTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/GameStatsCharacterPrepWidgetTests.cs
@@ -44,6 +44,34 @@ public sealed class GameStatsCharacterPrepWidgetTests
     }
 
     [Fact]
+    public async Task Widget_excludes_soft_deleted_submissions()
+    {
+        // GameStatsService reads Registrations via navigation through Submission.
+        // EF's HasQueryFilter on Registration (!x.Person.IsDeleted && !x.Submission.IsDeleted)
+        // should hide the soft-deleted submission's players from both
+        // CharacterPrepTotal and CharacterPrepFilled. This test locks that in so a
+        // future LINQ refactor cannot drift away from the dashboard stats/rows methods.
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        // Active submission: 1 fully-filled player.
+        await AddSubmissionAsync(options, submissionId: 1,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) });
+
+        // Soft-deleted submission: 1 fully-filled player — must NOT appear in widget counts.
+        await AddSubmissionAsync(options, submissionId: 2,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) },
+            isDeleted: true);
+
+        var service = new GameStatsService(new TestDbContextFactory(options));
+        var stats = await service.GetGameStatsAsync(GameId);
+
+        Assert.NotNull(stats);
+        Assert.Equal(1, stats!.CharacterPrepTotal);
+        Assert.Equal(1, stats.CharacterPrepFilled);
+    }
+
+    [Fact]
     public async Task Widget_shows_zero_over_zero_when_no_players()
     {
         var options = CreateOptions();
@@ -96,7 +124,8 @@ public sealed class GameStatsCharacterPrepWidgetTests
     private static async Task AddSubmissionAsync(
         DbContextOptions<ApplicationDbContext> options,
         int submissionId,
-        IReadOnlyList<PlayerSpec> players)
+        IReadOnlyList<PlayerSpec> players,
+        bool isDeleted = false)
     {
         await using var db = new ApplicationDbContext(options);
         var userId = "user-" + submissionId;
@@ -124,7 +153,8 @@ public sealed class GameStatsCharacterPrepWidgetTests
             Status = SubmissionStatus.Submitted,
             SubmittedAtUtc = FixedUtc,
             LastEditedAtUtc = FixedUtc,
-            ExpectedTotalAmount = 1200
+            ExpectedTotalAmount = 1200,
+            IsDeleted = isDeleted
         });
         await db.SaveChangesAsync();
 

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/GameStatsCharacterPrepWidgetTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/GameStatsCharacterPrepWidgetTests.cs
@@ -1,0 +1,163 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.Stats;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+/// <summary>
+/// The character-prep widget on /organizace/hry/{gameId}/statistiky reads
+/// CharacterPrepFilled / CharacterPrepTotal from GameStats so the page doesn't
+/// need to inject a second service.
+/// </summary>
+public sealed class GameStatsCharacterPrepWidgetTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private const int GameId = 1;
+    private const int EquipmentId = 10;
+
+    [Fact]
+    public async Task Widget_shows_player_count_fully_filled_over_total()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        // Submission 1: 2 players, 1 fully filled.
+        await AddSubmissionAsync(options, submissionId: 1,
+            players: new[]
+            {
+                new PlayerSpec(hasName: true, hasEquipment: true),
+                new PlayerSpec(hasName: false, hasEquipment: false),
+            });
+        // Submission 2: 1 player, fully filled.
+        await AddSubmissionAsync(options, submissionId: 2,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) });
+        // Submission 3: 1 player, missing equipment.
+        await AddSubmissionAsync(options, submissionId: 3,
+            players: new[] { new PlayerSpec(hasName: true, hasEquipment: false) });
+
+        var service = new GameStatsService(new TestDbContextFactory(options));
+        var stats = await service.GetGameStatsAsync(GameId);
+
+        Assert.NotNull(stats);
+        Assert.Equal(4, stats!.CharacterPrepTotal);
+        Assert.Equal(2, stats.CharacterPrepFilled);
+    }
+
+    [Fact]
+    public async Task Widget_shows_zero_over_zero_when_no_players()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        var service = new GameStatsService(new TestDbContextFactory(options));
+        var stats = await service.GetGameStatsAsync(GameId);
+
+        Assert.NotNull(stats);
+        Assert.Equal(0, stats!.CharacterPrepTotal);
+        Assert.Equal(0, stats.CharacterPrepFilled);
+    }
+
+    // ------------------------------------------------------------ helpers
+
+    private sealed record PlayerSpec(bool hasName, bool hasEquipment);
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedGameAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = GameId, Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(15),
+            PaymentDueAtUtc = FixedUtc.AddDays(25),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = EquipmentId, GameId = GameId, Key = "sword", DisplayName = "Meč", SortOrder = 1
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task AddSubmissionAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int submissionId,
+        IReadOnlyList<PlayerSpec> players)
+    {
+        await using var db = new ApplicationDbContext(options);
+        var userId = "user-" + submissionId;
+        db.Users.Add(new ApplicationUser
+        {
+            Id = userId,
+            DisplayName = "U" + submissionId,
+            Email = $"u{submissionId}@example.cz",
+            NormalizedEmail = $"U{submissionId}@EXAMPLE.CZ",
+            UserName = $"u{submissionId}@example.cz",
+            NormalizedUserName = $"U{submissionId}@EXAMPLE.CZ",
+            EmailConfirmed = true, IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = submissionId,
+            GameId = GameId,
+            RegistrantUserId = userId,
+            PrimaryContactName = "HH " + submissionId,
+            PrimaryEmail = $"u{submissionId}@example.cz",
+            PrimaryPhone = "777000000",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200
+        });
+        await db.SaveChangesAsync();
+
+        for (var i = 0; i < players.Count; i++)
+        {
+            var pid = submissionId * 100 + i + 1;
+            db.People.Add(new Person
+            {
+                Id = pid, FirstName = "Kid" + i, LastName = "S" + submissionId, BirthYear = 2015,
+                CreatedAtUtc = FixedUtc, UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = pid,
+                SubmissionId = submissionId,
+                PersonId = pid,
+                AttendeeType = AttendeeType.Player,
+                Status = RegistrationStatus.Active,
+                CharacterName = players[i].hasName ? "Hero " + i : null,
+                StartingEquipmentOptionId = players[i].hasEquipment ? EquipmentId : null,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/SubmissionDetailCharacterPrepSectionTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/SubmissionDetailCharacterPrepSectionTests.cs
@@ -1,0 +1,338 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.CharacterPrep;
+
+namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
+
+/// <summary>
+/// Service-level flow tests for the "Příprava postav" section on the organizer
+/// submission detail page (Phase 8 / Task 21). The razor markup wires up exactly the
+/// same service methods a human would hit with the three action buttons, so locking
+/// them in here keeps the page regression-proof without spinning up a full
+/// WebApplicationFactory.
+/// </summary>
+public sealed class SubmissionDetailCharacterPrepSectionTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset NowUtc = new(FixedUtc);
+    private const int GameId = 1;
+    private const int EquipmentId = 10;
+
+    [Fact]
+    public async Task Send_pozvanka_from_detail_invokes_service_and_stamps_timestamp()
+    {
+        // Mirrors the "Poslat pozvánku" button click: submission has no invite yet,
+        // service must send, mark invited, and persist a token for the copy-link UI.
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, adults: 0);
+
+        var (mailService, sender) = CreateMailService(options);
+
+        var result = await mailService.SendPozvankaAsync(1, NowUtc, CancellationToken.None);
+
+        Assert.Equal(SendSingleResult.Sent, result);
+        Assert.Single(sender.Captured);
+
+        await using var verify = new ApplicationDbContext(options);
+        var submission = await verify.RegistrationSubmissions.SingleAsync(x => x.Id == 1);
+        Assert.Equal(NowUtc, submission.CharacterPrepInvitedAtUtc);
+        Assert.False(string.IsNullOrWhiteSpace(submission.CharacterPrepToken));
+    }
+
+    [Fact]
+    public async Task Send_pripominka_enforces_24h_throttle_on_detail()
+    {
+        // Detail page's "Poslat připomínku" button must surrender to the same
+        // 24h guard that the bulk send path uses, so two clicks in quick
+        // succession do not blast the household twice.
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: NowUtc.AddDays(-3),
+            players: 1, adults: 0,
+            reminderLastSentAtUtc: NowUtc.AddHours(-1));
+
+        var (mailService, sender) = CreateMailService(options);
+
+        var throttled = await mailService.SendPripominkaAsync(1, NowUtc, CancellationToken.None);
+
+        Assert.Equal(SendSingleResult.ThrottledSkipped, throttled);
+        Assert.Empty(sender.Captured);
+
+        // Walk past the 24h boundary and the same call should now go through.
+        var later = NowUtc.AddHours(24).AddSeconds(1);
+        var sent = await mailService.SendPripominkaAsync(1, later, CancellationToken.None);
+
+        Assert.Equal(SendSingleResult.Sent, sent);
+        Assert.Single(sender.Captured);
+    }
+
+    [Fact]
+    public async Task Regenerate_token_invalidates_old_and_produces_new_value()
+    {
+        // "Vygenerovat nový odkaz" must both mint a fresh token and take the old
+        // URL out of circulation — otherwise the destructive confirm prompt in
+        // the UI is a lie.
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, invitedAtUtc: null, players: 1, adults: 0);
+
+        var tokenService = new CharacterPrepTokenService(new TestDbContextFactory(options));
+
+        var original = await tokenService.EnsureTokenAsync(1, CancellationToken.None);
+        var rotated = await tokenService.RotateTokenAsync(1, CancellationToken.None);
+
+        Assert.NotEqual(original, rotated);
+
+        var lookupOld = await tokenService.FindBySubmissionTokenAsync(original, CancellationToken.None);
+        Assert.Null(lookupOld);
+
+        var lookupNew = await tokenService.FindBySubmissionTokenAsync(rotated, CancellationToken.None);
+        Assert.NotNull(lookupNew);
+        Assert.Equal(1, lookupNew!.Id);
+    }
+
+    [Theory]
+    [InlineData(false, false, false, CharacterPrepStatus.NotInvited)]
+    [InlineData(true, false, false, CharacterPrepStatus.Waiting)]
+    [InlineData(true, true, false, CharacterPrepStatus.Waiting)]   // name but no equipment → still waiting
+    [InlineData(true, false, true, CharacterPrepStatus.Waiting)]   // equipment but no name → still waiting
+    [InlineData(true, true, true, CharacterPrepStatus.Done)]
+    public async Task Status_derived_correctly_for_each_submission_state(
+        bool invited,
+        bool characterNameFilled,
+        bool equipmentFilled,
+        CharacterPrepStatus expected)
+    {
+        // The Nezváno / Čeká / Hotovo badge on SubmissionDetail is derived by the
+        // same predicate that drives the dashboard — lock the truth table here.
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(
+            options, submissionId: 1,
+            invitedAtUtc: invited ? NowUtc.AddDays(-2) : null,
+            players: 1, adults: 0,
+            characterName: characterNameFilled ? "Aragorn" : null,
+            equipmentId: equipmentFilled ? EquipmentId : null);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        var status = await service.GetSubmissionStatusAsync(1, CancellationToken.None);
+
+        Assert.Equal(expected, status);
+    }
+
+    [Fact]
+    public async Task GetSubmissionStatusAsync_returns_null_for_unknown_submission()
+    {
+        // Guard against accidental "assume it exists" — SubmissionDetail resolves
+        // the detail first, but a concurrent soft-delete must not blow up the page.
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        var service = new CharacterPrepService(new TestDbContextFactory(options));
+
+        var status = await service.GetSubmissionStatusAsync(9999, CancellationToken.None);
+
+        Assert.Null(status);
+    }
+
+    [Fact]
+    public void Public_prep_url_format_is_base_slash_postavy_slash_token()
+    {
+        // The copy-to-clipboard button on SubmissionDetail hands the parent the
+        // exact URL the pozvánka email advertises — must line up with the format
+        // CharacterPrepMailService.BuildEmailModel builds.
+        const string baseUrl = "https://registrace.ovcina.cz";
+        const string token = "abcDEF-123_456";
+
+        var url = $"{baseUrl.TrimEnd('/')}/postavy/{token}";
+
+        Assert.Equal("https://registrace.ovcina.cz/postavy/abcDEF-123_456", url);
+    }
+
+    // ------------------------------------------------------------ helpers
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static (CharacterPrepMailService Service, FakeCharacterPrepEmailSender Sender) CreateMailService(
+        DbContextOptions<ApplicationDbContext> options)
+    {
+        var factory = new TestDbContextFactory(options);
+        var prepService = new CharacterPrepService(factory);
+        var tokenService = new CharacterPrepTokenService(factory);
+        var renderer = new CharacterPrepEmailRenderer();
+        var sender = new FakeCharacterPrepEmailSender();
+        var mailOptions = Options.Create(new CharacterPrepOptions
+        {
+            PublicBaseUrl = "https://registrace.ovcina.cz",
+            OrganizerContactEmail = "organizatori@ovcina.cz"
+        });
+        var mailService = new CharacterPrepMailService(
+            factory,
+            renderer,
+            tokenService,
+            prepService,
+            sender,
+            mailOptions,
+            NullLogger<CharacterPrepMailService>.Instance);
+        return (mailService, sender);
+    }
+
+    private static async Task SeedGameAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = GameId,
+            Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(30),
+            EndsAtUtc = FixedUtc.AddDays(32),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(20),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(15),
+            PaymentDueAtUtc = FixedUtc.AddDays(25),
+            PlayerBasePrice = 1200,
+            AdultHelperBasePrice = 800,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.StartingEquipmentOptions.Add(new StartingEquipmentOption
+        {
+            Id = EquipmentId,
+            GameId = GameId,
+            Key = "tesak",
+            DisplayName = "Tesák",
+            SortOrder = 1
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task AddSubmissionAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int submissionId,
+        DateTimeOffset? invitedAtUtc,
+        int players,
+        int adults,
+        bool allPlayersEquipped = false,
+        DateTimeOffset? reminderLastSentAtUtc = null,
+        string? characterName = null,
+        int? equipmentId = null)
+    {
+        await using var db = new ApplicationDbContext(options);
+        var userId = "user-" + submissionId;
+        db.Users.Add(new ApplicationUser
+        {
+            Id = userId,
+            DisplayName = "U" + submissionId,
+            Email = $"u{submissionId}@example.cz",
+            NormalizedEmail = $"U{submissionId}@EXAMPLE.CZ",
+            UserName = $"u{submissionId}@example.cz",
+            NormalizedUserName = $"U{submissionId}@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = submissionId,
+            GameId = GameId,
+            RegistrantUserId = userId,
+            PrimaryContactName = "Contact " + submissionId,
+            PrimaryEmail = $"u{submissionId}@example.cz",
+            PrimaryPhone = "777000000",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = 1200,
+            CharacterPrepInvitedAtUtc = invitedAtUtc,
+            CharacterPrepReminderLastSentAtUtc = reminderLastSentAtUtc
+        });
+
+        var personBaseId = submissionId * 1000;
+        var regBaseId = submissionId * 1000;
+        for (var i = 0; i < players; i++)
+        {
+            var pid = personBaseId + i + 1;
+            db.People.Add(new Person
+            {
+                Id = pid,
+                FirstName = "Player" + i,
+                LastName = "S" + submissionId,
+                BirthYear = 2015,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = regBaseId + i + 1,
+                SubmissionId = submissionId,
+                PersonId = pid,
+                AttendeeType = AttendeeType.Player,
+                Status = RegistrationStatus.Active,
+                CharacterName = characterName ?? (allPlayersEquipped ? "Hero " + i : null),
+                StartingEquipmentOptionId = equipmentId ?? (allPlayersEquipped ? EquipmentId : (int?)null),
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        for (var i = 0; i < adults; i++)
+        {
+            var pid = personBaseId + 500 + i + 1;
+            db.People.Add(new Person
+            {
+                Id = pid,
+                FirstName = "Adult" + i,
+                LastName = "S" + submissionId,
+                BirthYear = 1985,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = regBaseId + 500 + i + 1,
+                SubmissionId = submissionId,
+                PersonId = pid,
+                AttendeeType = AttendeeType.Adult,
+                Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+
+    private sealed class FakeCharacterPrepEmailSender : ICharacterPrepEmailSender
+    {
+        public List<SentMessage> Captured { get; } = new();
+
+        public Task SendAsync(string recipientEmail, string subject, string htmlBody, CancellationToken cancellationToken)
+        {
+            Captured.Add(new SentMessage(recipientEmail, subject, htmlBody));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record SentMessage(string To, string Subject, string HtmlBody);
+}

--- a/tests/RegistraceOvcina.Web.Tests/MailboxSyncReconciliationTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/MailboxSyncReconciliationTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Tests;
+
+/// <summary>
+/// Guards the prefix filter used by <c>MailboxSyncService</c> to select local
+/// placeholder rows for reconciliation. The prefixes are a literal contract with
+/// the writer services: <c>InboxService</c> uses "composed-" and "reply-", and
+/// <c>CharacterPrepMailService</c> uses "prep-". If a writer introduces a new
+/// prefix without the filter learning about it, that outbox row will be
+/// duplicated on the next sync pass.
+///
+/// We assert the filter against the same in-memory EF Core context the sync
+/// service uses, by executing the exact same IQueryable shape — this stays
+/// truthful without having to stand up the full Graph HTTP pipeline.
+/// </summary>
+public sealed class MailboxSyncReconciliationTests
+{
+    [Fact]
+    public async Task Placeholder_filter_includes_prep_prefix_alongside_composed_and_reply()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+        await using (var seed = new ApplicationDbContext(options))
+        {
+            seed.EmailMessages.AddRange(
+                NewOutbound("composed-aaa"),
+                NewOutbound("reply-bbb"),
+                NewOutbound("prep-ccc"),
+                NewOutbound("AAMkA-real-graph-id"), // real Graph id: must NOT match
+                NewInbound("prep-ddd-but-inbound"));  // inbound: must NOT match
+            await seed.SaveChangesAsync();
+        }
+
+        await using var db = new ApplicationDbContext(options);
+
+        // Mirror of the query shape used inside MailboxSyncService.SyncInboxAsync.
+        var placeholders = await db.EmailMessages
+            .Where(e => e.Direction == EmailDirection.Outbound
+                && (e.MailboxItemId.StartsWith("composed-")
+                    || e.MailboxItemId.StartsWith("reply-")
+                    || e.MailboxItemId.StartsWith("prep-")))
+            .OrderByDescending(e => e.SentAtUtc)
+            .ToListAsync();
+
+        Assert.Equal(3, placeholders.Count);
+        Assert.Contains(placeholders, p => p.MailboxItemId == "composed-aaa");
+        Assert.Contains(placeholders, p => p.MailboxItemId == "reply-bbb");
+        Assert.Contains(placeholders, p => p.MailboxItemId == "prep-ccc");
+        Assert.DoesNotContain(placeholders, p => p.MailboxItemId == "AAMkA-real-graph-id");
+        Assert.DoesNotContain(placeholders, p => p.MailboxItemId == "prep-ddd-but-inbound");
+    }
+
+    [Fact]
+    public async Task Reconciled_prep_placeholder_is_updated_in_place_not_inserted_as_duplicate()
+    {
+        // Simulates the end-state of a successful reconciliation: a prep-* row
+        // that existed before sync now holds the real Graph id, and no second
+        // row was created for the same logical message. If the mail service's
+        // "prep-" prefix fell outside the sync filter, the service would have
+        // inserted a second row with the Graph id — we assert that shape does
+        // not arise when the reconciliation step fires.
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+        const string placeholderId = "prep-abc";
+        const string graphId = "AAMkAGVlYTY-real-id";
+        const int submissionId = 42;
+
+        await using (var seed = new ApplicationDbContext(options))
+        {
+            seed.EmailMessages.Add(new EmailMessage
+            {
+                MailboxItemId = placeholderId,
+                Direction = EmailDirection.Outbound,
+                From = "ovcina@ovcina.cz",
+                To = "parent@example.cz",
+                Subject = "Příprava postav pro Ovčina 2026 — vyber startovní výbavu",
+                BodyText = "Ahoj, chystáme ...",
+                SentAtUtc = DateTime.UtcNow.AddMinutes(-5),
+                LinkedSubmissionId = submissionId
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        // Act: simulate the reconciliation match step from MailboxSyncService.
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var candidate = await db.EmailMessages
+                .Where(e => e.Direction == EmailDirection.Outbound
+                    && (e.MailboxItemId.StartsWith("composed-")
+                        || e.MailboxItemId.StartsWith("reply-")
+                        || e.MailboxItemId.StartsWith("prep-")))
+                .Where(e => e.To == "parent@example.cz"
+                    && e.Subject == "Příprava postav pro Ovčina 2026 — vyber startovní výbavu")
+                .SingleAsync();
+
+            Assert.Equal(placeholderId, candidate.MailboxItemId);
+            candidate.MailboxItemId = graphId;
+            candidate.ReceivedAtUtc = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+        }
+
+        // Assert: exactly one row, now holding the Graph id, still linked to the submission.
+        await using (var verify = new ApplicationDbContext(options))
+        {
+            var rows = await verify.EmailMessages
+                .Where(e => e.LinkedSubmissionId == submissionId)
+                .ToListAsync();
+
+            Assert.Single(rows);
+            Assert.Equal(graphId, rows[0].MailboxItemId);
+            Assert.DoesNotContain(rows, r => r.MailboxItemId == placeholderId);
+        }
+    }
+
+    private static EmailMessage NewOutbound(string mailboxItemId) => new()
+    {
+        MailboxItemId = mailboxItemId,
+        Direction = EmailDirection.Outbound,
+        From = "ovcina@ovcina.cz",
+        To = "recipient@example.cz",
+        Subject = "Subject " + mailboxItemId,
+        BodyText = "Body " + mailboxItemId,
+        SentAtUtc = DateTime.UtcNow
+    };
+
+    private static EmailMessage NewInbound(string mailboxItemId) => new()
+    {
+        MailboxItemId = mailboxItemId,
+        Direction = EmailDirection.Inbound,
+        From = "someone@example.cz",
+        To = "ovcina@ovcina.cz",
+        Subject = "Subject " + mailboxItemId,
+        BodyText = "Body " + mailboxItemId,
+        ReceivedAtUtc = DateTime.UtcNow
+    };
+}

--- a/tests/RegistraceOvcina.Web.Tests/RegistrationCharacterPrepColumnsTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/RegistrationCharacterPrepColumnsTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Tests;
+
+public sealed class RegistrationCharacterPrepColumnsTests
+{
+    [Fact]
+    public void StartingEquipmentOptionId_IsNullableFkProperty()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(Registration))!;
+
+        var property = entityType.FindProperty(nameof(Registration.StartingEquipmentOptionId))!;
+
+        Assert.NotNull(property);
+        Assert.True(property.IsNullable);
+    }
+
+    [Fact]
+    public void StartingEquipmentOption_NavigationProperty_Exists()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(Registration))!;
+
+        var navigation = entityType.FindNavigation(nameof(Registration.StartingEquipmentOption));
+
+        Assert.NotNull(navigation);
+        Assert.Equal(typeof(StartingEquipmentOption), navigation.ClrType);
+    }
+
+    [Fact]
+    public void CharacterPrepNote_HasMaxLength4000AndIsNullable()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(Registration))!;
+
+        var property = entityType.FindProperty(nameof(Registration.CharacterPrepNote))!;
+
+        Assert.Equal(4000, property.GetMaxLength());
+        Assert.True(property.IsNullable);
+    }
+
+    [Fact]
+    public void CharacterPrepUpdatedAtUtc_IsNullableDateTimeOffset()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(Registration))!;
+
+        var property = entityType.FindProperty(nameof(Registration.CharacterPrepUpdatedAtUtc))!;
+
+        Assert.NotNull(property);
+        Assert.True(property.IsNullable);
+        Assert.Equal(typeof(DateTimeOffset?), property.ClrType);
+    }
+
+    [Fact]
+    public void ForeignKey_To_StartingEquipmentOption_IsRestrict()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(Registration))!;
+
+        var fk = entityType.GetForeignKeys()
+            .Single(f => f.PrincipalEntityType.ClrType == typeof(StartingEquipmentOption));
+
+        Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior);
+    }
+
+    private static ApplicationDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/RegistrationSubmissionTokenColumnsTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/RegistrationSubmissionTokenColumnsTests.cs
@@ -1,0 +1,70 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Tests;
+
+public sealed class RegistrationSubmissionTokenColumnsTests
+{
+    [Fact]
+    public void CharacterPrepToken_HasMaxLength64AndIsNullable()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(RegistrationSubmission))!;
+
+        var property = entityType.FindProperty(nameof(RegistrationSubmission.CharacterPrepToken))!;
+
+        Assert.Equal(64, property.GetMaxLength());
+        Assert.True(property.IsNullable);
+    }
+
+    [Fact]
+    public void CharacterPrepInvitedAtUtc_IsNullableDateTimeOffset()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(RegistrationSubmission))!;
+
+        var property = entityType.FindProperty(nameof(RegistrationSubmission.CharacterPrepInvitedAtUtc))!;
+
+        Assert.NotNull(property);
+        Assert.True(property.IsNullable);
+        Assert.Equal(typeof(DateTimeOffset?), property.ClrType);
+    }
+
+    [Fact]
+    public void CharacterPrepReminderLastSentAtUtc_IsNullableDateTimeOffset()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(RegistrationSubmission))!;
+
+        var property = entityType.FindProperty(nameof(RegistrationSubmission.CharacterPrepReminderLastSentAtUtc))!;
+
+        Assert.NotNull(property);
+        Assert.True(property.IsNullable);
+        Assert.Equal(typeof(DateTimeOffset?), property.ClrType);
+    }
+
+    [Fact]
+    public void UniqueFilteredIndex_On_CharacterPrepToken_Exists()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(RegistrationSubmission))!;
+
+        var tokenIndex = entityType.GetIndexes().SingleOrDefault(i =>
+            i.IsUnique &&
+            i.Properties.Count == 1 &&
+            i.Properties[0].Name == nameof(RegistrationSubmission.CharacterPrepToken));
+
+        Assert.NotNull(tokenIndex);
+        var filter = tokenIndex.GetFilter();
+        Assert.NotNull(filter);
+        Assert.Equal("\"CharacterPrepToken\" IS NOT NULL", filter);
+    }
+
+    private static ApplicationDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/StartingEquipmentOptionConfigurationTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/StartingEquipmentOptionConfigurationTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Tests;
+
+public sealed class StartingEquipmentOptionConfigurationTests
+{
+    [Fact]
+    public void StartingEquipmentOption_IsRegisteredAsEntity()
+    {
+        using var db = CreateDb();
+
+        var entityType = db.Model.FindEntityType(typeof(StartingEquipmentOption));
+
+        Assert.NotNull(entityType);
+    }
+
+    [Fact]
+    public void StartingEquipmentOption_HasDbSetOnContext()
+    {
+        using var db = CreateDb();
+
+        Assert.NotNull(db.StartingEquipmentOptions);
+    }
+
+    [Fact]
+    public void Key_HasMaxLength50AndIsRequired()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(StartingEquipmentOption))!;
+
+        var property = entityType.FindProperty(nameof(StartingEquipmentOption.Key))!;
+
+        Assert.Equal(50, property.GetMaxLength());
+        Assert.False(property.IsNullable);
+    }
+
+    [Fact]
+    public void DisplayName_HasMaxLength100AndIsRequired()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(StartingEquipmentOption))!;
+
+        var property = entityType.FindProperty(nameof(StartingEquipmentOption.DisplayName))!;
+
+        Assert.Equal(100, property.GetMaxLength());
+        Assert.False(property.IsNullable);
+    }
+
+    [Fact]
+    public void Description_HasMaxLength500AndIsNullable()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(StartingEquipmentOption))!;
+
+        var property = entityType.FindProperty(nameof(StartingEquipmentOption.Description))!;
+
+        Assert.Equal(500, property.GetMaxLength());
+        Assert.True(property.IsNullable);
+    }
+
+    [Fact]
+    public void UniqueIndex_On_GameId_Key_Exists()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(StartingEquipmentOption))!;
+
+        var uniqueComposite = entityType.GetIndexes().SingleOrDefault(i =>
+            i.IsUnique &&
+            i.Properties.Count == 2 &&
+            i.Properties[0].Name == nameof(StartingEquipmentOption.GameId) &&
+            i.Properties[1].Name == nameof(StartingEquipmentOption.Key));
+
+        Assert.NotNull(uniqueComposite);
+    }
+
+    [Fact]
+    public void ForeignKey_ToGame_IsCascade()
+    {
+        using var db = CreateDb();
+        var entityType = db.Model.FindEntityType(typeof(StartingEquipmentOption))!;
+
+        var fk = entityType.GetForeignKeys().Single(f => f.PrincipalEntityType.ClrType == typeof(Game));
+
+        Assert.Equal(DeleteBehavior.Cascade, fk.DeleteBehavior);
+    }
+
+    private static ApplicationDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/StartingEquipmentOptionConfigurationTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/StartingEquipmentOptionConfigurationTests.cs
@@ -76,14 +76,14 @@ public sealed class StartingEquipmentOptionConfigurationTests
     }
 
     [Fact]
-    public void ForeignKey_ToGame_IsCascade()
+    public void ForeignKey_ToGame_IsRestrict()
     {
         using var db = CreateDb();
         var entityType = db.Model.FindEntityType(typeof(StartingEquipmentOption))!;
 
         var fk = entityType.GetForeignKeys().Single(f => f.PrincipalEntityType.ClrType == typeof(Game));
 
-        Assert.Equal(DeleteBehavior.Cascade, fk.DeleteBehavior);
+        Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior);
     }
 
     private static ApplicationDbContext CreateDb()


### PR DESCRIPTION
## Summary
- Parents pre-pick each Player's **character name + starting equipment + optional note** via a tokenized link emailed to the household, so the LARP opening isn't blocked by 40 kids making choices on the morning.
- Token is opaque, 32-byte Base64Url, forwardable to the child; single page `/postavy/{token}` renders one card per Player attendee, pre-fills existing values, saves to `Registration` directly (no draft table).
- Organizer dashboard at `/organizace/hry/{gameId}/priprava-postav` with 4 stats tiles, filterable/sortable table, bulk **Poslat pozvánku** + **Poslat připomínku** buttons (24h throttle), per-row reminder, XLSX export, and a link to the equipment config page.
- Admin CRUD for the 5 equipment options at `/organizace/hry/{gameId}/priprava-postav/vybava` — per-game reference data, copy-from-another-game + one-click seed-defaults button.
- SubmissionDetail grows a **Příprava postav** section with status badge, token URL, copy/regenerate buttons, send buttons, and a send-history timeline.
- `MailboxSyncService` now reconciles `prep-*` outbox placeholders alongside `composed-*`/`reply-*` (prevents duplicate `EmailMessage` rows after sync passes).

## Architecture
New folder `Features/CharacterPrep/`: `CharacterPrepService` (view/save/bulk filters/dashboard stats), `CharacterPrepTokenService`, `CharacterPrepMailService`, `CharacterPrepEmailRenderer` (Czech Pozvánka + Připomínka, HTML + plaintext), `CharacterPrepOptionsService` (CRUD + seed), `CharacterPrepExportService` (ClosedXML, mirrors Kingdom export). One EF migration `AddCharacterPrepAndStartingEquipment` — additive, all new columns nullable, FK with `OnDelete(Restrict)` for both new FKs. `CharacterPrepOptions` config section validated on start (`PublicBaseUrl` required).

## Design + plan docs
- [`docs/plans/2026-04-20-character-prep-design.md`](docs/plans/2026-04-20-character-prep-design.md)
- [`docs/plans/2026-04-20-character-prep-implementation.md`](docs/plans/2026-04-20-character-prep-implementation.md)

## Test plan
- [x] **216 unit tests green** (77 baseline + 139 new across 13 test classes) — `dotnet test`
- [x] **11 E2E tests green** — existing 10 + 1 new `CharacterPrepSmokeTests` golden-path scenario (organizer bulk-invites → parent opens token link → fills 2 Player rows → saves → dashboard reflects Hotovo)
- [x] **Clean build**, 0 warnings, 0 errors on Web project
- [ ] Manual QA on staging once deployed — see design doc §9
- [ ] **After migration applies in prod**, seed the 5 equipment options by clicking **Vložit výchozí výbavu** on `/organizace/hry/{Ovčina2026GameId}/priprava-postav/vybava`
- [ ] Confirm prod config has `CharacterPrep:PublicBaseUrl=https://registrace.ovcina.cz` (injected via env per project convention) — `ValidateOnStart` will fail-fast if missing
- [ ] Send test pozvánka to one household, verify Graph outbox delivery + link resolves
- [ ] Walk through `/postavy/{token}` on mobile to confirm card layout works

## Deploy notes
- Migration is purely additive + nullable, safe to roll forward against existing data.
- No breaking changes to existing APIs; `SubmissionDetail.razor` picked up `@rendermode InteractiveServer` (its existing server-rendered form still posts normally via its own `<form method="post">`).
- Config key `CharacterPrep:PublicBaseUrl` must be set in prod environment.

## Known non-blocking follow-ups
- Server-side search / pagination if the dashboard ever hits > ~300 players (currently in-memory filter is fine at LARP scale).
- Rate limiting on `/postavy/{token}` if abuse is ever observed (attack surface is narrow: random 256-bit token, 3-column write scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)