### PR TITLE
hotfix: set CharacterPrep:PublicBaseUrl in appsettings.json

### DIFF
--- a/src/RegistraceOvcina.Web/appsettings.json
+++ b/src/RegistraceOvcina.Web/appsettings.json
@@ -36,5 +36,9 @@
       "ClientId": "",
       "ClientSecret": ""
     }
+  },
+  "CharacterPrep": {
+    "PublicBaseUrl": "https://registrace.ovcina.cz",
+    "OrganizerContactEmail": ""
   }
 }


### PR DESCRIPTION
Prod deploy at 76fb202 failed with OptionsValidationException: 'PublicBaseUrl field is required'. Adding the value (not a secret — it's the app's own public host) to base appsettings.json so all environments pick it up without requiring env var injection. Development and Testing configs already have their own overrides.