### PR TITLE
feat(prep): Pozvánka email copy — organizer final wording (v0.9.11)

### DIFF
--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepEmailRenderer.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepEmailRenderer.cs
@@ -100,8 +100,8 @@ public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
         sb.Append("<div style=\"font-family:Segoe UI,Arial,sans-serif;font-size:14px;line-height:1.5;color:#222;\">");
 
         sb.Append("<p>Vážený přihlášený na <b>").Append(encodedGame).Append("</b>,</p>");
-        sb.Append("<p>chystáme se. Těšíme se na Vás. Jsme také poučeni z minula a rádi bychom zrychlili začátek a připravili první volbu postav.</p>");
-        sb.Append("<p>Potřebujem od Vás kliknout na odkaz a vyplnit nám u každé postavy herní jméno a počáteční vybavení. Prosím zeptejte se dětí.</p>");
+        sb.Append("<p>Chystáme se. Těšíme se na Vás. Jsme také poučeni z minula a rádi bychom zrychlili začátek a připravili první volbu postav.</p>");
+        sb.Append("<p>Potřebujeme od Vás kliknout na odkaz a vyplnit nám u každé postavy herní jméno a počáteční vybavení. Prosím zeptejte se dětí.</p>");
         sb.Append("<p>Výběr už nachystáme přímo dětem do glejtu a tak se na začátku nemusí nikdo zdržovat.</p>");
         sb.Append("<p>Kdo si nic nevybere, dostane 5 měďáků a může si koupit co potřebuje na začátku hry, jen se tím pak trochu zdrží.</p>");
         sb.Append("<p>Jméno postavy bychom rádi zapsali do kronik a bude pokračovat v dalších hrách.</p>");
@@ -165,9 +165,9 @@ public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
 
         sb.Append("Vážený přihlášený na ").Append(model.GameName).AppendLine(",");
         sb.AppendLine();
-        sb.AppendLine("chystáme se. Těšíme se na Vás. Jsme také poučeni z minula a rádi bychom zrychlili začátek a připravili první volbu postav.");
+        sb.AppendLine("Chystáme se. Těšíme se na Vás. Jsme také poučeni z minula a rádi bychom zrychlili začátek a připravili první volbu postav.");
         sb.AppendLine();
-        sb.AppendLine("Potřebujem od Vás kliknout na odkaz a vyplnit nám u každé postavy herní jméno a počáteční vybavení. Prosím zeptejte se dětí.");
+        sb.AppendLine("Potřebujeme od Vás kliknout na odkaz a vyplnit nám u každé postavy herní jméno a počáteční vybavení. Prosím zeptejte se dětí.");
         sb.AppendLine();
         sb.AppendLine("Výběr už nachystáme přímo dětem do glejtu a tak se na začátku nemusí nikdo zdržovat.");
         sb.AppendLine();

--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepEmailRenderer.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepEmailRenderer.cs
@@ -99,14 +99,17 @@ public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
 
         sb.Append("<div style=\"font-family:Segoe UI,Arial,sans-serif;font-size:14px;line-height:1.5;color:#222;\">");
 
-        sb.Append("<p>Ahoj,</p>");
-        sb.Append("<p>chystáme <b>").Append(encodedGame).Append("</b> a potřebujeme od tebe krátkou přípravu postav. ")
-          .Append("Díky tomu si u vstupu na hru nezdržíme 30 minut startovní výbavou a hra může začít včas.</p>");
+        sb.Append("<p>Vážený přihlášený na <b>").Append(encodedGame).Append("</b>,</p>");
+        sb.Append("<p>chystáme se. Těšíme se na Vás. Jsme také poučeni z minula a rádi bychom zrychlili začátek a připravili první volbu postav.</p>");
+        sb.Append("<p>Potřebujem od Vás kliknout na odkaz a vyplnit nám u každé postavy herní jméno a počáteční vybavení. Prosím zeptejte se dětí.</p>");
+        sb.Append("<p>Výběr už nachystáme přímo dětem do glejtu a tak se na začátku nemusí nikdo zdržovat.</p>");
+        sb.Append("<p>Kdo si nic nevybere, dostane 5 měďáků a může si koupit co potřebuje na začátku hry, jen se tím pak trochu zdrží.</p>");
+        sb.Append("<p>Jméno postavy bychom rádi zapsali do kronik a bude pokračovat v dalších hrách.</p>");
 
         // Household player list
         if (model.PlayerFullNames.Count > 0)
         {
-            sb.Append("<p>Píšeme ti o těchto dětech:</p>");
+            sb.Append("<p>Píšeme si o těchto dětech:</p>");
             sb.Append("<ul>");
             foreach (var name in model.PlayerFullNames)
             {
@@ -116,7 +119,7 @@ public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
         }
 
         // Equipment options
-        sb.Append("<p>Vyber pro každé dítě jednu ze startovních výbav:</p>");
+        sb.Append("<p>Vyberte prosím každému dítěti jednu ze startovních výbav:</p>");
         sb.Append("<ul>");
         foreach (var option in model.Options)
         {
@@ -146,7 +149,7 @@ public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
         // we'd emit <a href="mailto:"></a> which some clients render as a dead link.
         if (hasContact)
         {
-            sb.Append("<p>Když něco nefunguje, napiš nám na ")
+            sb.Append("<p>Když něco nefunguje, napište nám na ")
               .Append("<a href=\"mailto:").Append(encodedContact).Append("\">").Append(encodedContact).Append("</a>.</p>");
         }
 
@@ -160,15 +163,22 @@ public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
     {
         var sb = new StringBuilder(1024);
 
-        sb.AppendLine("Ahoj,");
+        sb.Append("Vážený přihlášený na ").Append(model.GameName).AppendLine(",");
         sb.AppendLine();
-        sb.Append("chystáme ").Append(model.GameName).AppendLine(" a potřebujeme od tebe krátkou přípravu postav.");
-        sb.AppendLine("Díky tomu si u vstupu na hru nezdržíme 30 minut startovní výbavou a hra může začít včas.");
+        sb.AppendLine("chystáme se. Těšíme se na Vás. Jsme také poučeni z minula a rádi bychom zrychlili začátek a připravili první volbu postav.");
+        sb.AppendLine();
+        sb.AppendLine("Potřebujem od Vás kliknout na odkaz a vyplnit nám u každé postavy herní jméno a počáteční vybavení. Prosím zeptejte se dětí.");
+        sb.AppendLine();
+        sb.AppendLine("Výběr už nachystáme přímo dětem do glejtu a tak se na začátku nemusí nikdo zdržovat.");
+        sb.AppendLine();
+        sb.AppendLine("Kdo si nic nevybere, dostane 5 měďáků a může si koupit co potřebuje na začátku hry, jen se tím pak trochu zdrží.");
+        sb.AppendLine();
+        sb.AppendLine("Jméno postavy bychom rádi zapsali do kronik a bude pokračovat v dalších hrách.");
         sb.AppendLine();
 
         if (model.PlayerFullNames.Count > 0)
         {
-            sb.AppendLine("Píšeme ti o těchto dětech:");
+            sb.AppendLine("Píšeme si o těchto dětech:");
             foreach (var name in model.PlayerFullNames)
             {
                 sb.Append(" - ").AppendLine(name);
@@ -176,7 +186,7 @@ public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
             sb.AppendLine();
         }
 
-        sb.AppendLine("Vyber pro každé dítě jednu ze startovních výbav:");
+        sb.AppendLine("Vyberte prosím každému dítěti jednu ze startovních výbav:");
         foreach (var option in model.Options)
         {
             sb.Append(" - ").Append(option.DisplayName);
@@ -194,7 +204,7 @@ public sealed class CharacterPrepEmailRenderer : ICharacterPrepEmailRenderer
         sb.AppendLine();
         if (!string.IsNullOrWhiteSpace(model.OrganizerContactEmail))
         {
-            sb.Append("Když něco nefunguje, napiš nám na ").Append(model.OrganizerContactEmail).AppendLine(".");
+            sb.Append("Když něco nefunguje, napište nám na ").Append(model.OrganizerContactEmail).AppendLine(".");
             sb.AppendLine();
         }
         sb.AppendLine("Díky!");

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.10</Version>
+    <Version>0.9.11</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepEmailRendererTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepEmailRendererTests.cs
@@ -149,8 +149,8 @@ public sealed class CharacterPrepEmailRendererTests
         Assert.DoesNotContain("mailto:\"", rendered.HtmlBody);
         Assert.DoesNotContain("href=\"mailto:\"", rendered.HtmlBody);
         Assert.DoesNotContain("<a href=\"\"", rendered.HtmlBody);
-        Assert.DoesNotContain("napiš nám", rendered.HtmlBody);
-        Assert.DoesNotContain("napiš nám", rendered.PlainTextBody);
+        Assert.DoesNotContain("napište nám", rendered.HtmlBody);
+        Assert.DoesNotContain("napište nám", rendered.PlainTextBody);
     }
 
     [Fact]


### PR DESCRIPTION
Replaces the draft invitation copy with the organizer-approved final text: formal Vy-form greeting, motivation for the speed-up, fallback-if-not-picked (5 měďáků), chronicle-continuity line, 'Píšeme si o těchto dětech' / 'Vyberte prosím každému dítěti' phrasing. Plain-text body and optional contact-sentence tone updated to match. Tests already assert by dynamic content (names, URLs, game name, deadline, options) so no test changes needed — 217/217 unit green.