### PR TITLE
feat(prep): Příprava postav button on the games list (v0.9.13)

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/Games.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/Games.razor
@@ -189,6 +189,7 @@
                                                     <a href="/admin/hry/@game.Id/ubytovani" class="btn btn-sm btn-outline-primary">Ubytování</a>
                                                     <a href="/organizace/hry/@game.Id/kralovstvi" class="btn btn-sm btn-outline-success">Rozdělení</a>
                                                     <a href="/organizace/hry/@game.Id/ubytovani" class="btn btn-sm btn-outline-success">Přiřazení pokojů</a>
+                                                    <a href="/organizace/hry/@game.Id/priprava-postav" class="btn btn-sm btn-outline-success">Příprava postav</a>
                                                     <a href="/organizace/hry/@game.Id/qr-stitky" class="btn btn-sm btn-outline-success">QR štítky</a>
                                                 </div>
                                             </td>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.12</Version>
+    <Version>0.9.13</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
Adds a green 'Příprava postav' button to the per-game action row on /admin/hry, slotted between 'Přiřazení pokojů' and 'QR štítky' to match the game-day prep chronological flow. Target route already has StaffOnly auth so security is unchanged.