### PR TITLE
fix(prep): minimal layout on /postavy/{token} page — no login CTA (v0.9.15, closes #163)

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Layout/PrepLayout.razor
+++ b/src/RegistraceOvcina.Web/Components/Layout/PrepLayout.razor
@@ -1,0 +1,20 @@
+@inherits LayoutComponentBase
+
+<div class="prep-shell">
+    <header class="prep-header">
+        <div class="container py-3 d-flex flex-column flex-sm-row align-items-sm-center justify-content-between gap-2">
+            <a class="prep-brand-link" href="/">Ovčina registrace</a>
+            <span class="text-secondary prep-header-subtitle">Příprava postav</span>
+        </div>
+    </header>
+
+    <main class="container py-4">
+        @Body
+    </main>
+
+    <footer class="prep-footer">
+        <div class="container py-3 text-center text-secondary">
+            <small>Ovčina — kontaktujte organizátory, pokud potřebujete pomoc.</small>
+        </div>
+    </footer>
+</div>

--- a/src/RegistraceOvcina.Web/Components/Layout/PrepLayout.razor
+++ b/src/RegistraceOvcina.Web/Components/Layout/PrepLayout.razor
@@ -1,6 +1,11 @@
 @inherits LayoutComponentBase
 
 <div class="prep-shell">
+    @if (isInteractive)
+    {
+        <span data-testid="interactive-ready" hidden></span>
+    }
+
     <header class="prep-header">
         <div class="container py-3 d-flex flex-column flex-sm-row align-items-sm-center justify-content-between gap-2">
             <a class="prep-brand-link" href="/">Ovčina registrace</a>
@@ -18,3 +23,18 @@
         </div>
     </footer>
 </div>
+
+@code {
+    private bool isInteractive;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (!firstRender || isInteractive)
+        {
+            return;
+        }
+
+        isInteractive = true;
+        StateHasChanged();
+    }
+}

--- a/src/RegistraceOvcina.Web/Components/Layout/PrepLayout.razor
+++ b/src/RegistraceOvcina.Web/Components/Layout/PrepLayout.razor
@@ -24,6 +24,12 @@
     </footer>
 </div>
 
+<div id="blazor-error-ui" data-nosnippet>
+    Došlo k neočekávané chybě.
+    <a href="." class="reload">Načíst znovu</a>
+    <span class="dismiss">🗙</span>
+</div>
+
 @code {
     private bool isInteractive;
 

--- a/src/RegistraceOvcina.Web/Components/Pages/CharacterPrep/CharacterPrep.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/CharacterPrep/CharacterPrep.razor
@@ -1,6 +1,7 @@
 @page "/postavy/{Token}"
 @attribute [AllowAnonymous]
 @rendermode InteractiveServer
+@layout PrepLayout
 
 @using System.Globalization
 @using RegistraceOvcina.Web.Features.CharacterPrep

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.14</Version>
+    <Version>0.9.15</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Components/PrepLayoutAssertionsTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Components/PrepLayoutAssertionsTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace RegistraceOvcina.Web.Tests.Components;
+
+/// <summary>
+/// Static source-text assertions guarding the anonymous /postavy/{token} chrome.
+///
+/// Parents reaching CharacterPrep via the Pozvánka email link must not see a
+/// "Přihlásit se" button — GitHub issue #163. These tests are crude file-text
+/// checks (no bUnit dependency) but reliably catch regressions where someone
+/// re-adds a login CTA to PrepLayout or drops the @layout directive on the
+/// CharacterPrep page.
+/// </summary>
+public sealed class PrepLayoutAssertionsTests
+{
+    private static string RepoRoot =>
+        LocateRepoRoot(AppContext.BaseDirectory);
+
+    private static string LocateRepoRoot(string start)
+    {
+        var dir = new DirectoryInfo(start);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "RegistraceOvcina.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate repo root (RegistraceOvcina.slnx) starting from '{start}'.");
+    }
+
+    private static string ReadText(params string[] relativeSegments)
+    {
+        var full = Path.Combine(new[] { RepoRoot }.Concat(relativeSegments).ToArray());
+        Assert.True(File.Exists(full), $"Expected file to exist: {full}");
+        return File.ReadAllText(full);
+    }
+
+    [Fact]
+    public void PrepLayout_DoesNotContain_LoginCtaText()
+    {
+        var text = ReadText("src", "RegistraceOvcina.Web", "Components", "Layout", "PrepLayout.razor");
+
+        Assert.DoesNotContain("Přihlásit", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PrepLayout_DoesNotReuse_NavMenu()
+    {
+        var text = ReadText("src", "RegistraceOvcina.Web", "Components", "Layout", "PrepLayout.razor");
+
+        Assert.DoesNotContain("NavMenu", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrepLayout_InheritsLayoutComponentBase_AndRendersBody()
+    {
+        var text = ReadText("src", "RegistraceOvcina.Web", "Components", "Layout", "PrepLayout.razor");
+
+        Assert.Contains("@inherits LayoutComponentBase", text, StringComparison.Ordinal);
+        Assert.Contains("@Body", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CharacterPrepPage_OptsIntoPrepLayout()
+    {
+        var text = ReadText("src", "RegistraceOvcina.Web", "Components", "Pages", "CharacterPrep", "CharacterPrep.razor");
+
+        Assert.Contains("@layout PrepLayout", text, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #163.

The anonymous `/postavy/{token}` page inherited `MainLayout`, which
renders the site's top-nav **Přihlásit se** button for unauthenticated
visitors. Parents arriving via the Pozvánka email link read the button
as "your save won't persist until you log in", even though the save
toast already confirms the opposite.

This PR introduces a minimal `PrepLayout`:

- Brand-only header ("Ovčina registrace" + "Příprava postav" subtitle)
- No login CTA, no org/admin nav links, no user dropdown
- Minimal footer with organizer-contact hint
- `CharacterPrep` page opts in via `@layout PrepLayout`

Version bumped to **0.9.15**.

## What changed

- `src/RegistraceOvcina.Web/Components/Layout/PrepLayout.razor` — new, standalone (does not compose `NavMenu` or any other shared partial)
- `src/RegistraceOvcina.Web/Components/Pages/CharacterPrep/CharacterPrep.razor` — added `@layout PrepLayout` directive
- `src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj` — `0.9.14` → `0.9.15`
- `tests/RegistraceOvcina.Web.Tests/Components/PrepLayoutAssertionsTests.cs` — 4 new file-text assertions guarding against regressions (no bUnit dependency)

## Test plan

- [x] `dotnet build` — green
- [x] `dotnet test` — 231 passing (was 227), including the 4 new assertions
- [ ] Manual smoke test on deployed prod: open `/postavy/{token}` in a private window and confirm no "Přihlásit se" button in the header