### PR TITLE
fix(api): /check honors ApplicationUser→Person link for guardianOnly (v0.9.16)

### DIFF
--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
@@ -428,10 +428,19 @@ public static class IntegrationApiEndpoints
         // whitespace introduced by import scripts.
         var normalizedEmail = email.Trim().ToUpperInvariant();
 
-        // 1) Attendee by Person.Email (any AttendeeType — Player and Adult both
-        // count as "registered"; the old code only filtered by email, which is
-        // equivalent, but make it explicit here for clarity and future-proofing
-        // against new attendee types).
+        // ---------------------------------------------------------------
+        // Signal A — own-Registration match (strongest): the email resolves
+        // to a Person who has their own active Registration in this game.
+        //
+        // This is computed ALWAYS (not gated behind Signal A.1 failing) and
+        // unions three email→Person paths, so we don't miss edge cases where
+        // one path fails (e.g. duplicate ApplicationUser rows with the same
+        // NormalizedEmail, or a dedup pass that nulled Person.Email but left
+        // UserEmails alone). Mirrors how LoadUserGameInfoAsync resolves the
+        // caller: email → ApplicationUser → PersonId → Registration.
+        // ---------------------------------------------------------------
+
+        // A.1 — direct Person.Email match on a Registration in this game.
         var attendeeByPersonEmail = await db.Registrations
             .AsNoTracking()
             .AnyAsync(r =>
@@ -443,43 +452,57 @@ public static class IntegrationApiEndpoints
                 r.Person.Email.Trim().ToUpper() == normalizedEmail,
                 ct);
 
-        // 2) Attendee by linked ApplicationUser (primary NormalizedEmail or
-        // alias UserEmails) → PersonId. This covers the case where
-        // Person.Email was cleared during dedup (see SubmissionService) but
-        // the user still has an account with the email.
-        var attendeeByUserLink = false;
-        if (!attendeeByPersonEmail)
-        {
-            var userId = await userEmailService.ResolveUserIdByEmailAsync(email, ct);
-            if (userId is not null)
-            {
-                var personId = await db.Users
-                    .AsNoTracking()
-                    .Where(u => u.Id == userId)
-                    .Select(u => u.PersonId)
-                    .FirstOrDefaultAsync(ct);
+        // A.2 — email resolves to any ApplicationUser (primary NormalizedEmail
+        // or an alias in UserEmails) whose PersonId has an active Registration
+        // in this game. We collect ALL matching user ids (defensive against
+        // duplicate rows from historic imports) and project through to
+        // PersonId values, so a single duplicate doesn't make us miss the link.
+        var matchingUserIds = await db.Users
+            .AsNoTracking()
+            .Where(u => u.NormalizedEmail == normalizedEmail)
+            .Select(u => u.Id)
+            .ToListAsync(ct);
 
-                if (personId.HasValue)
-                {
-                    attendeeByUserLink = await db.Registrations
-                        .AsNoTracking()
-                        .AnyAsync(r =>
-                            r.Submission.GameId == gameId &&
-                            r.Submission.Status == SubmissionStatus.Submitted &&
-                            r.Status == RegistrationStatus.Active &&
-                            !r.Submission.IsDeleted &&
-                            r.PersonId == personId.Value,
-                            ct);
-                }
-            }
-        }
+        var aliasUserIds = await db.UserEmails
+            .AsNoTracking()
+            .Where(ue => ue.NormalizedEmail == normalizedEmail)
+            .Select(ue => ue.UserId)
+            .ToListAsync(ct);
 
-        var hasAttendeeRegistration = attendeeByPersonEmail || attendeeByUserLink;
+        var candidateUserIds = matchingUserIds
+            .Concat(aliasUserIds)
+            .Distinct()
+            .ToList();
 
-        // 3) Household contact: email matches a submission's PrimaryEmail,
-        // even when the caller has no Registration of their own. This is the
-        // common case for parents who register their kids.
-        var hasSubmissionAsPrimaryContact = await db.RegistrationSubmissions
+        var personIdsFromUsers = candidateUserIds.Count == 0
+            ? new List<int>()
+            : await db.Users
+                .AsNoTracking()
+                .Where(u => candidateUserIds.Contains(u.Id) && u.PersonId != null)
+                .Select(u => u.PersonId!.Value)
+                .Distinct()
+                .ToListAsync(ct);
+
+        var attendeeByUserLink = personIdsFromUsers.Count > 0
+            && await db.Registrations
+                .AsNoTracking()
+                .AnyAsync(r =>
+                    r.Submission.GameId == gameId &&
+                    r.Submission.Status == SubmissionStatus.Submitted &&
+                    r.Status == RegistrationStatus.Active &&
+                    !r.Submission.IsDeleted &&
+                    personIdsFromUsers.Contains(r.PersonId),
+                    ct);
+
+        var hasOwnRegistrationForThisPerson = attendeeByPersonEmail || attendeeByUserLink;
+
+        // ---------------------------------------------------------------
+        // Signal B — primary-contact match: email matches a submission's
+        // PrimaryEmail on a submitted, non-deleted submission in this game.
+        // This lets parents who registered their kids but not themselves
+        // still show up as "registered", flagged guardianOnly.
+        // ---------------------------------------------------------------
+        var hasPrimaryContactMatch = await db.RegistrationSubmissions
             .AsNoTracking()
             .AnyAsync(s =>
                 s.GameId == gameId &&
@@ -488,8 +511,11 @@ public static class IntegrationApiEndpoints
                 s.PrimaryEmail.Trim().ToUpper() == normalizedEmail,
                 ct);
 
-        var isRegistered = hasAttendeeRegistration || hasSubmissionAsPrimaryContact;
-        var guardianOnly = !hasAttendeeRegistration && hasSubmissionAsPrimaryContact;
+        // ---------------------------------------------------------------
+        // Verdict — own-Registration ALWAYS wins over primary-contact-only.
+        // ---------------------------------------------------------------
+        var isRegistered = hasOwnRegistrationForThisPerson || hasPrimaryContactMatch;
+        var guardianOnly = !hasOwnRegistrationForThisPerson && hasPrimaryContactMatch;
 
         return new PresenceCheckDto(isRegistered, guardianOnly);
     }

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.15</Version>
+    <Version>0.9.16</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/RegistrationsCheckEndpointTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/RegistrationsCheckEndpointTests.cs
@@ -207,6 +207,109 @@ public sealed class RegistrationsCheckEndpointTests
         Assert.False(result.GuardianOnly);
     }
 
+    // ----- Scenario 10: Person.Email null, ApplicationUser primary email match,
+    // Submission.PrimaryEmail also matches, registration exists → NotGuardianOnly. -----
+    [Fact]
+    public async Task PersonEmailNulled_UserEmailLinked_WithOwnRegistration_ReturnsNotGuardianOnly()
+    {
+        // Targeted regression for the PrimaryEmail-wins-over-AppUserLink bug:
+        // Person.Email is null (dedup nulled it out), ApplicationUser carries the
+        // email and is linked via PersonId, and the attendee has their own active
+        // Registration in the game. The Submission.PrimaryEmail also matches
+        // (common for self-registering adults). The own-Registration signal MUST
+        // override the PrimaryEmail-only verdict.
+        await using var seeded = await SeedAsync(s =>
+        {
+            var game = s.AddGame(1);
+            var person = s.AddPerson(346, "Lukáš", "Heinz", 1984, email: null);
+            s.AddApplicationUser("u-346", "lukas.heinz@seznam.cz", personId: person.Id);
+            var submission = s.AddSubmission(1000, game.Id, registrantUserId: "u-346", primaryEmail: "lukas.heinz@seznam.cz");
+            s.AddRegistration(1058, submission.Id, person.Id, AttendeeType.Adult);
+        });
+
+        var result = await Check(seeded, "lukas.heinz@seznam.cz", gameId: 1);
+
+        Assert.True(result.IsRegistered);
+        Assert.False(result.GuardianOnly);
+    }
+
+    // ----- Scenario 11: Alternate UserEmails row (not the primary) linked to a
+    // Person who has their own Registration → NotGuardianOnly. -----
+    [Fact]
+    public async Task AlternateUserEmail_LinkedToPerson_WithOwnRegistration_ReturnsNotGuardianOnly()
+    {
+        // User's ApplicationUser.NormalizedEmail is a different address; the
+        // incoming email only matches an entry in UserEmails (alias). The link
+        // to Person still resolves via ApplicationUser.PersonId, and that Person
+        // has an active Adult Registration in this game. Must be NotGuardianOnly.
+        await using var seeded = await SeedAsync(s =>
+        {
+            var game = s.AddGame(1);
+            var person = s.AddPerson(400, "Alt", "User", 1990, email: null);
+            s.AddApplicationUser("u-alt", "primary@test.cz", personId: person.Id);
+            s.AddUserEmail("u-alt", "alias@test.cz");
+            var submission = s.AddSubmission(40, game.Id, registrantUserId: "u-alt", primaryEmail: "primary@test.cz");
+            s.AddRegistration(4000, submission.Id, person.Id, AttendeeType.Adult);
+        });
+
+        var result = await Check(seeded, "alias@test.cz", gameId: 1);
+
+        Assert.True(result.IsRegistered);
+        Assert.False(result.GuardianOnly);
+    }
+
+    // ----- Scenario 12: ApplicationUser links resolve email → Person, but that
+    // Person has NO Registration in the game. Only the submission's PrimaryEmail
+    // matches. → Stays guardianOnly=true. -----
+    [Fact]
+    public async Task UserLinkedButNoOwnRegistrationInGame_OnlyPrimaryContactMatch_StaysGuardianOnly()
+    {
+        // The classic guardian case: parent is the registrant + Submission's
+        // primary contact, has an ApplicationUser linked to a Person, but did
+        // not register themselves as an attendee — only their kids. The endpoint
+        // must keep guardianOnly=true here.
+        await using var seeded = await SeedAsync(s =>
+        {
+            var game = s.AddGame(1);
+            var parent = s.AddPerson(500, "Marek", "Štěpán", 1980, email: null);
+            s.AddApplicationUser("u-marek", "marek@test.cz", personId: parent.Id);
+            var kid = s.AddPerson(501, "Anna", "Štěpán", 2014, email: null);
+            var submission = s.AddSubmission(50, game.Id, registrantUserId: "u-marek", primaryEmail: "marek@test.cz");
+            s.AddRegistration(5001, submission.Id, kid.Id, AttendeeType.Player);
+            // Note: no Registration for parent.Id — only a kid.
+        });
+
+        var result = await Check(seeded, "marek@test.cz", gameId: 1);
+
+        Assert.True(result.IsRegistered);
+        Assert.True(result.GuardianOnly);
+    }
+
+    // ----- Scenario 13: Full Lukáš production snapshot. -----
+    [Fact]
+    public async Task LukasCaseSnapshot()
+    {
+        // Full reproduction of the production scenario that triggered this fix:
+        //   - Person.Email = null (dedup path).
+        //   - ApplicationUser linked to Person with Email populated.
+        //   - An active Adult Registration exists in the game.
+        //   - Submission.PrimaryEmail matches the same email (self-registrant).
+        // Expected: isRegistered=true, guardianOnly=false.
+        await using var seeded = await SeedAsync(s =>
+        {
+            var game = s.AddGame(1);
+            var lukas = s.AddPerson(346, "Lukáš", "Heinz", 1984, email: null);
+            s.AddApplicationUser("u-lukas-prod", "lukas.heinz@seznam.cz", personId: lukas.Id);
+            var submission = s.AddSubmission(1000, game.Id, registrantUserId: "u-lukas-prod", primaryEmail: "lukas.heinz@seznam.cz");
+            s.AddRegistration(1058, submission.Id, lukas.Id, AttendeeType.Adult);
+        });
+
+        var result = await Check(seeded, "lukas.heinz@seznam.cz", gameId: 1);
+
+        Assert.True(result.IsRegistered);
+        Assert.False(result.GuardianOnly);
+    }
+
     // ----- Helpers -----
 
     private static async Task<PresenceCheckDto> Check(SeededDb seeded, string email, int gameId)
@@ -299,6 +402,19 @@ public sealed class RegistrationsCheckEndpointTests
             };
             db.Users.Add(user);
             return user;
+        }
+
+        public UserEmail AddUserEmail(string userId, string email)
+        {
+            var entity = new UserEmail
+            {
+                UserId = userId,
+                Email = email,
+                NormalizedEmail = email.ToUpperInvariant(),
+                CreatedAtUtc = FixedUtc
+            };
+            db.UserEmails.Add(entity);
+            return entity;
         }
 
         public RegistrationSubmission AddSubmission(int id, int gameId, string registrantUserId, string primaryEmail)


### PR DESCRIPTION
## Summary
- Fixes `GET /api/v1/registrations/check` false-positive `guardianOnly=true` for adults whose `Person.Email` was nulled by dedup.
- Computes `hasOwnRegistrationForThisPerson` and `hasPrimaryContactMatch` as independent signals; own-Registration ALWAYS wins over PrimaryEmail-only.
- Resolves email → Person via both `ApplicationUser.NormalizedEmail` and the alternate `UserEmails` table (matching the path `LoadUserGameInfoAsync` already uses), defensive against duplicate user rows.
- Bumps version to 0.9.16.

## Lukáš case
- Person.Email nulled by dedup.
- ApplicationUser linked to Person with Email populated.
- Active Adult Registration in game 1.
- Submission PrimaryEmail also matches.
- Before: `{true, true}` (guardian false-positive).
- After: `{true, false}`.

## Test plan
- [x] Baseline 231 tests green.
- [x] 4 new tests added (235 total, all green):
  - `PersonEmailNulled_UserEmailLinked_WithOwnRegistration_ReturnsNotGuardianOnly`
  - `AlternateUserEmail_LinkedToPerson_WithOwnRegistration_ReturnsNotGuardianOnly`
  - `UserLinkedButNoOwnRegistrationInGame_OnlyPrimaryContactMatch_StaysGuardianOnly`
  - `LukasCaseSnapshot`
- [x] Clean build (0 warnings).
- [ ] CI green on main deploy after merge.