### PR TITLE
hotfix(api): restore /check — revert ToUpperInvariant on DB side (v0.9.18)

### DIFF
--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
@@ -445,6 +445,8 @@ public static class IntegrationApiEndpoints
         // ---------------------------------------------------------------
 
         // A.1 — direct Person.Email match on a Registration in this game.
+        // Npgsql can't translate ToUpperInvariant(); ToUpper() maps to PostgreSQL UPPER().
+        // Input is already ToUpperInvariant-normalized; server-side UPPER is sufficient for our ASCII-only emails.
         var attendeeByPersonEmail = await db.Registrations
             .AsNoTracking()
             .AnyAsync(r =>
@@ -453,7 +455,7 @@ public static class IntegrationApiEndpoints
                 r.Status == RegistrationStatus.Active &&
                 !r.Submission.IsDeleted &&
                 r.Person.Email != null &&
-                r.Person.Email.Trim().ToUpperInvariant() == normalizedEmail,
+                r.Person.Email.Trim().ToUpper() == normalizedEmail,
                 ct);
 
         // A.2 — email resolves to any ApplicationUser (primary NormalizedEmail
@@ -519,13 +521,15 @@ public static class IntegrationApiEndpoints
             // with this submission's Adult attendees' names. Small result set
             // (usually 0 or 1 submission per email), so we evaluate the name
             // comparison in memory with diacritic normalization.
+            // Npgsql can't translate ToUpperInvariant(); ToUpper() maps to PostgreSQL UPPER().
+            // Input is already ToUpperInvariant-normalized; server-side UPPER is sufficient for our ASCII-only emails.
             var primaryContactCandidates = await db.RegistrationSubmissions
                 .AsNoTracking()
                 .Where(s =>
                     s.GameId == gameId &&
                     s.Status == SubmissionStatus.Submitted &&
                     !s.IsDeleted &&
-                    s.PrimaryEmail.Trim().ToUpperInvariant() == normalizedEmail)
+                    s.PrimaryEmail.Trim().ToUpper() == normalizedEmail)
                 .Select(s => new
                 {
                     s.PrimaryContactName,
@@ -578,13 +582,15 @@ public static class IntegrationApiEndpoints
         // this game. Parents who registered their kids but not themselves
         // still show up as "registered", flagged guardianOnly.
         // ---------------------------------------------------------------
+        // Npgsql can't translate ToUpperInvariant(); ToUpper() maps to PostgreSQL UPPER().
+        // Input is already ToUpperInvariant-normalized; server-side UPPER is sufficient for our ASCII-only emails.
         var hasPrimaryContactMatch = await db.RegistrationSubmissions
             .AsNoTracking()
             .AnyAsync(s =>
                 s.GameId == gameId &&
                 s.Status == SubmissionStatus.Submitted &&
                 !s.IsDeleted &&
-                s.PrimaryEmail.Trim().ToUpperInvariant() == normalizedEmail,
+                s.PrimaryEmail.Trim().ToUpper() == normalizedEmail,
                 ct);
 
         // ---------------------------------------------------------------
@@ -624,7 +630,7 @@ public static class IntegrationApiEndpoints
 
         var trimmed = s.Trim().ToLowerInvariant();
         var decomposed = trimmed.Normalize(NormalizationForm.FormD);
-        var builder = new System.Text.StringBuilder(decomposed.Length);
+        var builder = new StringBuilder(decomposed.Length);
         foreach (var ch in decomposed)
         {
             if (CharUnicodeInfo.GetUnicodeCategory(ch) != UnicodeCategory.NonSpacingMark)

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.17</Version>
+    <Version>0.9.18</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/RegistrationsCheckEndpointTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/RegistrationsCheckEndpointTests.cs
@@ -20,7 +20,7 @@ namespace RegistraceOvcina.Web.Tests;
 ///   6. Whitespace-trimmed input (" lukas@test.cz ") → true.
 ///   7. Email matches attendee in a DIFFERENT game → false for this game.
 ///   8. Email matches a soft-deleted submission's row → false (respects IsDeleted filter).
-///   9. Fallback via ApplicationUser / UserEmailService when Person.Email is null
+///   9. Fallback via ApplicationUser / Users / UserEmails lookup when Person.Email is null
 ///      (the dedup path) → still true.
 ///  14. Submission.PrimaryContactName matches an Adult attendee's First+LastName
 ///      with no ApplicationUser or Person.Email → not guardian-only (Lukáš case).


### PR DESCRIPTION
## Prod hotfix

`GET /api/v1/registrations/check` is returning **500** on `registrace.ovcina.cz` since the v0.9.17 deploy (PR #166). The endpoint throws an unhandled EF Core translation exception:

```
System.InvalidOperationException: The LINQ expression '... .Any(r => ... r.Outer.Inner.Email.Trim().ToUpperInvariant() == @normalizedEmail)' could not be translated.
Translation of method 'string.ToUpperInvariant' failed.
```

Npgsql cannot translate `string.ToUpperInvariant()` to SQL. The Copilot suggestion adopted in PR #166 was theoretically more culture-safe, but broke the endpoint in production. xUnit tests passed because `UseInMemoryDatabase` runs the LINQ in .NET, not SQL.

## What this changes

Reverts the three **server-side column comparisons** in `IntegrationApiEndpoints.CheckRegistrationPresenceAsync` from `.ToUpperInvariant()` back to `.ToUpper()`, which Npgsql translates to PostgreSQL `UPPER()`.

- The **managed-side input normalization** (`normalizedEmail`) remains `ToUpperInvariant()` — that's culture-invariant ASCII upper-casing in .NET and is safe.
- For ASCII-only emails (our dataset), server-side `UPPER()` is equivalent; the PostgreSQL server's locale is stable.
- Each DB-side comparison now has a short comment noting the Npgsql constraint so future reviewers don't re-suggest `ToUpperInvariant()`.

## Also

Addresses the two outstanding Copilot comments carried over from PR #166:

1. `src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs:2` — `using System.Text;` is actually required (`NormalizationForm` in `NormalizeForNameCompare`). Cleaned up the fully-qualified `new System.Text.StringBuilder(...)` call to `new StringBuilder(...)` so the `using` has a non-qualified reference.
2. `tests/RegistraceOvcina.Web.Tests/RegistrationsCheckEndpointTests.cs:23` — stale comment header mentioning `UserEmailService` updated to describe the actual fallback path (direct `ApplicationUser` / `Users` / `UserEmails` lookup).

## Translation-safety test

Deferred — the test project currently uses `Microsoft.EntityFrameworkCore.InMemory` only. Adding a Sqlite translation-safety test requires a new NuGet dependency and verifying the PostgreSQL-specific model config (tsvector, jsonb, arrays, etc.) doesn't trip `EnsureCreated` on Sqlite. Priority here is restoring prod. Follow-up ticket to track this guardrail.

## Version

`0.9.17` → `0.9.18`.

## Verification

- `dotnet build` — succeeded.
- `dotnet test` — **239/239 pass** (no test count delta; test header comment was the only test-side change).

## References

- Introduced by PR #166 (v0.9.17)
- Prod exception at `IntegrationApiEndpoints.cs:line 448`