### PR TITLE
feat(admin): account linking admin page with auto-match (v0.9.19)

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Layout/MainLayout.razor
+++ b/src/RegistraceOvcina.Web/Components/Layout/MainLayout.razor
@@ -44,6 +44,7 @@
                             <a class="nav-link" href="/admin/kralovstvi">Správa království</a>
                             <a class="nav-link" href="/admin/organizatori">Organizátoři</a>
                             <a class="nav-link" href="/admin/uzivatele">Uživatelé</a>
+                            <a class="nav-link" href="/admin/propojit-ucty">Propojit účty</a>
                             <a class="nav-link" href="/admin/oznameni">Oznámení</a>
                             <a class="nav-link" href="/admin/osloveni">Oslovení</a>
                             <a class="nav-link" href="/admin/roles">Role</a>

--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/AccountLinking.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/AccountLinking.razor
@@ -1,0 +1,604 @@
+@page "/admin/propojit-ucty"
+@attribute [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
+@rendermode InteractiveServer
+
+@using Microsoft.AspNetCore.WebUtilities
+@using RegistraceOvcina.Web.Features.AccountLinking
+@using RegistraceOvcina.Web.Infrastructure
+
+@inject IAccountLinkingService LinkingService
+@inject NavigationManager NavigationManager
+
+<PageTitle>Propojit účty</PageTitle>
+
+<div class="row g-4">
+    <div class="col-12">
+        <section class="card shadow-sm">
+            <div class="card-body p-4">
+                <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 mb-3">
+                    <div>
+                        <h1 class="h3 mb-2" data-testid="account-linking-title">Propojit účty</h1>
+                        <p class="text-secondary mb-0">
+                            Napojte přihlašovací účty na osobní karty (Osoby) bez obesílání rodičů.
+                            Vysoce jisté shody jde propojit hromadně, zbytek prochází ručně.
+                        </p>
+                    </div>
+
+                    @if (proposals is not null)
+                    {
+                        <div class="d-flex flex-wrap gap-4">
+                            <div>
+                                <div class="small text-secondary">Vysoká shoda</div>
+                                <div class="h4 mb-0" data-testid="high-confidence-count">@proposals.HighConfidence.Count</div>
+                            </div>
+                            <div>
+                                <div class="small text-secondary">Ruční kontrola</div>
+                                <div class="h4 mb-0" data-testid="medium-confidence-count">@proposals.MediumConfidence.Count</div>
+                            </div>
+                            <div>
+                                <div class="small text-secondary">Osoby bez účtu</div>
+                                <div class="h4 mb-0" data-testid="unlinked-persons-count">@unlinkedPersons.Count</div>
+                            </div>
+                            <div>
+                                <div class="small text-secondary">Propojené</div>
+                                <div class="h4 mb-0" data-testid="linked-count">@linkedViews.Count</div>
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                @if (!string.IsNullOrWhiteSpace(statusMessage))
+                {
+                    <div class="alert alert-success mb-0" role="status" data-testid="status-message">@statusMessage</div>
+                }
+
+                @if (!string.IsNullOrWhiteSpace(errorMessage))
+                {
+                    <div class="alert alert-danger mb-0" role="alert" data-testid="error-message">@errorMessage</div>
+                }
+            </div>
+        </section>
+    </div>
+
+    <div class="col-12">
+        <ul class="nav nav-tabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button type="button"
+                        class="nav-link @(activeTab == Tab.High ? "active" : "")"
+                        @onclick="() => SwitchTab(Tab.High)"
+                        data-testid="tab-high">
+                    Vysoká shoda <span class="badge text-bg-secondary">@(proposals?.HighConfidence.Count ?? 0)</span>
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button type="button"
+                        class="nav-link @(activeTab == Tab.Medium ? "active" : "")"
+                        @onclick="() => SwitchTab(Tab.Medium)"
+                        data-testid="tab-medium">
+                    Ruční kontrola <span class="badge text-bg-secondary">@(proposals?.MediumConfidence.Count ?? 0)</span>
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button type="button"
+                        class="nav-link @(activeTab == Tab.Unlinked ? "active" : "")"
+                        @onclick="() => SwitchTab(Tab.Unlinked)"
+                        data-testid="tab-unlinked">
+                    Osoby bez účtu <span class="badge text-bg-secondary">@unlinkedPersons.Count</span>
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button type="button"
+                        class="nav-link @(activeTab == Tab.Linked ? "active" : "")"
+                        @onclick="() => SwitchTab(Tab.Linked)"
+                        data-testid="tab-linked">
+                    Propojené <span class="badge text-bg-secondary">@linkedViews.Count</span>
+                </button>
+            </li>
+        </ul>
+    </div>
+
+    <div class="col-12">
+        <section class="card shadow-sm">
+            <div class="card-body p-4">
+                @if (proposals is null)
+                {
+                    <p class="text-secondary">Načítám návrhy...</p>
+                }
+                else
+                {
+                    @switch (activeTab)
+                    {
+                        case Tab.High:
+                            @RenderHighTab()
+                            break;
+                        case Tab.Medium:
+                            @RenderMediumTab()
+                            break;
+                        case Tab.Unlinked:
+                            @RenderUnlinkedTab()
+                            break;
+                        case Tab.Linked:
+                            @RenderLinkedTab()
+                            break;
+                    }
+                }
+            </div>
+        </section>
+    </div>
+</div>
+
+@code {
+    private enum Tab { High, Medium, Unlinked, Linked }
+
+    private ProposalBucket? proposals;
+    private IReadOnlyList<UnlinkedPersonView> unlinkedPersons = Array.Empty<UnlinkedPersonView>();
+    private IReadOnlyList<AlreadyLinkedView> linkedViews = Array.Empty<AlreadyLinkedView>();
+    private Tab activeTab = Tab.High;
+    private string? statusMessage;
+    private string? errorMessage;
+
+    // Picker state for "Osoby bez účtu" rows. Key is PersonId.
+    private readonly Dictionary<int, string> pickerQueries = new();
+    private readonly Dictionary<int, IReadOnlyList<UserPickerResult>> pickerResults = new();
+    private readonly Dictionary<int, string?> pickerSelectedUserId = new();
+    private CancellationTokenSource? searchCts;
+
+    protected override async Task OnInitializedAsync()
+    {
+        ReadQueryString();
+        await ReloadAsync();
+    }
+
+    private void ReadQueryString()
+    {
+        var uri = NavigationManager.ToAbsoluteUri(NavigationManager.Uri);
+        var query = QueryHelpers.ParseQuery(uri.Query);
+
+        if (query.TryGetValue("tab", out var tab))
+        {
+            activeTab = tab.ToString() switch
+            {
+                "medium" => Tab.Medium,
+                "unlinked" => Tab.Unlinked,
+                "linked" => Tab.Linked,
+                _ => Tab.High
+            };
+        }
+
+        if (query.TryGetValue("status", out var status))
+        {
+            statusMessage = status.ToString() switch
+            {
+                "auto-linked" when query.TryGetValue("count", out var c) =>
+                    $"Automaticky propojeno {c} účtů.",
+                "linked" => "Účet byl propojen.",
+                "unlinked" => "Účet byl odpojen.",
+                "dismissed" => "Návrh byl zamítnut.",
+                _ => null
+            };
+        }
+
+        if (query.TryGetValue("error", out var err))
+        {
+            errorMessage = err.ToString();
+        }
+    }
+
+    private async Task ReloadAsync()
+    {
+        proposals = await LinkingService.ProposeAsync(CancellationToken.None);
+        unlinkedPersons = await LinkingService.ListUnlinkedPersonsAsync(CancellationToken.None);
+        linkedViews = await LinkingService.ListLinkedAsync(CancellationToken.None);
+    }
+
+    private void SwitchTab(Tab tab)
+    {
+        activeTab = tab;
+    }
+
+    private RenderFragment RenderHighTab() => builder =>
+    {
+        builder.OpenElement(0, "div");
+
+        if (proposals!.HighConfidence.Count == 0)
+        {
+            builder.OpenElement(1, "p");
+            builder.AddAttribute(2, "class", "text-secondary mb-0");
+            builder.AddContent(3, "Žádné vysoce jisté shody k propojení.");
+            builder.CloseElement();
+            builder.CloseElement();
+            return;
+        }
+
+        builder.OpenElement(10, "form");
+        builder.AddAttribute(11, "method", "post");
+        builder.AddAttribute(12, "action", "/admin/propojit-ucty/automaticky");
+        builder.AddAttribute(13, "class", "mb-3");
+        builder.OpenComponent<AntiforgeryToken>(14);
+        builder.CloseComponent();
+        builder.OpenElement(15, "button");
+        builder.AddAttribute(16, "type", "submit");
+        builder.AddAttribute(17, "class", "btn btn-primary");
+        builder.AddAttribute(18, "data-testid", "auto-link-all");
+        builder.AddAttribute(19, "disabled", proposals.HighConfidence.Count == 0);
+        builder.AddContent(20, $"Propojit vše ({proposals.HighConfidence.Count})");
+        builder.CloseElement();
+        builder.CloseElement();
+
+        builder.AddContent(30, RenderProposalTable(proposals.HighConfidence, showScore: false));
+
+        builder.CloseElement();
+    };
+
+    private RenderFragment RenderMediumTab() => builder =>
+    {
+        builder.OpenElement(0, "div");
+        if (proposals!.MediumConfidence.Count == 0)
+        {
+            builder.OpenElement(1, "p");
+            builder.AddAttribute(2, "class", "text-secondary mb-0");
+            builder.AddContent(3, "Žádné návrhy k ruční kontrole.");
+            builder.CloseElement();
+            builder.CloseElement();
+            return;
+        }
+        builder.AddContent(10, RenderProposalTable(proposals.MediumConfidence, showScore: true));
+        builder.CloseElement();
+    };
+
+    private RenderFragment RenderProposalTable(IReadOnlyList<LinkProposal> rows, bool showScore) => builder =>
+    {
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "class", "table-responsive");
+
+        builder.OpenElement(2, "table");
+        builder.AddAttribute(3, "class", "table table-sm align-middle");
+
+        builder.OpenElement(10, "thead");
+        builder.OpenElement(11, "tr");
+        builder.AddMarkupContent(12, "<th>ApplicationUser</th><th>Osoba</th><th>Signál</th>");
+        if (showScore)
+        {
+            builder.AddMarkupContent(13, "<th>Skóre</th>");
+        }
+        builder.AddMarkupContent(14, "<th class=\"text-end\">Akce</th>");
+        builder.CloseElement();
+        builder.CloseElement();
+
+        builder.OpenElement(20, "tbody");
+        var seq = 100;
+        foreach (var row in rows)
+        {
+            builder.OpenElement(seq++, "tr");
+            builder.AddAttribute(seq++, "data-testid", $"proposal-row-{row.UserId}-{row.PersonId}");
+
+            // ApplicationUser
+            builder.OpenElement(seq++, "td");
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "fw-semibold");
+            builder.AddContent(seq++, row.UserEmail);
+            builder.CloseElement();
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "small text-secondary");
+            builder.AddContent(seq++, row.UserDisplayName ?? "");
+            builder.CloseElement();
+            builder.CloseElement();
+
+            // Person
+            builder.OpenElement(seq++, "td");
+            builder.AddContent(seq++, row.PersonFullName);
+            builder.CloseElement();
+
+            // Signal
+            builder.OpenElement(seq++, "td");
+            builder.AddContent(seq++, FormatSignal(row.Signal));
+            builder.CloseElement();
+
+            if (showScore)
+            {
+                builder.OpenElement(seq++, "td");
+                builder.AddContent(seq++, row.FuzzyScore?.ToString() ?? "");
+                builder.CloseElement();
+            }
+
+            // Actions
+            builder.OpenElement(seq++, "td");
+            builder.AddAttribute(seq++, "class", "text-end");
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "d-flex flex-wrap justify-content-end gap-1");
+
+            builder.OpenElement(seq++, "form");
+            builder.AddAttribute(seq++, "method", "post");
+            builder.AddAttribute(seq++, "action", "/admin/propojit-ucty/propojit");
+            builder.AddAttribute(seq++, "class", "d-inline");
+            builder.OpenComponent<AntiforgeryToken>(seq++);
+            builder.CloseComponent();
+            builder.AddMarkupContent(seq++,
+                $"<input type=\"hidden\" name=\"userId\" value=\"{System.Net.WebUtility.HtmlEncode(row.UserId)}\" />" +
+                $"<input type=\"hidden\" name=\"personId\" value=\"{row.PersonId}\" />" +
+                $"<input type=\"hidden\" name=\"returnTab\" value=\"{(showScore ? "medium" : "high")}\" />");
+            builder.OpenElement(seq++, "button");
+            builder.AddAttribute(seq++, "type", "submit");
+            builder.AddAttribute(seq++, "class", "btn btn-sm btn-outline-success");
+            builder.AddAttribute(seq++, "data-testid", $"link-{row.UserId}-{row.PersonId}");
+            builder.AddContent(seq++, "Propojit");
+            builder.CloseElement();
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "form");
+            builder.AddAttribute(seq++, "method", "post");
+            builder.AddAttribute(seq++, "action", "/admin/propojit-ucty/zamitnout");
+            builder.AddAttribute(seq++, "class", "d-inline");
+            builder.OpenComponent<AntiforgeryToken>(seq++);
+            builder.CloseComponent();
+            builder.AddMarkupContent(seq++,
+                $"<input type=\"hidden\" name=\"userId\" value=\"{System.Net.WebUtility.HtmlEncode(row.UserId)}\" />" +
+                $"<input type=\"hidden\" name=\"personId\" value=\"{row.PersonId}\" />");
+            builder.OpenElement(seq++, "button");
+            builder.AddAttribute(seq++, "type", "submit");
+            builder.AddAttribute(seq++, "class", "btn btn-sm btn-outline-secondary");
+            builder.AddAttribute(seq++, "data-testid", $"dismiss-{row.UserId}-{row.PersonId}");
+            builder.AddContent(seq++, "Zamítnout");
+            builder.CloseElement();
+            builder.CloseElement();
+
+            builder.CloseElement();
+            builder.CloseElement();
+
+            builder.CloseElement(); // </tr>
+        }
+        builder.CloseElement(); // </tbody>
+        builder.CloseElement(); // </table>
+        builder.CloseElement(); // </div>
+    };
+
+    private RenderFragment RenderUnlinkedTab() => builder =>
+    {
+        builder.OpenElement(0, "div");
+        if (unlinkedPersons.Count == 0)
+        {
+            builder.OpenElement(1, "p");
+            builder.AddAttribute(2, "class", "text-secondary mb-0");
+            builder.AddContent(3, "Všechny osoby mají přiřazený přihlašovací účet.");
+            builder.CloseElement();
+            builder.CloseElement();
+            return;
+        }
+
+        builder.OpenElement(10, "div");
+        builder.AddAttribute(11, "class", "table-responsive");
+        builder.OpenElement(12, "table");
+        builder.AddAttribute(13, "class", "table table-sm align-middle");
+        builder.AddMarkupContent(14, "<thead><tr><th>Osoba</th><th>Rok narození</th><th>E-mail</th><th>Vybrat účet</th><th class=\"text-end\">Akce</th></tr></thead>");
+        builder.OpenElement(15, "tbody");
+        var seq = 100;
+        foreach (var p in unlinkedPersons)
+        {
+            builder.OpenElement(seq++, "tr");
+            builder.AddAttribute(seq++, "data-testid", $"unlinked-row-{p.PersonId}");
+
+            builder.OpenElement(seq++, "td");
+            builder.AddContent(seq++, p.PersonFullName);
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "td");
+            builder.AddContent(seq++, p.BirthYear?.ToString() ?? "");
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "td");
+            builder.AddContent(seq++, p.Email ?? "");
+            builder.CloseElement();
+
+            // Picker cell
+            builder.OpenElement(seq++, "td");
+            {
+                var personId = p.PersonId;
+                builder.OpenElement(seq++, "div");
+                builder.AddAttribute(seq++, "class", "d-flex flex-column gap-1");
+
+                // search input
+                builder.OpenElement(seq++, "input");
+                builder.AddAttribute(seq++, "type", "text");
+                builder.AddAttribute(seq++, "class", "form-control form-control-sm");
+                builder.AddAttribute(seq++, "placeholder", "Hledat účet podle e-mailu nebo jména...");
+                builder.AddAttribute(seq++, "data-testid", $"user-search-{personId}");
+                builder.AddAttribute(seq++, "value", pickerQueries.GetValueOrDefault(personId, ""));
+                builder.AddAttribute(seq++, "oninput",
+                    EventCallback.Factory.Create<ChangeEventArgs>(this, e => OnSearchInputAsync(personId, e)));
+                builder.CloseElement();
+
+                // results
+                var results = pickerResults.GetValueOrDefault(personId);
+                if (results is { Count: > 0 })
+                {
+                    builder.OpenElement(seq++, "ul");
+                    builder.AddAttribute(seq++, "class", "list-group list-group-flush small");
+                    builder.AddAttribute(seq++, "data-testid", $"user-results-{personId}");
+                    foreach (var r in results)
+                    {
+                        var isSelected = pickerSelectedUserId.GetValueOrDefault(personId) == r.UserId;
+                        builder.OpenElement(seq++, "li");
+                        builder.AddAttribute(seq++, "class", $"list-group-item list-group-item-action {(isSelected ? "active" : "")}".Trim());
+                        builder.AddAttribute(seq++, "style", "cursor:pointer;");
+                        builder.AddAttribute(seq++, "data-testid", $"user-result-{personId}-{r.UserId}");
+                        var userRef = r;
+                        builder.AddAttribute(seq++, "onclick",
+                            EventCallback.Factory.Create<MouseEventArgs>(this, _ => SelectUser(personId, userRef)));
+                        builder.OpenElement(seq++, "div");
+                        builder.AddAttribute(seq++, "class", "fw-semibold");
+                        builder.AddContent(seq++, r.Email);
+                        builder.CloseElement();
+                        if (!string.IsNullOrWhiteSpace(r.DisplayName))
+                        {
+                            builder.OpenElement(seq++, "div");
+                            builder.AddAttribute(seq++, "class", "text-secondary");
+                            builder.AddContent(seq++, r.DisplayName);
+                            builder.CloseElement();
+                        }
+                        builder.CloseElement();
+                    }
+                    builder.CloseElement();
+                }
+
+                builder.CloseElement();
+            }
+            builder.CloseElement();
+
+            // Action
+            builder.OpenElement(seq++, "td");
+            builder.AddAttribute(seq++, "class", "text-end");
+            var selectedUser = pickerSelectedUserId.GetValueOrDefault(p.PersonId);
+            if (!string.IsNullOrWhiteSpace(selectedUser))
+            {
+                builder.OpenElement(seq++, "form");
+                builder.AddAttribute(seq++, "method", "post");
+                builder.AddAttribute(seq++, "action", "/admin/propojit-ucty/propojit");
+                builder.OpenComponent<AntiforgeryToken>(seq++);
+                builder.CloseComponent();
+                builder.AddMarkupContent(seq++,
+                    $"<input type=\"hidden\" name=\"userId\" value=\"{System.Net.WebUtility.HtmlEncode(selectedUser)}\" />" +
+                    $"<input type=\"hidden\" name=\"personId\" value=\"{p.PersonId}\" />" +
+                    $"<input type=\"hidden\" name=\"returnTab\" value=\"unlinked\" />");
+                builder.OpenElement(seq++, "button");
+                builder.AddAttribute(seq++, "type", "submit");
+                builder.AddAttribute(seq++, "class", "btn btn-sm btn-outline-success");
+                builder.AddAttribute(seq++, "data-testid", $"link-manual-{p.PersonId}");
+                builder.AddContent(seq++, "Propojit");
+                builder.CloseElement();
+                builder.CloseElement();
+            }
+            else
+            {
+                builder.OpenElement(seq++, "button");
+                builder.AddAttribute(seq++, "type", "button");
+                builder.AddAttribute(seq++, "class", "btn btn-sm btn-outline-secondary");
+                builder.AddAttribute(seq++, "disabled", true);
+                builder.AddContent(seq++, "Propojit");
+                builder.CloseElement();
+            }
+            builder.CloseElement();
+
+            builder.CloseElement(); // </tr>
+        }
+        builder.CloseElement();
+        builder.CloseElement();
+        builder.CloseElement();
+        builder.CloseElement();
+    };
+
+    private RenderFragment RenderLinkedTab() => builder =>
+    {
+        builder.OpenElement(0, "div");
+        if (linkedViews.Count == 0)
+        {
+            builder.OpenElement(1, "p");
+            builder.AddAttribute(2, "class", "text-secondary mb-0");
+            builder.AddContent(3, "Žádné propojené účty.");
+            builder.CloseElement();
+            builder.CloseElement();
+            return;
+        }
+
+        builder.OpenElement(10, "div");
+        builder.AddAttribute(11, "class", "table-responsive");
+        builder.OpenElement(12, "table");
+        builder.AddAttribute(13, "class", "table table-sm align-middle");
+        builder.AddMarkupContent(14, "<thead><tr><th>ApplicationUser</th><th>Osoba</th><th>Propojeno</th><th class=\"text-end\">Akce</th></tr></thead>");
+        builder.OpenElement(15, "tbody");
+        var seq = 100;
+        foreach (var v in linkedViews)
+        {
+            builder.OpenElement(seq++, "tr");
+            builder.AddAttribute(seq++, "data-testid", $"linked-row-{v.UserId}");
+
+            builder.OpenElement(seq++, "td");
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "fw-semibold");
+            builder.AddContent(seq++, v.UserEmail);
+            builder.CloseElement();
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "small text-secondary");
+            builder.AddContent(seq++, v.UserDisplayName ?? "");
+            builder.CloseElement();
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "td");
+            builder.AddContent(seq++, v.PersonFullName);
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "td");
+            builder.AddContent(seq++, v.LinkedAtUtc.HasValue ? CzechTime.Format(v.LinkedAtUtc.Value.UtcDateTime) : "—");
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "td");
+            builder.AddAttribute(seq++, "class", "text-end");
+            builder.OpenElement(seq++, "form");
+            builder.AddAttribute(seq++, "method", "post");
+            builder.AddAttribute(seq++, "action", "/admin/propojit-ucty/odpojit");
+            builder.AddAttribute(seq++, "onsubmit", "return confirm('Opravdu odpojit tento účet od osoby?');");
+            builder.OpenComponent<AntiforgeryToken>(seq++);
+            builder.CloseComponent();
+            builder.AddMarkupContent(seq++,
+                $"<input type=\"hidden\" name=\"userId\" value=\"{System.Net.WebUtility.HtmlEncode(v.UserId)}\" />");
+            builder.OpenElement(seq++, "button");
+            builder.AddAttribute(seq++, "type", "submit");
+            builder.AddAttribute(seq++, "class", "btn btn-sm btn-outline-danger");
+            builder.AddAttribute(seq++, "data-testid", $"unlink-{v.UserId}");
+            builder.AddContent(seq++, "Odpojit");
+            builder.CloseElement();
+            builder.CloseElement();
+            builder.CloseElement();
+
+            builder.CloseElement();
+        }
+        builder.CloseElement();
+        builder.CloseElement();
+        builder.CloseElement();
+        builder.CloseElement();
+    };
+
+    private async Task OnSearchInputAsync(int personId, ChangeEventArgs e)
+    {
+        var query = e.Value?.ToString() ?? "";
+        pickerQueries[personId] = query;
+        if (query.Trim().Length < 2)
+        {
+            pickerResults[personId] = Array.Empty<UserPickerResult>();
+            return;
+        }
+
+        searchCts?.Cancel();
+        searchCts = new CancellationTokenSource();
+        var ct = searchCts.Token;
+
+        // Debounce ~250ms.
+        try
+        {
+            await Task.Delay(250, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        var results = await LinkingService.SearchUsersAsync(query, 10, ct);
+        if (ct.IsCancellationRequested) return;
+        pickerResults[personId] = results;
+        StateHasChanged();
+    }
+
+    private void SelectUser(int personId, UserPickerResult user)
+    {
+        pickerSelectedUserId[personId] = user.UserId;
+        pickerQueries[personId] = user.Email;
+    }
+
+    private static string FormatSignal(LinkSignal signal) => signal switch
+    {
+        LinkSignal.ExactEmailMatch => "Shoda primárního e-mailu",
+        LinkSignal.AlternateEmailMatch => "Shoda alternativního e-mailu",
+        LinkSignal.SubmissionPrimaryContactMatch => "Shoda přihlášky a jména",
+        LinkSignal.FuzzyNameMatch => "Podobnost jména",
+        _ => signal.ToString()
+    };
+}

--- a/src/RegistraceOvcina.Web/Features/AccountLinking/AccountLinkingService.cs
+++ b/src/RegistraceOvcina.Web/Features/AccountLinking/AccountLinkingService.cs
@@ -1,0 +1,644 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Features.AccountLinking;
+
+public enum LinkSignal
+{
+    ExactEmailMatch,
+    AlternateEmailMatch,
+    SubmissionPrimaryContactMatch,
+    FuzzyNameMatch
+}
+
+public sealed record LinkProposal(
+    string UserId,
+    string UserEmail,
+    string? UserDisplayName,
+    int PersonId,
+    string PersonFullName,
+    LinkSignal Signal,
+    int? FuzzyScore = null);
+
+public sealed record ProposalBucket(
+    IReadOnlyList<LinkProposal> HighConfidence,
+    IReadOnlyList<LinkProposal> MediumConfidence);
+
+public sealed record AlreadyLinkedView(
+    string UserId,
+    string UserEmail,
+    string? UserDisplayName,
+    int PersonId,
+    string PersonFullName,
+    DateTimeOffset? LinkedAtUtc);
+
+public sealed record UnlinkedPersonView(
+    int PersonId,
+    string PersonFullName,
+    int? BirthYear,
+    string? Email);
+
+public sealed record UserPickerResult(
+    string UserId,
+    string Email,
+    string? DisplayName);
+
+public interface IAccountLinkingService
+{
+    Task<ProposalBucket> ProposeAsync(CancellationToken ct);
+    Task<int> AutoLinkHighConfidenceAsync(string actorUserId, CancellationToken ct);
+    Task LinkAsync(string userId, int personId, string actorUserId, CancellationToken ct);
+    Task UnlinkAsync(string userId, string actorUserId, CancellationToken ct);
+    Task<IReadOnlyList<AlreadyLinkedView>> ListLinkedAsync(CancellationToken ct);
+    Task<IReadOnlyList<UnlinkedPersonView>> ListUnlinkedPersonsAsync(CancellationToken ct);
+    Task<IReadOnlyList<UserPickerResult>> SearchUsersAsync(string query, int limit, CancellationToken ct);
+}
+
+public sealed class AccountLinkingService(
+    IDbContextFactory<ApplicationDbContext> dbContextFactory,
+    TimeProvider timeProvider,
+    ILogger<AccountLinkingService> logger)
+    : IAccountLinkingService
+{
+    private const int FuzzyScoreThreshold = 75;
+    private const int MaxLevenshteinDistance = 2;
+
+    public async Task<ProposalBucket> ProposeAsync(CancellationToken ct)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
+        // Only propose for ApplicationUsers that aren't already linked.
+        var unlinkedUsers = await db.Users.AsNoTracking()
+            .Where(u => u.PersonId == null)
+            .Select(u => new UnlinkedUser(
+                u.Id,
+                u.Email ?? "",
+                u.NormalizedEmail ?? "",
+                u.DisplayName))
+            .ToListAsync(ct);
+
+        // Only propose Persons that have no ApplicationUser pointing at them.
+        var linkedPersonIds = await db.Users.AsNoTracking()
+            .Where(u => u.PersonId != null)
+            .Select(u => u.PersonId!.Value)
+            .ToListAsync(ct);
+        var linkedPersonSet = new HashSet<int>(linkedPersonIds);
+
+        var unlinkedPersons = await db.People.AsNoTracking()
+            .Select(p => new UnlinkedPerson(
+                p.Id,
+                p.FirstName,
+                p.LastName,
+                p.Email))
+            .ToListAsync(ct);
+
+        unlinkedPersons = unlinkedPersons
+            .Where(p => !linkedPersonSet.Contains(p.PersonId))
+            .ToList();
+
+        // Group Persons by normalized email for exact email match.
+        var personsByEmail = unlinkedPersons
+            .Where(p => !string.IsNullOrWhiteSpace(p.Email))
+            .GroupBy(p => p.Email!.Trim().ToUpperInvariant())
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // Alt emails lookup — userId → set of normalized emails.
+        var altEmails = await db.UserEmails.AsNoTracking()
+            .Select(ue => new { ue.UserId, ue.NormalizedEmail })
+            .ToListAsync(ct);
+        var altEmailsByUser = altEmails
+            .GroupBy(x => x.UserId)
+            .ToDictionary(g => g.Key, g => g.Select(x => x.NormalizedEmail).ToList());
+
+        // Submissions: join to attendees that are Adults. We need each submission's PrimaryEmail,
+        // PrimaryContactName, and the list of adult attendees (FirstName/LastName) through Registrations→Person.
+        var submissionRows = await db.RegistrationSubmissions.AsNoTracking()
+            .Where(s => !s.IsDeleted)
+            .Select(s => new SubmissionRow(
+                s.Id,
+                s.PrimaryEmail,
+                s.PrimaryContactName,
+                s.Registrations
+                    .Where(r => r.AttendeeType == AttendeeType.Adult
+                                && r.Status == RegistrationStatus.Active
+                                && !r.Person.IsDeleted)
+                    .Select(r => new AdultAttendee(r.Person.Id, r.Person.FirstName, r.Person.LastName))
+                    .ToList()))
+            .ToListAsync(ct);
+
+        // Group submissions by normalized primary email for fast lookup.
+        var submissionsByEmail = submissionRows
+            .Where(s => !string.IsNullOrWhiteSpace(s.PrimaryEmail))
+            .GroupBy(s => s.PrimaryEmail.Trim().ToUpperInvariant())
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var highConfidence = new List<LinkProposal>();
+        var mediumConfidence = new List<LinkProposal>();
+        var usersMatchedHigh = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var user in unlinkedUsers)
+        {
+            if (string.IsNullOrWhiteSpace(user.NormalizedEmail)) continue;
+
+            // 1. Exact email match (Person.Email == User.NormalizedEmail).
+            if (personsByEmail.TryGetValue(user.NormalizedEmail, out var matchedByEmail))
+            {
+                if (matchedByEmail.Count == 1)
+                {
+                    var p = matchedByEmail[0];
+                    highConfidence.Add(new LinkProposal(
+                        user.UserId, user.Email, user.DisplayName,
+                        p.PersonId, FullName(p.FirstName, p.LastName),
+                        LinkSignal.ExactEmailMatch));
+                    usersMatchedHigh.Add(user.UserId);
+                    continue;
+                }
+                // Ambiguous — multiple Persons share the email. Skip (tie).
+                usersMatchedHigh.Add(user.UserId);
+                continue;
+            }
+
+            // 2. Alternate email match — any of this user's alt emails lands on a Person.
+            if (altEmailsByUser.TryGetValue(user.UserId, out var alts))
+            {
+                var matchedPersons = new List<UnlinkedPerson>();
+                foreach (var alt in alts)
+                {
+                    if (personsByEmail.TryGetValue(alt, out var list))
+                    {
+                        matchedPersons.AddRange(list);
+                    }
+                }
+                // Dedup by PersonId.
+                var distinct = matchedPersons.DistinctBy(p => p.PersonId).ToList();
+                if (distinct.Count == 1)
+                {
+                    var p = distinct[0];
+                    highConfidence.Add(new LinkProposal(
+                        user.UserId, user.Email, user.DisplayName,
+                        p.PersonId, FullName(p.FirstName, p.LastName),
+                        LinkSignal.AlternateEmailMatch));
+                    usersMatchedHigh.Add(user.UserId);
+                    continue;
+                }
+                if (distinct.Count > 1)
+                {
+                    // Ambiguous — skip.
+                    usersMatchedHigh.Add(user.UserId);
+                    continue;
+                }
+            }
+
+            // 3. SubmissionPrimaryContactMatch — user.NormalizedEmail == submission.PrimaryEmail (normalized)
+            //    AND there's exactly one adult attendee whose FirstName+LastName matches PrimaryContactName.
+            if (submissionsByEmail.TryGetValue(user.NormalizedEmail, out var subList))
+            {
+                var candidates = new List<UnlinkedPerson>();
+                foreach (var sub in subList)
+                {
+                    var (contactFirst, contactLast) = SplitFullName(sub.PrimaryContactName);
+                    if (string.IsNullOrWhiteSpace(contactFirst) && string.IsNullOrWhiteSpace(contactLast))
+                        continue;
+
+                    var normContactFirst = NormalizeForNameCompare(contactFirst);
+                    var normContactLast = NormalizeForNameCompare(contactLast);
+
+                    foreach (var adult in sub.AdultAttendees)
+                    {
+                        // Skip if this attendee is already linked.
+                        if (linkedPersonSet.Contains(adult.PersonId)) continue;
+
+                        if (NormalizeForNameCompare(adult.FirstName) == normContactFirst
+                            && NormalizeForNameCompare(adult.LastName) == normContactLast)
+                        {
+                            candidates.Add(new UnlinkedPerson(
+                                adult.PersonId, adult.FirstName, adult.LastName, null));
+                        }
+                    }
+                }
+
+                var distinctCandidates = candidates.DistinctBy(p => p.PersonId).ToList();
+                if (distinctCandidates.Count == 1)
+                {
+                    var p = distinctCandidates[0];
+                    highConfidence.Add(new LinkProposal(
+                        user.UserId, user.Email, user.DisplayName,
+                        p.PersonId, FullName(p.FirstName, p.LastName),
+                        LinkSignal.SubmissionPrimaryContactMatch));
+                    usersMatchedHigh.Add(user.UserId);
+                    continue;
+                }
+                if (distinctCandidates.Count > 1)
+                {
+                    // Tie — skip.
+                    usersMatchedHigh.Add(user.UserId);
+                    continue;
+                }
+            }
+        }
+
+        // 4. FuzzyNameMatch — only for users without any high-confidence match.
+        foreach (var user in unlinkedUsers)
+        {
+            if (usersMatchedHigh.Contains(user.UserId)) continue;
+
+            var (userFirst, userLast) = SplitFullName(user.DisplayName);
+            if (string.IsNullOrWhiteSpace(userLast)) continue;
+
+            var normUserFirst = NormalizeForNameCompare(userFirst);
+            var normUserLast = NormalizeForNameCompare(userLast);
+
+            var bestMatches = new List<(UnlinkedPerson Person, int Score)>();
+
+            foreach (var person in unlinkedPersons)
+            {
+                var normPersonFirst = NormalizeForNameCompare(person.FirstName);
+                var normPersonLast = NormalizeForNameCompare(person.LastName);
+
+                if (normPersonLast != normUserLast) continue;
+
+                var distance = LevenshteinDistance(normUserFirst, normPersonFirst);
+                if (distance > MaxLevenshteinDistance) continue;
+
+                var score = 100 - distance * 10;
+                if (score >= FuzzyScoreThreshold)
+                {
+                    bestMatches.Add((person, score));
+                }
+            }
+
+            if (bestMatches.Count == 1)
+            {
+                var (p, score) = bestMatches[0];
+                mediumConfidence.Add(new LinkProposal(
+                    user.UserId, user.Email, user.DisplayName,
+                    p.PersonId, FullName(p.FirstName, p.LastName),
+                    LinkSignal.FuzzyNameMatch, score));
+            }
+            else if (bestMatches.Count > 1)
+            {
+                // For medium confidence, still surface them — take top score, but if tied skip.
+                var ordered = bestMatches.OrderByDescending(x => x.Score).ToList();
+                if (ordered[0].Score > ordered[1].Score)
+                {
+                    var (p, score) = ordered[0];
+                    mediumConfidence.Add(new LinkProposal(
+                        user.UserId, user.Email, user.DisplayName,
+                        p.PersonId, FullName(p.FirstName, p.LastName),
+                        LinkSignal.FuzzyNameMatch, score));
+                }
+            }
+        }
+
+        return new ProposalBucket(highConfidence, mediumConfidence);
+    }
+
+    public async Task<int> AutoLinkHighConfidenceAsync(string actorUserId, CancellationToken ct)
+    {
+        var bucket = await ProposeAsync(ct);
+        if (bucket.HighConfidence.Count == 0) return 0;
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+        var nowUtc = timeProvider.GetUtcNow().UtcDateTime;
+
+        var userIds = bucket.HighConfidence.Select(p => p.UserId).Distinct().ToList();
+        var users = await db.Users
+            .Where(u => userIds.Contains(u.Id))
+            .ToListAsync(ct);
+        var usersById = users.ToDictionary(u => u.Id, u => u);
+
+        // Re-check Persons aren't already linked — guard against races.
+        var alreadyLinkedPersonIds = await db.Users.AsNoTracking()
+            .Where(u => u.PersonId != null)
+            .Select(u => u.PersonId!.Value)
+            .ToListAsync(ct);
+        var alreadyLinkedSet = new HashSet<int>(alreadyLinkedPersonIds);
+
+        var count = 0;
+        foreach (var proposal in bucket.HighConfidence)
+        {
+            if (!usersById.TryGetValue(proposal.UserId, out var user)) continue;
+            if (user.PersonId != null) continue; // already linked — no-op
+            if (alreadyLinkedSet.Contains(proposal.PersonId)) continue; // person taken
+
+            user.PersonId = proposal.PersonId;
+            alreadyLinkedSet.Add(proposal.PersonId);
+
+            db.AuditLogs.Add(new AuditLog
+            {
+                EntityType = nameof(ApplicationUser),
+                EntityId = user.Id,
+                Action = "LinkAccount",
+                ActorUserId = actorUserId,
+                CreatedAtUtc = nowUtc,
+                DetailsJson = JsonSerializer.Serialize(new
+                {
+                    PersonId = proposal.PersonId,
+                    PersonName = proposal.PersonFullName,
+                    Signal = proposal.Signal.ToString(),
+                    Automatic = true
+                })
+            });
+
+            count++;
+        }
+
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation("Auto-linked {Count} accounts (actor {ActorId}).", count, actorUserId);
+        return count;
+    }
+
+    public async Task LinkAsync(string userId, int personId, string actorUserId, CancellationToken ct)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+        var nowUtc = timeProvider.GetUtcNow().UtcDateTime;
+
+        var user = await db.Users.SingleOrDefaultAsync(u => u.Id == userId, ct);
+        if (user is null)
+        {
+            logger.LogDebug("LinkAsync: user {UserId} not found — no-op.", userId);
+            return;
+        }
+
+        if (user.PersonId != null)
+        {
+            logger.LogDebug("LinkAsync: user {UserId} already linked to person {PersonId} — no-op.",
+                userId, user.PersonId);
+            return;
+        }
+
+        // Use IgnoreQueryFilters to also catch soft-deleted rows and bail correctly.
+        var person = await db.People.AsNoTracking()
+            .IgnoreQueryFilters()
+            .SingleOrDefaultAsync(p => p.Id == personId, ct);
+        if (person is null || person.IsDeleted)
+        {
+            logger.LogDebug("LinkAsync: person {PersonId} not found or deleted — no-op.", personId);
+            return;
+        }
+
+        var personAlreadyLinked = await db.Users.AsNoTracking()
+            .AnyAsync(u => u.PersonId == personId, ct);
+        if (personAlreadyLinked)
+        {
+            logger.LogDebug("LinkAsync: person {PersonId} already linked to another user — no-op.", personId);
+            return;
+        }
+
+        user.PersonId = personId;
+
+        db.AuditLogs.Add(new AuditLog
+        {
+            EntityType = nameof(ApplicationUser),
+            EntityId = user.Id,
+            Action = "LinkAccount",
+            ActorUserId = actorUserId,
+            CreatedAtUtc = nowUtc,
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                PersonId = personId,
+                PersonName = FullName(person.FirstName, person.LastName),
+                Signal = "Manual",
+                Automatic = false
+            })
+        });
+
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation("Manually linked user {UserId} to person {PersonId} (actor {ActorId}).",
+            userId, personId, actorUserId);
+    }
+
+    public async Task UnlinkAsync(string userId, string actorUserId, CancellationToken ct)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+        var nowUtc = timeProvider.GetUtcNow().UtcDateTime;
+
+        var user = await db.Users.SingleOrDefaultAsync(u => u.Id == userId, ct);
+        if (user is null || user.PersonId is null)
+        {
+            logger.LogDebug("UnlinkAsync: user {UserId} not found or already unlinked — no-op.", userId);
+            return;
+        }
+
+        var previousPersonId = user.PersonId.Value;
+        var person = await db.People.AsNoTracking()
+            .IgnoreQueryFilters()
+            .SingleOrDefaultAsync(p => p.Id == previousPersonId, ct);
+
+        user.PersonId = null;
+
+        db.AuditLogs.Add(new AuditLog
+        {
+            EntityType = nameof(ApplicationUser),
+            EntityId = user.Id,
+            Action = "UnlinkAccount",
+            ActorUserId = actorUserId,
+            CreatedAtUtc = nowUtc,
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                PersonId = previousPersonId,
+                PersonName = person is null ? null : FullName(person.FirstName, person.LastName)
+            })
+        });
+
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation("Unlinked user {UserId} from person {PersonId} (actor {ActorId}).",
+            userId, previousPersonId, actorUserId);
+    }
+
+    public async Task<IReadOnlyList<AlreadyLinkedView>> ListLinkedAsync(CancellationToken ct)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var linked = await db.Users.AsNoTracking()
+            .Where(u => u.PersonId != null)
+            .Select(u => new
+            {
+                u.Id,
+                Email = u.Email ?? "",
+                u.DisplayName,
+                PersonId = u.PersonId!.Value
+            })
+            .ToListAsync(ct);
+
+        if (linked.Count == 0) return Array.Empty<AlreadyLinkedView>();
+
+        var personIds = linked.Select(x => x.PersonId).Distinct().ToList();
+        var persons = await db.People.AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(p => personIds.Contains(p.Id))
+            .Select(p => new { p.Id, p.FirstName, p.LastName })
+            .ToListAsync(ct);
+        var personsById = persons.ToDictionary(p => p.Id, p => p);
+
+        // Pull the most recent LinkAccount audit entry for each user for LinkedAtUtc.
+        var userIds = linked.Select(x => x.Id).ToList();
+        var linkAuditDates = await db.AuditLogs.AsNoTracking()
+            .Where(a => a.EntityType == nameof(ApplicationUser)
+                        && a.Action == "LinkAccount"
+                        && userIds.Contains(a.EntityId))
+            .GroupBy(a => a.EntityId)
+            .Select(g => new { UserId = g.Key, LinkedAt = g.Max(x => x.CreatedAtUtc) })
+            .ToListAsync(ct);
+        var linkedAtByUser = linkAuditDates.ToDictionary(x => x.UserId, x => x.LinkedAt);
+
+        return linked
+            .Select(x =>
+            {
+                var personName = personsById.TryGetValue(x.PersonId, out var p)
+                    ? FullName(p.FirstName, p.LastName)
+                    : $"[Osoba #{x.PersonId}]";
+                DateTimeOffset? linkedAt = linkedAtByUser.TryGetValue(x.Id, out var dt)
+                    ? new DateTimeOffset(DateTime.SpecifyKind(dt, DateTimeKind.Utc))
+                    : null;
+                return new AlreadyLinkedView(x.Id, x.Email, x.DisplayName, x.PersonId, personName, linkedAt);
+            })
+            .OrderBy(x => x.UserEmail, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<UnlinkedPersonView>> ListUnlinkedPersonsAsync(CancellationToken ct)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var linkedPersonIds = await db.Users.AsNoTracking()
+            .Where(u => u.PersonId != null)
+            .Select(u => u.PersonId!.Value)
+            .ToListAsync(ct);
+        var linkedSet = new HashSet<int>(linkedPersonIds);
+
+        var persons = await db.People.AsNoTracking()
+            .Select(p => new UnlinkedPersonView(p.Id, p.FirstName + " " + p.LastName, p.BirthYear, p.Email))
+            .ToListAsync(ct);
+
+        return persons
+            .Where(p => !linkedSet.Contains(p.PersonId))
+            .OrderBy(p => p.PersonFullName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<UserPickerResult>> SearchUsersAsync(
+        string query, int limit, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(query) || query.Trim().Length < 2)
+            return Array.Empty<UserPickerResult>();
+
+        if (limit <= 0) limit = 10;
+
+        var term = query.Trim().ToUpperInvariant();
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var primaryMatches = await db.Users.AsNoTracking()
+            .Where(u => u.NormalizedEmail!.Contains(term) || u.DisplayName.ToUpper().Contains(term))
+            .Select(u => u.Id)
+            .Take(limit * 2)
+            .ToListAsync(ct);
+
+        var alternateMatches = await db.UserEmails.AsNoTracking()
+            .Where(ue => ue.NormalizedEmail.Contains(term))
+            .Select(ue => ue.UserId)
+            .Distinct()
+            .Take(limit * 2)
+            .ToListAsync(ct);
+
+        var allUserIds = primaryMatches.Union(alternateMatches).Distinct().ToList();
+        if (allUserIds.Count == 0) return Array.Empty<UserPickerResult>();
+
+        var results = await db.Users.AsNoTracking()
+            .Where(u => allUserIds.Contains(u.Id))
+            .OrderBy(u => u.DisplayName)
+            .ThenBy(u => u.Email)
+            .Take(limit)
+            .Select(u => new UserPickerResult(u.Id, u.Email ?? "", u.DisplayName))
+            .ToListAsync(ct);
+
+        return results;
+    }
+
+    // ---- helpers ----
+
+    private static string FullName(string first, string last)
+    {
+        first = (first ?? "").Trim();
+        last = (last ?? "").Trim();
+        return string.Join(" ", new[] { first, last }.Where(s => s.Length > 0));
+    }
+
+    private static (string First, string Last) SplitFullName(string? fullName)
+    {
+        if (string.IsNullOrWhiteSpace(fullName)) return ("", "");
+        var parts = fullName.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return ("", "");
+        if (parts.Length == 1) return (parts[0], "");
+        // first token is first name, remainder is last name (handles compound surnames).
+        var first = parts[0];
+        var last = string.Join(" ", parts.Skip(1));
+        return (first, last);
+    }
+
+    /// <summary>
+    /// Trims, lowercases (invariant), and strips combining diacritic marks so
+    /// "Tomáš" and "tomas" compare equal. Mirrors the helper used in
+    /// <see cref="Features.Integration.IntegrationApiEndpoints"/>.
+    /// </summary>
+    private static string NormalizeForNameCompare(string? s)
+    {
+        if (string.IsNullOrWhiteSpace(s)) return "";
+
+        var trimmed = s.Trim().ToLowerInvariant();
+        var decomposed = trimmed.Normalize(NormalizationForm.FormD);
+        var builder = new StringBuilder(decomposed.Length);
+        foreach (var ch in decomposed)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) != UnicodeCategory.NonSpacingMark)
+            {
+                builder.Append(ch);
+            }
+        }
+        return builder.ToString().Normalize(NormalizationForm.FormC);
+    }
+
+    /// <summary>
+    /// Standard iterative Levenshtein distance with two rows. Returns edit distance
+    /// between two already-normalized strings.
+    /// </summary>
+    private static int LevenshteinDistance(string a, string b)
+    {
+        if (string.IsNullOrEmpty(a)) return b?.Length ?? 0;
+        if (string.IsNullOrEmpty(b)) return a.Length;
+
+        var prev = new int[b.Length + 1];
+        var curr = new int[b.Length + 1];
+        for (var j = 0; j <= b.Length; j++) prev[j] = j;
+
+        for (var i = 1; i <= a.Length; i++)
+        {
+            curr[0] = i;
+            for (var j = 1; j <= b.Length; j++)
+            {
+                var cost = a[i - 1] == b[j - 1] ? 0 : 1;
+                curr[j] = Math.Min(
+                    Math.Min(curr[j - 1] + 1, prev[j] + 1),
+                    prev[j - 1] + cost);
+            }
+            (prev, curr) = (curr, prev);
+        }
+
+        return prev[b.Length];
+    }
+
+    private sealed record UnlinkedUser(string UserId, string Email, string NormalizedEmail, string? DisplayName);
+
+    private sealed record UnlinkedPerson(int PersonId, string FirstName, string LastName, string? Email);
+
+    private sealed record SubmissionRow(
+        int Id,
+        string PrimaryEmail,
+        string PrimaryContactName,
+        List<AdultAttendee> AdultAttendees);
+
+    private sealed record AdultAttendee(int PersonId, string FirstName, string LastName);
+}

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -27,6 +27,7 @@ using RegistraceOvcina.Web.Features.Integration;
 using RegistraceOvcina.Web.Features.Roles;
 using RegistraceOvcina.Web.Features.Announcements;
 using RegistraceOvcina.Web.Features.Auth;
+using RegistraceOvcina.Web.Features.AccountLinking;
 using RegistraceOvcina.Web.Features.ExternalContacts;
 using RegistraceOvcina.Web.Features.Stats;
 using RegistraceOvcina.Web.Features.Users;
@@ -267,6 +268,7 @@ public class Program
         builder.Services.AddScoped<GuestAuthService>();
         builder.Services.AddScoped<UserAdministrationService>();
         builder.Services.AddScoped<UserEmailService>();
+        builder.Services.AddScoped<IAccountLinkingService, AccountLinkingService>();
         builder.Services.AddScoped<GameRoleService>();
         builder.Services.AddScoped<AnnouncementService>();
         builder.Services.AddScoped<GameStatsService>();
@@ -715,6 +717,82 @@ public class Program
                     {
                         return Results.LocalRedirect($"/admin/hry/{gameId}/jidla?error={Uri.EscapeDataString(ex.Message)}");
                     }
+                })
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly);
+        app.MapPost(
+                "/admin/propojit-ucty/automaticky",
+                async (HttpContext httpContext, UserManager<ApplicationUser> userManager, IAccountLinkingService accountLinkingService, CancellationToken ct) =>
+                {
+                    var user = await userManager.GetUserAsync(httpContext.User);
+                    if (user is null)
+                    {
+                        return Results.LocalRedirect($"/Account/Login?ReturnUrl={Uri.EscapeDataString("/admin/propojit-ucty")}");
+                    }
+
+                    try
+                    {
+                        var count = await accountLinkingService.AutoLinkHighConfidenceAsync(user.Id, ct);
+                        return Results.LocalRedirect($"/admin/propojit-ucty?status=auto-linked&count={count}");
+                    }
+                    catch (ValidationException ex)
+                    {
+                        return Results.LocalRedirect($"/admin/propojit-ucty?error={Uri.EscapeDataString(ex.Message)}");
+                    }
+                })
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly);
+        app.MapPost(
+                "/admin/propojit-ucty/propojit",
+                async ([FromForm] string userId, [FromForm] int personId, [FromForm] string? returnTab, HttpContext httpContext, UserManager<ApplicationUser> userManager, IAccountLinkingService accountLinkingService, CancellationToken ct) =>
+                {
+                    var user = await userManager.GetUserAsync(httpContext.User);
+                    if (user is null)
+                    {
+                        return Results.LocalRedirect($"/Account/Login?ReturnUrl={Uri.EscapeDataString("/admin/propojit-ucty")}");
+                    }
+
+                    try
+                    {
+                        await accountLinkingService.LinkAsync(userId, personId, user.Id, ct);
+                        var tab = string.IsNullOrWhiteSpace(returnTab) ? "" : $"&tab={Uri.EscapeDataString(returnTab)}";
+                        return Results.LocalRedirect($"/admin/propojit-ucty?status=linked{tab}");
+                    }
+                    catch (ValidationException ex)
+                    {
+                        return Results.LocalRedirect($"/admin/propojit-ucty?error={Uri.EscapeDataString(ex.Message)}");
+                    }
+                })
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly);
+        app.MapPost(
+                "/admin/propojit-ucty/odpojit",
+                async ([FromForm] string userId, HttpContext httpContext, UserManager<ApplicationUser> userManager, IAccountLinkingService accountLinkingService, CancellationToken ct) =>
+                {
+                    var user = await userManager.GetUserAsync(httpContext.User);
+                    if (user is null)
+                    {
+                        return Results.LocalRedirect($"/Account/Login?ReturnUrl={Uri.EscapeDataString("/admin/propojit-ucty")}");
+                    }
+
+                    try
+                    {
+                        await accountLinkingService.UnlinkAsync(userId, user.Id, ct);
+                        return Results.LocalRedirect("/admin/propojit-ucty?status=unlinked&tab=linked");
+                    }
+                    catch (ValidationException ex)
+                    {
+                        return Results.LocalRedirect($"/admin/propojit-ucty?error={Uri.EscapeDataString(ex.Message)}");
+                    }
+                })
+            .RequireAuthorization(AuthorizationPolicies.AdminOnly);
+        app.MapPost(
+                "/admin/propojit-ucty/zamitnout",
+                ([FromForm] string userId, [FromForm] int personId) =>
+                {
+                    // "Zamítnout" is client-side dismissal; we have no persistent rejection model. Server just
+                    // redirects back so the page refreshes the proposal list. Keeping it server-side keeps
+                    // the UI contract uniform (all actions POST) and leaves room to add a deny-list later.
+                    _ = userId;
+                    _ = personId;
+                    return Results.LocalRedirect("/admin/propojit-ucty?status=dismissed");
                 })
             .RequireAuthorization(AuthorizationPolicies.AdminOnly);
         app.MapPost(

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.18</Version>
+    <Version>0.9.19</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/AccountLinking/AccountLinkingServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/AccountLinking/AccountLinkingServiceTests.cs
@@ -1,0 +1,594 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.AccountLinking;
+
+namespace RegistraceOvcina.Web.Tests.Features.AccountLinking;
+
+public sealed class AccountLinkingServiceTests
+{
+    private const string ActorId = "actor-1";
+
+    // 1 ------------------------------------------------------------
+    [Fact]
+    public async Task ProposeAsync_empty_db_returns_empty_buckets()
+    {
+        var options = CreateOptions();
+        await EnsureCreatedAsync(options);
+
+        var service = CreateService(options);
+
+        var bucket = await service.ProposeAsync(CancellationToken.None);
+
+        Assert.Empty(bucket.HighConfidence);
+        Assert.Empty(bucket.MediumConfidence);
+    }
+
+    // 2 ------------------------------------------------------------
+    [Fact]
+    public async Task ProposeAsync_exact_email_match_goes_to_HighConfidence()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Alice", "alice@example.cz"));
+            db.People.Add(new Person
+            {
+                FirstName = "Alice",
+                LastName = "Novotná",
+                BirthYear = 1990,
+                Email = "alice@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+
+        var bucket = await service.ProposeAsync(CancellationToken.None);
+
+        var proposal = Assert.Single(bucket.HighConfidence);
+        Assert.Equal("user-1", proposal.UserId);
+        Assert.Equal(LinkSignal.ExactEmailMatch, proposal.Signal);
+        Assert.Empty(bucket.MediumConfidence);
+    }
+
+    // 3 ------------------------------------------------------------
+    [Fact]
+    public async Task ProposeAsync_alternate_email_match_goes_to_HighConfidence()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Alice", "alice@example.cz"));
+            db.UserEmails.Add(new UserEmail
+            {
+                UserId = "user-1",
+                Email = "alice-alt@example.cz",
+                NormalizedEmail = "ALICE-ALT@EXAMPLE.CZ",
+                CreatedAtUtc = FixedDate()
+            });
+            db.People.Add(new Person
+            {
+                FirstName = "Alice",
+                LastName = "Svobodová",
+                BirthYear = 1990,
+                Email = "alice-alt@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+
+        var bucket = await service.ProposeAsync(CancellationToken.None);
+
+        var proposal = Assert.Single(bucket.HighConfidence);
+        Assert.Equal(LinkSignal.AlternateEmailMatch, proposal.Signal);
+    }
+
+    // 4 ------------------------------------------------------------
+    [Fact]
+    public async Task ProposeAsync_submission_primary_with_name_match_goes_to_HighConfidence()
+    {
+        var options = CreateOptions();
+        int personId;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Tomáš Pajonk", "tomas@example.cz"));
+            db.Games.Add(CreateGame(1));
+            var person = new Person
+            {
+                FirstName = "Tomáš",
+                LastName = "Pajonk",
+                BirthYear = 1980,
+                // No email on the person — this is exactly the case SubmissionPrimaryContactMatch exists to cover.
+                Email = null,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+
+            var submission = new RegistrationSubmission
+            {
+                GameId = 1,
+                RegistrantUserId = "user-1",
+                PrimaryContactName = "Tomáš Pajonk",
+                GroupName = "Rodina Pajonk",
+                PrimaryEmail = "tomas@example.cz",
+                PrimaryPhone = "+420 777 111 222",
+                Status = SubmissionStatus.Submitted,
+                LastEditedAtUtc = FixedDate()
+            };
+            db.RegistrationSubmissions.Add(submission);
+            await db.SaveChangesAsync();
+
+            db.Registrations.Add(new Registration
+            {
+                SubmissionId = submission.Id,
+                PersonId = personId,
+                AttendeeType = AttendeeType.Adult,
+                Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var bucket = await service.ProposeAsync(CancellationToken.None);
+
+        var proposal = Assert.Single(bucket.HighConfidence);
+        Assert.Equal(LinkSignal.SubmissionPrimaryContactMatch, proposal.Signal);
+        Assert.Equal(personId, proposal.PersonId);
+    }
+
+    // 5 ------------------------------------------------------------
+    [Fact]
+    public async Task ProposeAsync_submission_primary_name_mismatch_not_proposed()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Unrelated Display", "tomas@example.cz"));
+            db.Games.Add(CreateGame(1));
+            var person = new Person
+            {
+                // Different name from the Submission.PrimaryContactName.
+                FirstName = "Jana",
+                LastName = "Nováková",
+                BirthYear = 1995,
+                Email = null,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+
+            var submission = new RegistrationSubmission
+            {
+                GameId = 1,
+                RegistrantUserId = "user-1",
+                PrimaryContactName = "Tomáš Pajonk",
+                GroupName = "Family",
+                PrimaryEmail = "tomas@example.cz",
+                PrimaryPhone = "555",
+                Status = SubmissionStatus.Submitted,
+                LastEditedAtUtc = FixedDate()
+            };
+            db.RegistrationSubmissions.Add(submission);
+            await db.SaveChangesAsync();
+
+            db.Registrations.Add(new Registration
+            {
+                SubmissionId = submission.Id,
+                PersonId = person.Id,
+                AttendeeType = AttendeeType.Adult,
+                Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var bucket = await service.ProposeAsync(CancellationToken.None);
+
+        Assert.Empty(bucket.HighConfidence);
+    }
+
+    // 6 ------------------------------------------------------------
+    [Fact]
+    public async Task ProposeAsync_ambiguous_multiple_persons_same_email_skipped()
+    {
+        var options = CreateOptions();
+
+        // In-memory provider doesn't honor the unique-email filter, so we can exercise
+        // the "tie" branch even though prod Postgres would disallow duplicates.
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Alice", "shared@example.cz"));
+            db.People.AddRange(
+                new Person
+                {
+                    FirstName = "Alice",
+                    LastName = "One",
+                    BirthYear = 1990,
+                    Email = "shared@example.cz",
+                    CreatedAtUtc = FixedDate(),
+                    UpdatedAtUtc = FixedDate()
+                },
+                new Person
+                {
+                    FirstName = "Alice",
+                    LastName = "Two",
+                    BirthYear = 1991,
+                    Email = "shared@example.cz",
+                    CreatedAtUtc = FixedDate(),
+                    UpdatedAtUtc = FixedDate()
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var bucket = await service.ProposeAsync(CancellationToken.None);
+
+        Assert.Empty(bucket.HighConfidence);
+        Assert.Empty(bucket.MediumConfidence);
+    }
+
+    // 7 ------------------------------------------------------------
+    [Fact]
+    public async Task ProposeAsync_already_linked_user_excluded()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var person = new Person
+            {
+                FirstName = "Alice",
+                LastName = "Exists",
+                BirthYear = 1990,
+                Email = "alice@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+
+            var linkedUser = CreateUser("user-1", "Alice", "alice@example.cz");
+            linkedUser.PersonId = person.Id;
+            db.Users.Add(linkedUser);
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var bucket = await service.ProposeAsync(CancellationToken.None);
+
+        Assert.Empty(bucket.HighConfidence);
+        Assert.Empty(bucket.MediumConfidence);
+    }
+
+    // 8 ------------------------------------------------------------
+    [Fact]
+    public async Task ProposeAsync_fuzzy_name_match_goes_to_MediumConfidence()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Tomas Pajonk", "someone@example.cz"));
+            db.People.Add(new Person
+            {
+                // Same last name, first name differs by one character (diacritic + accent).
+                FirstName = "Tomáš",
+                LastName = "Pajonk",
+                BirthYear = 1980,
+                Email = null,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var bucket = await service.ProposeAsync(CancellationToken.None);
+
+        Assert.Empty(bucket.HighConfidence);
+        var proposal = Assert.Single(bucket.MediumConfidence);
+        Assert.Equal(LinkSignal.FuzzyNameMatch, proposal.Signal);
+        Assert.NotNull(proposal.FuzzyScore);
+        Assert.True(proposal.FuzzyScore >= 75);
+    }
+
+    // 9 ------------------------------------------------------------
+    [Fact]
+    public async Task AutoLinkHighConfidenceAsync_sets_PersonId_and_writes_AuditLog()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Alice", "alice@example.cz"));
+            db.People.Add(new Person
+            {
+                FirstName = "Alice",
+                LastName = "Example",
+                BirthYear = 1990,
+                Email = "alice@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var count = await service.AutoLinkHighConfidenceAsync(ActorId, CancellationToken.None);
+
+        Assert.Equal(1, count);
+
+        await using var verify = new ApplicationDbContext(options);
+        var user = await verify.Users.SingleAsync(u => u.Id == "user-1");
+        Assert.NotNull(user.PersonId);
+
+        var audit = await verify.AuditLogs.SingleAsync();
+        Assert.Equal("ApplicationUser", audit.EntityType);
+        Assert.Equal("user-1", audit.EntityId);
+        Assert.Equal("LinkAccount", audit.Action);
+        Assert.Equal(ActorId, audit.ActorUserId);
+        Assert.NotNull(audit.DetailsJson);
+        Assert.Contains("ExactEmailMatch", audit.DetailsJson);
+    }
+
+    // 10 -----------------------------------------------------------
+    [Fact]
+    public async Task AutoLinkHighConfidenceAsync_idempotent_second_run_noop()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Alice", "alice@example.cz"));
+            db.People.Add(new Person
+            {
+                FirstName = "Alice",
+                LastName = "Example",
+                BirthYear = 1990,
+                Email = "alice@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var first = await service.AutoLinkHighConfidenceAsync(ActorId, CancellationToken.None);
+        var second = await service.AutoLinkHighConfidenceAsync(ActorId, CancellationToken.None);
+
+        Assert.Equal(1, first);
+        Assert.Equal(0, second);
+
+        await using var verify = new ApplicationDbContext(options);
+        Assert.Equal(1, await verify.AuditLogs.CountAsync());
+    }
+
+    // 11 -----------------------------------------------------------
+    [Fact]
+    public async Task LinkAsync_manual_link_writes_AuditLog()
+    {
+        var options = CreateOptions();
+        int personId;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Alice", "alice@example.cz"));
+            var person = new Person
+            {
+                FirstName = "Alice",
+                LastName = "Manual",
+                BirthYear = 1990,
+                Email = null,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+        }
+
+        var service = CreateService(options);
+        await service.LinkAsync("user-1", personId, ActorId, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var user = await verify.Users.SingleAsync(u => u.Id == "user-1");
+        Assert.Equal(personId, user.PersonId);
+        var audit = await verify.AuditLogs.SingleAsync();
+        Assert.Equal("LinkAccount", audit.Action);
+        Assert.Contains("Manual", audit.DetailsJson!);
+    }
+
+    // 12 -----------------------------------------------------------
+    [Fact]
+    public async Task UnlinkAsync_clears_PersonId_writes_AuditLog()
+    {
+        var options = CreateOptions();
+        int personId;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var person = new Person
+            {
+                FirstName = "Alice",
+                LastName = "Linked",
+                BirthYear = 1990,
+                Email = "a@b.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+
+            var seededUser = CreateUser("user-1", "Alice", "alice@example.cz");
+            seededUser.PersonId = personId;
+            db.Users.Add(seededUser);
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        await service.UnlinkAsync("user-1", ActorId, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var user = await verify.Users.SingleAsync(u => u.Id == "user-1");
+        Assert.Null(user.PersonId);
+        var audit = await verify.AuditLogs.SingleAsync();
+        Assert.Equal("UnlinkAccount", audit.Action);
+    }
+
+    // 13 -----------------------------------------------------------
+    [Fact]
+    public async Task ListUnlinkedPersonsAsync_excludes_persons_with_linked_user()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var linkedPerson = new Person
+            {
+                FirstName = "Linked",
+                LastName = "One",
+                BirthYear = 1990,
+                Email = "l@x.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            var freePerson = new Person
+            {
+                FirstName = "Free",
+                LastName = "Two",
+                BirthYear = 1995,
+                Email = "f@x.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.AddRange(linkedPerson, freePerson);
+            await db.SaveChangesAsync();
+
+            var user = CreateUser("user-1", "Linked User", "u@x.cz");
+            user.PersonId = linkedPerson.Id;
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var list = await service.ListUnlinkedPersonsAsync(CancellationToken.None);
+
+        var row = Assert.Single(list);
+        Assert.Equal("Free Two", row.PersonFullName);
+    }
+
+    // 14 -----------------------------------------------------------
+    [Fact]
+    public async Task SearchUsersAsync_matches_email_and_displayname()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.AddRange(
+                CreateUser("user-1", "Alice Novotná", "alice@example.cz"),
+                CreateUser("user-2", "Bob Dvořák", "bob@example.cz"),
+                CreateUser("user-3", "Someone Else", "noreply@example.cz"));
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+
+        var byEmail = await service.SearchUsersAsync("alice", 10, CancellationToken.None);
+        Assert.Contains(byEmail, r => r.UserId == "user-1");
+
+        var byDisplayName = await service.SearchUsersAsync("DVOŘ", 10, CancellationToken.None);
+        Assert.Contains(byDisplayName, r => r.UserId == "user-2");
+
+        var tooShort = await service.SearchUsersAsync("a", 10, CancellationToken.None);
+        Assert.Empty(tooShort);
+    }
+
+    // -------- helpers --------
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task EnsureCreatedAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    private static ApplicationUser CreateUser(string id, string displayName, string email) => new()
+    {
+        Id = id,
+        DisplayName = displayName,
+        Email = email,
+        NormalizedEmail = email.ToUpperInvariant(),
+        UserName = email,
+        NormalizedUserName = email.ToUpperInvariant(),
+        EmailConfirmed = true,
+        IsActive = true,
+        SecurityStamp = "initial-stamp",
+        CreatedAtUtc = FixedDate()
+    };
+
+    private static Game CreateGame(int id) => new()
+    {
+        Id = id,
+        Name = "Test Game",
+        Description = "",
+        BankAccount = "1234/5678",
+        BankAccountName = "Pořadatel",
+        StartsAtUtc = FixedDate().AddMonths(2),
+        EndsAtUtc = FixedDate().AddMonths(2).AddDays(2),
+        RegistrationClosesAtUtc = FixedDate().AddMonths(1),
+        MealOrderingClosesAtUtc = FixedDate().AddMonths(1),
+        PaymentDueAtUtc = FixedDate().AddMonths(1),
+        PlayerBasePrice = 100m,
+        SecondChildPrice = 80m,
+        ThirdPlusChildPrice = 60m,
+        AdultHelperBasePrice = 50m,
+        LodgingIndoorPrice = 0m,
+        LodgingOutdoorPrice = 0m,
+        VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId
+    };
+
+    private static DateTime FixedDate() => new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    private static AccountLinkingService CreateService(DbContextOptions<ApplicationDbContext> options)
+        => new(new TestDbContextFactory(options), new FixedTimeProvider(), NullLogger<AccountLinkingService>.Instance);
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now = new(new DateTime(2026, 4, 5, 12, 0, 0, DateTimeKind.Utc));
+
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}


### PR DESCRIPTION
## Summary
- New admin page `/admin/propojit-ucty` (AdminOnly, InteractiveServer) for reconciling ApplicationUsers with Person rows that aren't linked — no emails sent, pure backend hygiene
- `AccountLinkingService.ProposeAsync` classifies candidates as HighConfidence (ExactEmailMatch / AlternateEmailMatch / SubmissionPrimaryContactMatch, auto-linkable) or MediumConfidence (FuzzyNameMatch via Levenshtein with score threshold 75)
- Four tabs: Vysoká shoda (with bulk "Propojit vše" button), Ruční kontrola, Osoby bez účtu (searchable ApplicationUser picker per row), Propojené (with Odpojit action). Every link/unlink writes an AuditLog row
- Bumps version to 0.9.19

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 253 passed (+14 from baseline 239, covering all matching branches + auto-link idempotence + manual link/unlink + unlinked-persons filter + user-search)
- [ ] Manual admin-side walkthrough after deploy (controller to run)