### PR TITLE
fix(roles): group by self-declared + detect linked-via-PersonId accounts (v0.9.20)

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameRoles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameRoles.razor
@@ -3,9 +3,11 @@
 @attribute [Authorize(Policy = AuthorizationPolicies.StaffOnly)]
 
 @using Microsoft.EntityFrameworkCore
+@using RegistraceOvcina.Web.Features.Roles
 @inject IDbContextFactory<ApplicationDbContext> DbFactory
 @inject GameService GameService
 @inject GameRoleService GameRoleService
+@inject GameRolesViewService GameRolesViewService
 @inject AuthenticationStateProvider AuthStateProvider
 
 <PageTitle>Dospělí</PageTitle>
@@ -252,86 +254,17 @@ else
             .Select(r => r.Name!)
             .ToListAsync();
 
-        // Load adults
-        var adultRows = await db.Registrations.AsNoTracking()
-            .Where(r => r.Submission.GameId == selectedGameId.Value
-                && r.AttendeeType == AttendeeType.Adult
-                && r.Status == RegistrationStatus.Active
-                && !r.Submission.IsDeleted)
-            .OrderBy(r => r.Person.LastName)
-            .ThenBy(r => r.Person.FirstName)
-            .Select(r => new
-            {
-                r.Id,
-                FirstName = r.Person.FirstName,
-                LastName = r.Person.LastName,
-                r.Submission.GroupName,
-                Email = r.Person.Email,
-                r.AdultRoles
-            })
-            .ToListAsync();
-
-        // Load all emails that have user accounts
-        var allEmails = adultRows
-            .Where(a => !string.IsNullOrWhiteSpace(a.Email))
-            .Select(a => a.Email!.Trim().ToUpperInvariant())
-            .Distinct()
-            .ToList();
-
-        var emailsWithAccounts = allEmails.Count > 0
-            ? await db.Users.AsNoTracking()
-                .Where(u => allEmails.Contains(u.NormalizedEmail!))
-                .Select(u => u.NormalizedEmail!)
-                .ToListAsync()
-            : [];
-
-        var emailsWithAccountsSet = emailsWithAccounts.ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        // Load assigned game roles for this game
-        var assignedRoles = await db.GameRoles.AsNoTracking()
-            .Where(gr => gr.GameId == selectedGameId.Value)
-            .Select(gr => new { gr.User.Email, gr.RoleName })
-            .ToListAsync();
-
-        var rolesByEmail = assignedRoles
-            .Where(r => r.Email is not null)
-            .GroupBy(r => r.Email!.Trim(), StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(
-                g => g.Key,
-                g => g.Select(r => r.RoleName).OrderBy(r => r).ToList(),
-                StringComparer.OrdinalIgnoreCase);
-
-        adults = adultRows.Select(a =>
-        {
-            var email = a.Email?.Trim();
-            var normalizedEmail = email?.ToUpperInvariant();
-            var hasAccount = normalizedEmail is not null && emailsWithAccountsSet.Contains(normalizedEmail);
-            var assignedRolesList = email is not null && rolesByEmail.TryGetValue(email, out var roles)
-                ? roles
-                : new List<string>();
-
-            return new AdultRoleView
-            {
-                RegistrationId = a.Id,
-                FullName = $"{a.FirstName} {a.LastName}",
-                LastName = a.LastName,
-                FirstName = a.FirstName,
-                GroupName = a.GroupName,
-                Email = email,
-                AdultRoles = a.AdultRoles,
-                HasAccount = hasAccount,
-                AssignedGameRoles = assignedRolesList,
-                SelectedRole = ""
-            };
-        }).ToList();
+        // Adult view assembly (account detection via email OR PersonId link) now lives in
+        // GameRolesViewService so it can be unit-tested directly.
+        adults = await GameRolesViewService.BuildAdultViewsAsync(selectedGameId.Value);
     }
 
     private async Task AssignRoleAsync(AdultRoleView adult)
     {
-        if (string.IsNullOrEmpty(adult.SelectedRole) || string.IsNullOrEmpty(adult.Email) || !selectedGameId.HasValue)
+        if (string.IsNullOrEmpty(adult.SelectedRole) || string.IsNullOrEmpty(adult.UserId) || !selectedGameId.HasValue)
             return;
 
-        await GameRoleService.AssignRoleAsync(adult.Email, selectedGameId.Value, adult.SelectedRole, currentUserId);
+        await GameRoleService.AssignRoleByUserIdAsync(adult.UserId, selectedGameId.Value, adult.SelectedRole, currentUserId);
 
         // Update local state
         if (!adult.AssignedGameRoles.Contains(adult.SelectedRole, StringComparer.OrdinalIgnoreCase))
@@ -344,10 +277,10 @@ else
 
     private async Task RevokeRoleAsync(AdultRoleView adult, string roleName)
     {
-        if (string.IsNullOrEmpty(adult.Email) || !selectedGameId.HasValue)
+        if (string.IsNullOrEmpty(adult.UserId) || !selectedGameId.HasValue)
             return;
 
-        await GameRoleService.RevokeRoleAsync(adult.Email, selectedGameId.Value, roleName, currentUserId);
+        await GameRoleService.RevokeRoleByUserIdAsync(adult.UserId, selectedGameId.Value, roleName, currentUserId);
 
         // Update local state
         adult.AssignedGameRoles.RemoveAll(r => string.Equals(r, roleName, StringComparison.OrdinalIgnoreCase));
@@ -363,13 +296,7 @@ else
     private List<RoleGroup> GetRoleGroups()
     {
         if (adults is null) return [];
-
-        return availableGameRoles
-            .Select(roleName => new RoleGroup(
-                roleName,
-                adults.Where(a => a.AssignedGameRoles.Contains(roleName, StringComparer.OrdinalIgnoreCase)).ToList()))
-            .Where(g => g.Adults.Count > 0)
-            .ToList();
+        return GameRolesViewService.GroupAdultsByRole(adults);
     }
 
     private void ToggleSort() => sortDescending = !sortDescending;
@@ -391,20 +318,4 @@ else
         if (flags.HasFlag(AdultRoleFlags.Spectator)) labels.Add("Přihlížející");
         return labels;
     }
-
-    private sealed class AdultRoleView
-    {
-        public int RegistrationId { get; set; }
-        public string FullName { get; set; } = "";
-        public string LastName { get; set; } = "";
-        public string FirstName { get; set; } = "";
-        public string GroupName { get; set; } = "";
-        public string? Email { get; set; }
-        public AdultRoleFlags AdultRoles { get; set; }
-        public bool HasAccount { get; set; }
-        public List<string> AssignedGameRoles { get; set; } = [];
-        public string SelectedRole { get; set; } = "";
-    }
-
-    private sealed record RoleGroup(string RoleName, List<AdultRoleView> Adults);
 }

--- a/src/RegistraceOvcina.Web/Features/Roles/GameRoleService.cs
+++ b/src/RegistraceOvcina.Web/Features/Roles/GameRoleService.cs
@@ -128,6 +128,78 @@ public sealed class GameRoleService(IDbContextFactory<ApplicationDbContext> dbFa
         await db.SaveChangesAsync();
     }
 
+    /// <summary>
+    /// Assigns a role directly by ApplicationUser.Id, bypassing the email lookup.
+    /// Required for accounts linked via ApplicationUser.PersonId where Person.Email is null
+    /// or doesn't match ApplicationUser.NormalizedEmail.
+    /// </summary>
+    public async Task AssignRoleByUserIdAsync(string userId, int gameId, string roleName, string actorUserId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var normalizedRole = roleName.Trim().ToLowerInvariant();
+
+        var user = await db.Users.AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == userId);
+
+        if (user is null)
+            throw new InvalidOperationException($"Uživatel s ID '{userId}' nebyl nalezen.");
+
+        var exists = await db.GameRoles
+            .AnyAsync(gr => gr.UserId == userId && gr.GameId == gameId && gr.RoleName == normalizedRole);
+
+        if (exists)
+            return;
+
+        db.GameRoles.Add(new GameRole
+        {
+            UserId = userId,
+            GameId = gameId,
+            RoleName = normalizedRole,
+            AssignedAtUtc = DateTime.UtcNow
+        });
+
+        db.AuditLogs.Add(new AuditLog
+        {
+            EntityType = "GameRole",
+            EntityId = $"{userId}:{gameId}:{normalizedRole}",
+            Action = "Assigned",
+            ActorUserId = actorUserId,
+            CreatedAtUtc = DateTime.UtcNow,
+            DetailsJson = JsonSerializer.Serialize(new { userId, gameId, roleName = normalizedRole })
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Revokes a role directly by ApplicationUser.Id (counterpart to <see cref="AssignRoleByUserIdAsync"/>).
+    /// </summary>
+    public async Task RevokeRoleByUserIdAsync(string userId, int gameId, string roleName, string actorUserId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var normalizedRole = roleName.Trim().ToLowerInvariant();
+
+        var gameRole = await db.GameRoles
+            .FirstOrDefaultAsync(gr => gr.UserId == userId && gr.GameId == gameId && gr.RoleName == normalizedRole);
+
+        if (gameRole is null)
+            return;
+
+        db.GameRoles.Remove(gameRole);
+
+        db.AuditLogs.Add(new AuditLog
+        {
+            EntityType = "GameRole",
+            EntityId = $"{userId}:{gameId}:{normalizedRole}",
+            Action = "Revoked",
+            ActorUserId = actorUserId,
+            CreatedAtUtc = DateTime.UtcNow,
+            DetailsJson = JsonSerializer.Serialize(new { userId, gameId, roleName = normalizedRole })
+        });
+
+        await db.SaveChangesAsync();
+    }
+
     public async Task<List<UserWithRoles>> GetAllRolesForGameAsync(int gameId)
     {
         await using var db = await dbFactory.CreateDbContextAsync();

--- a/src/RegistraceOvcina.Web/Features/Roles/GameRolesViewService.cs
+++ b/src/RegistraceOvcina.Web/Features/Roles/GameRolesViewService.cs
@@ -1,0 +1,200 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+
+namespace RegistraceOvcina.Web.Features.Roles;
+
+/// <summary>
+/// View-model assembly for the /organizace/role (GameRoles.razor) page.
+/// Extracted from the razor file so the logic is unit-testable against an InMemory DbContext.
+/// </summary>
+public sealed class GameRolesViewService(IDbContextFactory<ApplicationDbContext> dbFactory)
+{
+    /// <summary>
+    /// Loads all adult registrations for a game along with their current account-linking
+    /// status (HasAccount / UserId) and assigned game-roles.
+    ///
+    /// HasAccount and the role lookup both honour TWO channels:
+    ///   (a) email match — Person.Email == ApplicationUser.NormalizedEmail (legacy path);
+    ///   (b) PersonId link — ApplicationUser.PersonId == Person.Id (populated by
+    ///       AccountLinkingService and used when Person.Email is null or does not match).
+    /// </summary>
+    public async Task<List<AdultRoleView>> BuildAdultViewsAsync(int gameId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var adultRows = await db.Registrations.AsNoTracking()
+            .Where(r => r.Submission.GameId == gameId
+                && r.AttendeeType == AttendeeType.Adult
+                && r.Status == RegistrationStatus.Active
+                && !r.Submission.IsDeleted)
+            .OrderBy(r => r.Person.LastName)
+            .ThenBy(r => r.Person.FirstName)
+            .Select(r => new
+            {
+                r.Id,
+                PersonId = r.Person.Id,
+                FirstName = r.Person.FirstName,
+                LastName = r.Person.LastName,
+                r.Submission.GroupName,
+                Email = r.Person.Email,
+                r.AdultRoles
+            })
+            .ToListAsync(ct);
+
+        // Channel (a): emails-with-accounts for the adults on this page.
+        var allEmails = adultRows
+            .Where(a => !string.IsNullOrWhiteSpace(a.Email))
+            .Select(a => a.Email!.Trim().ToUpperInvariant())
+            .Distinct()
+            .ToList();
+
+        var usersByNormalizedEmail = allEmails.Count > 0
+            ? await db.Users.AsNoTracking()
+                .Where(u => allEmails.Contains(u.NormalizedEmail!))
+                .Select(u => new { u.Id, u.NormalizedEmail })
+                .ToListAsync(ct)
+            : [];
+
+        var userIdByEmail = usersByNormalizedEmail
+            .Where(u => u.NormalizedEmail is not null)
+            .ToDictionary(u => u.NormalizedEmail!, u => u.Id, StringComparer.OrdinalIgnoreCase);
+
+        // Channel (b): PersonId links for the adults on this page.
+        var adultPersonIds = adultRows.Select(a => a.PersonId).Distinct().ToList();
+
+        var personIdLinks = adultPersonIds.Count > 0
+            ? await db.Users.AsNoTracking()
+                .Where(u => u.PersonId != null && adultPersonIds.Contains(u.PersonId!.Value))
+                .Select(u => new { u.Id, PersonId = u.PersonId!.Value })
+                .ToListAsync(ct)
+            : [];
+
+        var userIdByPersonId = personIdLinks.ToDictionary(l => l.PersonId, l => l.Id);
+
+        // Load assigned game roles for this game keyed by UserId (not by email string),
+        // so adults linked only via PersonId still see their roles.
+        var assignedRoles = await db.GameRoles.AsNoTracking()
+            .Where(gr => gr.GameId == gameId)
+            .Select(gr => new { gr.UserId, gr.RoleName })
+            .ToListAsync(ct);
+
+        var rolesByUserId = assignedRoles
+            .GroupBy(r => r.UserId, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(r => r.RoleName).OrderBy(r => r, StringComparer.Ordinal).ToList(),
+                StringComparer.Ordinal);
+
+        return adultRows.Select(a =>
+        {
+            var email = a.Email?.Trim();
+            var normalizedEmail = email?.ToUpperInvariant();
+
+            // Resolve UserId via email first (common case), then fall back to PersonId link.
+            string? userId = null;
+            if (normalizedEmail is not null && userIdByEmail.TryGetValue(normalizedEmail, out var emailUserId))
+                userId = emailUserId;
+            else if (userIdByPersonId.TryGetValue(a.PersonId, out var personUserId))
+                userId = personUserId;
+
+            var assignedRolesList = userId is not null && rolesByUserId.TryGetValue(userId, out var roles)
+                ? roles
+                : new List<string>();
+
+            return new AdultRoleView
+            {
+                RegistrationId = a.Id,
+                PersonId = a.PersonId,
+                FullName = $"{a.FirstName} {a.LastName}",
+                LastName = a.LastName,
+                FirstName = a.FirstName,
+                GroupName = a.GroupName,
+                Email = email,
+                AdultRoles = a.AdultRoles,
+                HasAccount = userId is not null,
+                UserId = userId,
+                AssignedGameRoles = assignedRolesList,
+                SelectedRole = ""
+            };
+        }).ToList();
+    }
+
+    /// <summary>
+    /// Groups adults by <see cref="AdultRoleFlags"/> using the 5 canonical labels
+    /// (Příšera, Pomocník, Technická pomoc, Hraničář, Přihlížející).
+    ///
+    /// For each of the 5 roles, an adult appears in the group if EITHER:
+    ///   - their AdultRoles flags include the matching flag (self-declared), OR
+    ///   - they have an officially assigned matching GameRole (mapped to the same label).
+    ///
+    /// An adult with multiple flags appears in multiple groups.
+    /// Adults with neither a flag nor an assignment land in a 6th "Nezvoleno" group.
+    /// Each group is sorted by LastName, then FirstName (case-insensitive).
+    /// Empty groups are dropped.
+    /// </summary>
+    public static List<RoleGroup> GroupAdultsByRole(IReadOnlyList<AdultRoleView> adults)
+    {
+        var result = new List<RoleGroup>(6);
+
+        foreach (var (label, flag, assignedRoleNames) in RoleMappings)
+        {
+            var inGroup = adults
+                .Where(a => a.AdultRoles.HasFlag(flag)
+                    || a.AssignedGameRoles.Any(r => assignedRoleNames.Contains(r, StringComparer.OrdinalIgnoreCase)))
+                .OrderBy(a => a.LastName, StringComparer.CurrentCultureIgnoreCase)
+                .ThenBy(a => a.FirstName, StringComparer.CurrentCultureIgnoreCase)
+                .ToList();
+
+            if (inGroup.Count > 0)
+                result.Add(new RoleGroup(label, inGroup));
+        }
+
+        // Catch-all bucket: no self-declared flag AND no assigned game role.
+        var uncategorized = adults
+            .Where(a => a.AdultRoles == AdultRoleFlags.None && a.AssignedGameRoles.Count == 0)
+            .OrderBy(a => a.LastName, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(a => a.FirstName, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+
+        if (uncategorized.Count > 0)
+            result.Add(new RoleGroup("Nezvoleno", uncategorized));
+
+        return result;
+    }
+
+    /// <summary>
+    /// Canonical Czech label ↔ AdultRoleFlags ↔ assigned GameRole.RoleName mapping.
+    /// The role-name list is intentionally loose because the admin can define arbitrary
+    /// game roles in the Roles table; we use the common seeded names ("npc", "tech-support",
+    /// "ranger-leader") plus a localized fallback so admins who use Czech role names still match.
+    /// </summary>
+    private static readonly (string Label, AdultRoleFlags Flag, string[] AssignedRoleNames)[] RoleMappings =
+    [
+        ("Příšera",         AdultRoleFlags.PlayMonster,        ["npc", "monster", "příšera"]),
+        ("Pomocník",        AdultRoleFlags.OrganizationHelper, ["helper", "pomocník", "pomocnik"]),
+        ("Technická pomoc", AdultRoleFlags.TechSupport,        ["tech-support", "tech", "technická pomoc"]),
+        ("Hraničář",        AdultRoleFlags.RangerLeader,       ["ranger-leader", "hraničář", "hranicar"]),
+        ("Přihlížející",    AdultRoleFlags.Spectator,          ["spectator", "přihlížející", "prihlizejici"]),
+    ];
+}
+
+public sealed class AdultRoleView
+{
+    public int RegistrationId { get; set; }
+    public int PersonId { get; set; }
+    public string FullName { get; set; } = "";
+    public string LastName { get; set; } = "";
+    public string FirstName { get; set; } = "";
+    public string GroupName { get; set; } = "";
+    public string? Email { get; set; }
+    public AdultRoleFlags AdultRoles { get; set; }
+    public bool HasAccount { get; set; }
+
+    /// <summary>ApplicationUser.Id resolved via email-match OR PersonId link. Null when no account.</summary>
+    public string? UserId { get; set; }
+
+    public List<string> AssignedGameRoles { get; set; } = [];
+    public string SelectedRole { get; set; } = "";
+}
+
+public sealed record RoleGroup(string RoleName, List<AdultRoleView> Adults);

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -270,6 +270,7 @@ public class Program
         builder.Services.AddScoped<UserEmailService>();
         builder.Services.AddScoped<IAccountLinkingService, AccountLinkingService>();
         builder.Services.AddScoped<GameRoleService>();
+        builder.Services.AddScoped<GameRolesViewService>();
         builder.Services.AddScoped<AnnouncementService>();
         builder.Services.AddScoped<GameStatsService>();
         builder.Services.Configure<IntegrationApiOptions>(

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.19</Version>
+    <Version>0.9.20</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/Roles/GameRoleServiceByUserIdTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/Roles/GameRoleServiceByUserIdTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.Roles;
+
+namespace RegistraceOvcina.Web.Tests.Features.Roles;
+
+/// <summary>
+/// Covers the UserId-based overloads added in v0.9.20 so that role assignment
+/// works for accounts linked via ApplicationUser.PersonId even when Person.Email
+/// is null or doesn't match ApplicationUser.NormalizedEmail.
+/// </summary>
+public sealed class GameRoleServiceByUserIdTests
+{
+    private const string ActorId = "actor-1";
+    private const int GameId = 1;
+
+    [Fact]
+    public async Task AssignRoleByUserIdAsync_creates_role_and_audit_log()
+    {
+        var options = CreateOptions();
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Eva", "eva@example.cz"));
+            await db.SaveChangesAsync();
+        }
+
+        var service = new GameRoleService(new TestDbContextFactory(options));
+        await service.AssignRoleByUserIdAsync("user-1", GameId, "NPC", ActorId);
+
+        await using var verify = new ApplicationDbContext(options);
+        var role = await verify.GameRoles.SingleAsync();
+        Assert.Equal("user-1", role.UserId);
+        Assert.Equal(GameId, role.GameId);
+        Assert.Equal("npc", role.RoleName);
+
+        var audit = await verify.AuditLogs.SingleAsync();
+        Assert.Equal("GameRole", audit.EntityType);
+        Assert.Equal("Assigned", audit.Action);
+        Assert.Equal(ActorId, audit.ActorUserId);
+    }
+
+    [Fact]
+    public async Task AssignRoleByUserIdAsync_is_idempotent_when_role_already_exists()
+    {
+        var options = CreateOptions();
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Eva", "eva@example.cz"));
+            db.GameRoles.Add(new GameRole
+            {
+                UserId = "user-1",
+                GameId = GameId,
+                RoleName = "npc",
+                AssignedAtUtc = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new GameRoleService(new TestDbContextFactory(options));
+        await service.AssignRoleByUserIdAsync("user-1", GameId, "npc", ActorId);
+
+        await using var verify = new ApplicationDbContext(options);
+        Assert.Equal(1, await verify.GameRoles.CountAsync());
+        Assert.Equal(0, await verify.AuditLogs.CountAsync());
+    }
+
+    [Fact]
+    public async Task AssignRoleByUserIdAsync_throws_when_user_missing()
+    {
+        var options = CreateOptions();
+        await using (var db = new ApplicationDbContext(options))
+        {
+            await db.SaveChangesAsync();
+        }
+
+        var service = new GameRoleService(new TestDbContextFactory(options));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.AssignRoleByUserIdAsync("missing-user", GameId, "npc", ActorId));
+    }
+
+    [Fact]
+    public async Task RevokeRoleByUserIdAsync_removes_role_and_writes_audit_log()
+    {
+        var options = CreateOptions();
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Eva", "eva@example.cz"));
+            db.GameRoles.Add(new GameRole
+            {
+                UserId = "user-1",
+                GameId = GameId,
+                RoleName = "npc",
+                AssignedAtUtc = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new GameRoleService(new TestDbContextFactory(options));
+        await service.RevokeRoleByUserIdAsync("user-1", GameId, "npc", ActorId);
+
+        await using var verify = new ApplicationDbContext(options);
+        Assert.Equal(0, await verify.GameRoles.CountAsync());
+        var audit = await verify.AuditLogs.SingleAsync();
+        Assert.Equal("Revoked", audit.Action);
+    }
+
+    [Fact]
+    public async Task RevokeRoleByUserIdAsync_is_noop_when_role_not_present()
+    {
+        var options = CreateOptions();
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Eva", "eva@example.cz"));
+            await db.SaveChangesAsync();
+        }
+
+        var service = new GameRoleService(new TestDbContextFactory(options));
+        await service.RevokeRoleByUserIdAsync("user-1", GameId, "npc", ActorId);
+
+        await using var verify = new ApplicationDbContext(options);
+        Assert.Equal(0, await verify.AuditLogs.CountAsync());
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static ApplicationUser CreateUser(string id, string displayName, string email) => new()
+    {
+        Id = id,
+        DisplayName = displayName,
+        Email = email,
+        NormalizedEmail = email.ToUpperInvariant(),
+        UserName = email,
+        NormalizedUserName = email.ToUpperInvariant(),
+        EmailConfirmed = true,
+        IsActive = true,
+        SecurityStamp = "initial-stamp",
+        CreatedAtUtc = FixedDate()
+    };
+
+    private static DateTime FixedDate() => new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}

--- a/tests/RegistraceOvcina.Web.Tests/Features/Roles/GameRolesViewServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/Roles/GameRolesViewServiceTests.cs
@@ -1,0 +1,341 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.Roles;
+
+namespace RegistraceOvcina.Web.Tests.Features.Roles;
+
+/// <summary>
+/// Covers the two /organizace/role bugs fixed in v0.9.20:
+///   1. "Group by role" must pick up self-declared AdultRoleFlags (not just assigned GameRoles).
+///   2. HasAccount + assigned-roles lookup must also work when the account is linked via
+///      ApplicationUser.PersonId (Person.Email null or mismatched).
+/// </summary>
+public sealed class GameRolesViewServiceTests
+{
+    private const string ActorId = "actor-1";
+    private const int GameId = 1;
+
+    // ---------------------------------------------------------------
+    // BuildAdultViewsAsync — HasAccount detection
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task HasAccount_true_when_email_matches_user()
+    {
+        var options = CreateOptions();
+        await using (var db = new ApplicationDbContext(options))
+        {
+            await SeedGameAsync(db);
+            var user = CreateUser("user-1", "Alice", "alice@example.cz");
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+
+            var person = CreatePerson("Alice", "Nováková", email: "alice@example.cz");
+            await AddAdultRegistrationAsync(db, person, AdultRoleFlags.None);
+        }
+
+        var views = await CreateService(options).BuildAdultViewsAsync(GameId);
+
+        var view = Assert.Single(views);
+        Assert.True(view.HasAccount);
+        Assert.Equal("user-1", view.UserId);
+    }
+
+    [Fact]
+    public async Task HasAccount_true_when_PersonEmail_null_but_User_linked_via_PersonId()
+    {
+        var options = CreateOptions();
+        int personId;
+        await using (var db = new ApplicationDbContext(options))
+        {
+            await SeedGameAsync(db);
+
+            // Person has NO email.
+            var person = CreatePerson("Bob", "Bez-Mailu", email: null);
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+
+            // ApplicationUser is linked to the person via PersonId (AccountLinkingService path).
+            var user = CreateUser("user-1", "Bob", "bob-login@example.cz");
+            user.PersonId = personId;
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+
+            await AddAdultRegistrationAsync(db, person, AdultRoleFlags.None);
+        }
+
+        var views = await CreateService(options).BuildAdultViewsAsync(GameId);
+
+        var view = Assert.Single(views);
+        Assert.True(view.HasAccount);
+        Assert.Equal("user-1", view.UserId);
+        Assert.Null(view.Email);
+    }
+
+    [Fact]
+    public async Task HasAccount_false_when_no_email_and_no_PersonId_link()
+    {
+        var options = CreateOptions();
+        await using (var db = new ApplicationDbContext(options))
+        {
+            await SeedGameAsync(db);
+            var person = CreatePerson("Cecilie", "Neaccount", email: null);
+            await AddAdultRegistrationAsync(db, person, AdultRoleFlags.None);
+        }
+
+        var views = await CreateService(options).BuildAdultViewsAsync(GameId);
+
+        var view = Assert.Single(views);
+        Assert.False(view.HasAccount);
+        Assert.Null(view.UserId);
+    }
+
+    // ---------------------------------------------------------------
+    // BuildAdultViewsAsync — assigned-roles lookup via PersonId link
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task AssignedRoles_visible_when_linked_via_PersonId_only()
+    {
+        var options = CreateOptions();
+        await using (var db = new ApplicationDbContext(options))
+        {
+            await SeedGameAsync(db);
+
+            var person = CreatePerson("Dana", "PersonIdOnly", email: null);
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+
+            var user = CreateUser("user-1", "Dana", "dana-login@example.cz");
+            user.PersonId = person.Id;
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+
+            await AddAdultRegistrationAsync(db, person, AdultRoleFlags.None);
+
+            // Seed an assigned game-role keyed by user.Id.
+            db.GameRoles.Add(new GameRole
+            {
+                UserId = "user-1",
+                GameId = GameId,
+                RoleName = "npc",
+                AssignedAtUtc = FixedDate()
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var views = await CreateService(options).BuildAdultViewsAsync(GameId);
+
+        var view = Assert.Single(views);
+        Assert.True(view.HasAccount);
+        Assert.Contains("npc", view.AssignedGameRoles);
+    }
+
+    // ---------------------------------------------------------------
+    // GroupAdultsByRole
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void GroupByRole_includes_self_declared_adults_even_without_assignment()
+    {
+        var adults = new List<AdultRoleView>
+        {
+            new() { LastName = "Appleby", FirstName = "A", AdultRoles = AdultRoleFlags.PlayMonster },
+            new() { LastName = "Bruk",    FirstName = "B", AdultRoles = AdultRoleFlags.PlayMonster },
+            new() { LastName = "Civek",   FirstName = "C", AdultRoles = AdultRoleFlags.PlayMonster }
+        };
+
+        var groups = GameRolesViewService.GroupAdultsByRole(adults);
+
+        var monsterGroup = groups.Single(g => g.RoleName == "Příšera");
+        Assert.Equal(3, monsterGroup.Adults.Count);
+    }
+
+    [Fact]
+    public void GroupByRole_includes_assigned_without_self_declaration()
+    {
+        var adults = new List<AdultRoleView>
+        {
+            new()
+            {
+                LastName = "Dvořák", FirstName = "D",
+                AdultRoles = AdultRoleFlags.None,
+                AssignedGameRoles = ["npc"]
+            }
+        };
+
+        var groups = GameRolesViewService.GroupAdultsByRole(adults);
+
+        var monsterGroup = groups.Single(g => g.RoleName == "Příšera");
+        Assert.Single(monsterGroup.Adults);
+        Assert.DoesNotContain(groups, g => g.RoleName == "Nezvoleno");
+    }
+
+    [Fact]
+    public void GroupByRole_adult_with_multiple_flags_appears_in_each_group()
+    {
+        var adults = new List<AdultRoleView>
+        {
+            new()
+            {
+                LastName = "Multi", FirstName = "M",
+                AdultRoles = AdultRoleFlags.PlayMonster | AdultRoleFlags.TechSupport | AdultRoleFlags.RangerLeader
+            }
+        };
+
+        var groups = GameRolesViewService.GroupAdultsByRole(adults);
+
+        Assert.Contains(groups, g => g.RoleName == "Příšera" && g.Adults.Count == 1);
+        Assert.Contains(groups, g => g.RoleName == "Technická pomoc" && g.Adults.Count == 1);
+        Assert.Contains(groups, g => g.RoleName == "Hraničář" && g.Adults.Count == 1);
+    }
+
+    [Fact]
+    public void GroupByRole_uncategorized_adults_land_in_Nezvoleno_bucket()
+    {
+        var adults = new List<AdultRoleView>
+        {
+            new() { LastName = "Blank", FirstName = "B", AdultRoles = AdultRoleFlags.None },
+            new() { LastName = "Monster", FirstName = "M", AdultRoles = AdultRoleFlags.PlayMonster }
+        };
+
+        var groups = GameRolesViewService.GroupAdultsByRole(adults);
+
+        var uncategorized = groups.Single(g => g.RoleName == "Nezvoleno");
+        Assert.Single(uncategorized.Adults);
+        Assert.Equal("Blank", uncategorized.Adults[0].LastName);
+    }
+
+    [Fact]
+    public void GroupByRole_sorts_adults_by_last_then_first_name()
+    {
+        var adults = new List<AdultRoleView>
+        {
+            new() { LastName = "Cihlář", FirstName = "X", AdultRoles = AdultRoleFlags.PlayMonster },
+            new() { LastName = "Alfa",   FirstName = "Z", AdultRoles = AdultRoleFlags.PlayMonster },
+            new() { LastName = "Alfa",   FirstName = "A", AdultRoles = AdultRoleFlags.PlayMonster }
+        };
+
+        var groups = GameRolesViewService.GroupAdultsByRole(adults);
+        var monster = groups.Single(g => g.RoleName == "Příšera").Adults;
+
+        Assert.Equal("Alfa",   monster[0].LastName);
+        Assert.Equal("A",      monster[0].FirstName);
+        Assert.Equal("Alfa",   monster[1].LastName);
+        Assert.Equal("Z",      monster[1].FirstName);
+        Assert.Equal("Cihlář", monster[2].LastName);
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static GameRolesViewService CreateService(DbContextOptions<ApplicationDbContext> options)
+        => new(new TestDbContextFactory(options));
+
+    private static async Task SeedGameAsync(ApplicationDbContext db)
+    {
+        db.Games.Add(CreateGame(GameId));
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task AddAdultRegistrationAsync(
+        ApplicationDbContext db,
+        Person person,
+        AdultRoleFlags flags)
+    {
+        if (person.Id == 0)
+        {
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+        }
+
+        var submission = new RegistrationSubmission
+        {
+            GameId = GameId,
+            RegistrantUserId = "registrant-1",
+            PrimaryContactName = $"{person.FirstName} {person.LastName}",
+            GroupName = "Test group",
+            PrimaryEmail = person.Email ?? "primary@example.cz",
+            PrimaryPhone = "555",
+            Status = SubmissionStatus.Submitted,
+            LastEditedAtUtc = FixedDate()
+        };
+        db.RegistrationSubmissions.Add(submission);
+        await db.SaveChangesAsync();
+
+        db.Registrations.Add(new Registration
+        {
+            SubmissionId = submission.Id,
+            PersonId = person.Id,
+            AttendeeType = AttendeeType.Adult,
+            AdultRoles = flags,
+            Status = RegistrationStatus.Active,
+            CreatedAtUtc = FixedDate(),
+            UpdatedAtUtc = FixedDate()
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static Person CreatePerson(string firstName, string lastName, string? email) => new()
+    {
+        FirstName = firstName,
+        LastName = lastName,
+        BirthYear = 1990,
+        Email = email,
+        CreatedAtUtc = FixedDate(),
+        UpdatedAtUtc = FixedDate()
+    };
+
+    private static ApplicationUser CreateUser(string id, string displayName, string email) => new()
+    {
+        Id = id,
+        DisplayName = displayName,
+        Email = email,
+        NormalizedEmail = email.ToUpperInvariant(),
+        UserName = email,
+        NormalizedUserName = email.ToUpperInvariant(),
+        EmailConfirmed = true,
+        IsActive = true,
+        SecurityStamp = "initial-stamp",
+        CreatedAtUtc = FixedDate()
+    };
+
+    private static Game CreateGame(int id) => new()
+    {
+        Id = id,
+        Name = "Test Game",
+        Description = "",
+        BankAccount = "1234/5678",
+        BankAccountName = "Pořadatel",
+        StartsAtUtc = FixedDate().AddMonths(2),
+        EndsAtUtc = FixedDate().AddMonths(2).AddDays(2),
+        RegistrationClosesAtUtc = FixedDate().AddMonths(1),
+        MealOrderingClosesAtUtc = FixedDate().AddMonths(1),
+        PaymentDueAtUtc = FixedDate().AddMonths(1),
+        PlayerBasePrice = 100m,
+        SecondChildPrice = 80m,
+        ThirdPlusChildPrice = 60m,
+        AdultHelperBasePrice = 50m,
+        LodgingIndoorPrice = 0m,
+        LodgingOutdoorPrice = 0m,
+        VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId
+    };
+
+    private static DateTime FixedDate() => new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}


### PR DESCRIPTION
## Summary

Two narrow bug fixes on `/organizace/role`:

- **Bug 1** — "Seskupit podle role" now groups by the 5 canonical `AdultRoleFlags` labels (Příšera, Pomocník, Technická pomoc, Hraničář, Přihlížející) unioned with assigned GameRoles. Previously only officially-assigned adults appeared — e.g. only 1 monster visible though many declared `PlayMonster` during registration. A 6th "Nezvoleno" bucket catches adults with neither a flag nor an assignment.
- **Bug 2** — "Bez účtu" badge no longer shows (and role assignment works) for adults whose `ApplicationUser` is linked via `ApplicationUser.PersonId`. Previously `HasAccount` was computed only from `Person.Email` → `User.NormalizedEmail`, missing the AccountLinkingService path where `Person.Email` is null but `ApplicationUser.PersonId == Person.Id`.

## Implementation

- Extracted view-assembly and grouping logic from `GameRoles.razor` into `Features/Roles/GameRolesViewService.cs` so the logic is unit-testable against InMemory EF.
- `BuildAdultViewsAsync` resolves `UserId` via email-match first, falls back to `PersonId` link. `AssignedGameRoles` lookup is now keyed by `UserId` (not email) so linked-via-PersonId adults see their roles.
- Added `GameRoleService.AssignRoleByUserIdAsync` / `RevokeRoleByUserIdAsync` so the page can assign/revoke by `UserId` (the email overloads would fail for linked-via-PersonId accounts with null Person.Email).
- Page reduced from 411 → ~300 lines; `AdultRoleView` / `RoleGroup` are now public types on the service.

## Tests

Baseline was 253; now 267 passing.

- `GameRolesViewServiceTests` (8 tests): HasAccount via email, via PersonId, false when neither; AssignedRoles visible via PersonId-only link; GroupByRole self-declared-without-assignment, assigned-without-self-declaration, multi-flag adult, Nezvoleno bucket, sort order.
- `GameRoleServiceByUserIdTests` (5 tests): assign creates role + audit, idempotent, throws on missing user, revoke removes + audit, revoke no-op.

## Version

Bumps `RegistraceOvcina.Web.csproj` 0.9.19 → 0.9.20.

## Test plan

- [ ] CI green
- [ ] Verify on dev: `/organizace/role` → "Seskupit podle role" shows all self-declared monsters
- [ ] Verify on dev: adult whose Person.Email is null but ApplicationUser.PersonId is set no longer shows "Bez účtu", role assignment UI appears and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)