### PR TITLE
hotfix(roles): tolerate duplicate PersonId links + guard future ones (v0.9.22)

### DIFF
--- a/src/RegistraceOvcina.Web/Features/AccountLinking/AccountLinkingService.cs
+++ b/src/RegistraceOvcina.Web/Features/AccountLinking/AccountLinkingService.cs
@@ -81,6 +81,8 @@ public sealed class AccountLinkingService(
             .ToListAsync(ct);
 
         // Only propose Persons that have no ApplicationUser pointing at them.
+        // NOTE: this also protects against proposing a Person that's already claimed —
+        // ProposeAsync filters them out upfront so the admin page never offers them.
         var linkedPersonIds = await db.Users.AsNoTracking()
             .Where(u => u.PersonId != null)
             .Select(u => u.PersonId!.Value)
@@ -318,11 +320,21 @@ public sealed class AccountLinkingService(
         var alreadyLinkedSet = new HashSet<int>(alreadyLinkedPersonIds);
 
         var count = 0;
+        var skippedPersonAlreadyLinked = 0;
         foreach (var proposal in bucket.HighConfidence)
         {
             if (!usersById.TryGetValue(proposal.UserId, out var user)) continue;
             if (user.PersonId != null) continue; // already linked — no-op
-            if (alreadyLinkedSet.Contains(proposal.PersonId)) continue; // person taken
+            if (alreadyLinkedSet.Contains(proposal.PersonId))
+            {
+                // Person is already linked to a different User — skip this proposal
+                // rather than creating a duplicate PersonId link.
+                skippedPersonAlreadyLinked++;
+                logger.LogInformation(
+                    "AutoLink: skipping proposal for user {UserId} → person {PersonId} because the person is already linked to another account.",
+                    proposal.UserId, proposal.PersonId);
+                continue;
+            }
 
             user.PersonId = proposal.PersonId;
             alreadyLinkedSet.Add(proposal.PersonId);
@@ -347,7 +359,9 @@ public sealed class AccountLinkingService(
         }
 
         await db.SaveChangesAsync(ct);
-        logger.LogInformation("Auto-linked {Count} accounts (actor {ActorId}).", count, actorUserId);
+        logger.LogInformation(
+            "Auto-linked {Count} accounts, skipped {Skipped} proposals whose target person was already linked (actor {ActorId}).",
+            count, skippedPersonAlreadyLinked, actorUserId);
         return count;
     }
 
@@ -381,11 +395,17 @@ public sealed class AccountLinkingService(
         }
 
         var personAlreadyLinked = await db.Users.AsNoTracking()
-            .AnyAsync(u => u.PersonId == personId, ct);
+            .AnyAsync(u => u.PersonId == personId && u.Id != userId, ct);
         if (personAlreadyLinked)
         {
-            logger.LogDebug("LinkAsync: person {PersonId} already linked to another user — no-op.", personId);
-            return;
+            // Surface the conflict so the admin UI can show a meaningful error instead of
+            // silently dropping the link (or worse, letting a duplicate through, which then
+            // crashes /organizace/role).
+            logger.LogWarning(
+                "LinkAsync: refused — person {PersonId} is already linked to another user (attempted by actor {ActorId} for user {UserId}).",
+                personId, actorUserId, userId);
+            throw new InvalidOperationException(
+                "Another account is already linked to this Person. Unlink the existing link first.");
         }
 
         user.PersonId = personId;

--- a/src/RegistraceOvcina.Web/Features/Roles/GameRolesViewService.cs
+++ b/src/RegistraceOvcina.Web/Features/Roles/GameRolesViewService.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using RegistraceOvcina.Web.Data;
 
 namespace RegistraceOvcina.Web.Features.Roles;
@@ -7,7 +8,9 @@ namespace RegistraceOvcina.Web.Features.Roles;
 /// View-model assembly for the /organizace/role (GameRoles.razor) page.
 /// Extracted from the razor file so the logic is unit-testable against an InMemory DbContext.
 /// </summary>
-public sealed class GameRolesViewService(IDbContextFactory<ApplicationDbContext> dbFactory)
+public sealed class GameRolesViewService(
+    IDbContextFactory<ApplicationDbContext> dbFactory,
+    ILogger<GameRolesViewService>? logger = null)
 {
     /// <summary>
     /// Loads all adult registrations for a game along with their current account-linking
@@ -69,7 +72,26 @@ public sealed class GameRolesViewService(IDbContextFactory<ApplicationDbContext>
                 .ToListAsync(ct)
             : [];
 
-        var userIdByPersonId = personIdLinks.ToDictionary(l => l.PersonId, l => l.Id);
+        // Data-quality guard: if multiple ApplicationUsers are linked to the same Person (which
+        // v0.9.19's AccountLinkingService was not defensive enough to prevent), picking the
+        // naive ToDictionary(PersonId) throws ArgumentException and takes the whole page down.
+        // Deterministically pick the earliest user Id and log the conflict so an admin can fix it.
+        var duplicatePersonIds = personIdLinks
+            .GroupBy(l => l.PersonId)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        if (duplicatePersonIds.Count > 0)
+        {
+            logger?.LogWarning(
+                "Multiple ApplicationUsers linked to the same PersonId(s): {PersonIds}. Using the earliest user per person.",
+                string.Join(",", duplicatePersonIds));
+        }
+
+        var userIdByPersonId = personIdLinks
+            .GroupBy(l => l.PersonId)
+            .ToDictionary(g => g.Key, g => g.OrderBy(x => x.Id, StringComparer.Ordinal).First().Id);
 
         // Load assigned game roles for this game keyed by UserId (not by email string),
         // so adults linked only via PersonId still see their roles.

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -761,6 +761,13 @@ public class Program
                     {
                         return Results.LocalRedirect($"/admin/propojit-ucty?error={Uri.EscapeDataString(ex.Message)}");
                     }
+                    catch (InvalidOperationException ex)
+                    {
+                        // v0.9.22: LinkAsync throws when the target Person is already linked to
+                        // another account. Surface the conflict as a friendly banner instead
+                        // of a 500 page.
+                        return Results.LocalRedirect($"/admin/propojit-ucty?error={Uri.EscapeDataString(ex.Message)}");
+                    }
                 })
             .RequireAuthorization(AuthorizationPolicies.AdminOnly);
         app.MapPost(

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.21</Version>
+    <Version>0.9.22</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/AccountLinking/AccountLinkingServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/AccountLinking/AccountLinkingServiceTests.cs
@@ -496,7 +496,140 @@ public sealed class AccountLinkingServiceTests
         Assert.Equal("Free Two", row.PersonFullName);
     }
 
-    // 14 -----------------------------------------------------------
+    // 14a -----------------------------------------------------------
+    // v0.9.22 hotfix: guard against creating duplicate PersonId links.
+    [Fact]
+    public async Task LinkAsync_throws_when_person_already_linked_to_another_user()
+    {
+        var options = CreateOptions();
+        int personId;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var person = new Person
+            {
+                FirstName = "Shared",
+                LastName = "Person",
+                BirthYear = 1990,
+                Email = null,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+
+            // user-existing already claims the person.
+            var existing = CreateUser("user-existing", "Existing", "existing@example.cz");
+            existing.PersonId = personId;
+            db.Users.Add(existing);
+            // user-new is the one we'll try to link — and it should fail.
+            db.Users.Add(CreateUser("user-new", "New", "new@example.cz"));
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.LinkAsync("user-new", personId, ActorId, CancellationToken.None));
+
+        // Existing link must be unchanged; new user must NOT be linked.
+        await using var verify = new ApplicationDbContext(options);
+        var existingUser = await verify.Users.SingleAsync(u => u.Id == "user-existing");
+        var newUser = await verify.Users.SingleAsync(u => u.Id == "user-new");
+        Assert.Equal(personId, existingUser.PersonId);
+        Assert.Null(newUser.PersonId);
+    }
+
+    // 14b -----------------------------------------------------------
+    [Fact]
+    public async Task AutoLinkHighConfidenceAsync_skips_proposals_whose_person_already_linked()
+    {
+        // In-memory provider doesn't enforce Person.Email uniqueness, so we can have two
+        // ApplicationUsers matched to the same Person's email and observe that AutoLink
+        // only links the first and skips the second (instead of creating a duplicate).
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            // user-a is already linked to the target Person.
+            var person = new Person
+            {
+                FirstName = "Alice",
+                LastName = "Shared",
+                BirthYear = 1990,
+                Email = "shared@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+
+            // user-b: unlinked, but shares the same normalized email as the Person.
+            // Without the guard, ProposeAsync would propose user-b → person, and
+            // AutoLink would create the duplicate that crashes /organizace/role.
+            var userA = CreateUser("user-a", "Alice Primary", "shared@example.cz");
+            userA.PersonId = person.Id;
+            db.Users.Add(userA);
+            db.Users.Add(CreateUser("user-b", "Alice Other", "shared@example.cz"));
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var count = await service.AutoLinkHighConfidenceAsync(ActorId, CancellationToken.None);
+
+        // user-b must NOT be linked because user-a already owns the Person.
+        // ProposeAsync already filters already-linked Persons out, so count is 0.
+        Assert.Equal(0, count);
+
+        await using var verify = new ApplicationDbContext(options);
+        var userB = await verify.Users.SingleAsync(u => u.Id == "user-b");
+        Assert.Null(userB.PersonId);
+
+        // And only one user points at the Person.
+        var linkedCount = await verify.Users.CountAsync(u => u.PersonId != null);
+        Assert.Equal(1, linkedCount);
+    }
+
+    // 14c -----------------------------------------------------------
+    [Fact]
+    public async Task ProposeAsync_excludes_persons_already_linked_to_another_user()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var person = new Person
+            {
+                FirstName = "Taken",
+                LastName = "Person",
+                BirthYear = 1990,
+                Email = "taken@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+
+            // user-owner already owns the Person.
+            var owner = CreateUser("user-owner", "Owner", "taken@example.cz");
+            owner.PersonId = person.Id;
+            db.Users.Add(owner);
+
+            // user-candidate shares the email but the Person is already claimed —
+            // ProposeAsync must NOT surface it as a proposal.
+            db.Users.Add(CreateUser("user-candidate", "Candidate", "taken@example.cz"));
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var bucket = await service.ProposeAsync(CancellationToken.None);
+
+        Assert.Empty(bucket.HighConfidence);
+        Assert.Empty(bucket.MediumConfidence);
+    }
+
+    // 15 -----------------------------------------------------------
     [Fact]
     public async Task SearchUsersAsync_matches_email_and_displayname()
     {

--- a/tests/RegistraceOvcina.Web.Tests/Features/Roles/GameRolesViewServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/Roles/GameRolesViewServiceTests.cs
@@ -92,6 +92,51 @@ public sealed class GameRolesViewServiceTests
     }
 
     // ---------------------------------------------------------------
+    // BuildAdultViewsAsync — data-quality guard
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// Regression test for v0.9.22 hotfix: /organizace/role crashed with
+    /// ArgumentException ("An item with the same key has already been added. Key: 114")
+    /// when two ApplicationUsers shared the same PersonId. The page must not crash;
+    /// it should pick one user deterministically (earliest Id) and log a warning.
+    /// </summary>
+    [Fact]
+    public async Task BuildAdultViewsAsync_does_not_crash_when_duplicate_personid_links_exist()
+    {
+        var options = CreateOptions();
+        int personId;
+        await using (var db = new ApplicationDbContext(options))
+        {
+            await SeedGameAsync(db);
+
+            var person = CreatePerson("Bob", "Duplicate", email: null);
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+
+            // Two ApplicationUsers linked to the SAME PersonId — the exact prod data-quality
+            // defect that crashed v0.9.21's .ToDictionary(l => l.PersonId, ...) call.
+            var userA = CreateUser("user-a", "Bob A", "bob-a@example.cz");
+            userA.PersonId = personId;
+            var userB = CreateUser("user-b", "Bob B", "bob-b@example.cz");
+            userB.PersonId = personId;
+            db.Users.AddRange(userA, userB);
+            await db.SaveChangesAsync();
+
+            await AddAdultRegistrationAsync(db, person, AdultRoleFlags.None);
+        }
+
+        // Must not throw.
+        var views = await CreateService(options).BuildAdultViewsAsync(GameId);
+
+        var view = Assert.Single(views);
+        Assert.True(view.HasAccount);
+        // Deterministic pick: earliest user-id by ordinal comparison.
+        Assert.Equal("user-a", view.UserId);
+    }
+
+    // ---------------------------------------------------------------
     // BuildAdultViewsAsync — assigned-roles lookup via PersonId link
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Production fix for an `ArgumentException` on `/organizace/role`:

```
An item with the same key has already been added. Key: 114
```

Two `ApplicationUser` rows shared the same `PersonId` (data inconsistency, probably introduced or surfaced by v0.9.19's AccountLinkingService auto-link). `GameRolesViewService` crashed on `personIdLinks.ToDictionary(l => l.PersonId, ...)` and took the whole page down.

## Fixes

- **Fix 1 — don't crash (GameRolesViewService)**: switched the PersonId→UserId dictionary build to `GroupBy + First`, deterministically picking the earliest user Id by ordinal sort. Logs a warning with the offending PersonIds so an admin can clean up manually.
- **Fix 2 — guard against creating new duplicates (AccountLinkingService)**:
  - `LinkAsync`: now throws `InvalidOperationException("Another account is already linked to this Person. Unlink the existing link first.")` when the target Person is already claimed by a different user.
  - `AutoLinkHighConfidenceAsync`: still skips proposals whose target Person is already linked, but now logs each skipped proposal explicitly and includes a skipped-count in the summary log line.
  - `ProposeAsync`: already filtered out Persons that have any ApplicationUser pointing at them — comment clarified.
- **Program.cs**: `/admin/propojit-ucty/propojit` endpoint now catches `InvalidOperationException` as well as `ValidationException`, so the admin sees a friendly banner instead of a 500.
- **Version bump**: 0.9.21 → 0.9.22.

Fix 3 (admin banner listing existing duplicates with per-user Odpojit buttons) deferred to a follow-up — out of scope for the hotfix; once duplicates are cleaned up manually and Fix 2 is live, new duplicates can no longer be created.

## Audit

Grepped every `ToDictionary` across `src/RegistraceOvcina.Web/Features/`. Only `GameRolesViewService.cs:72` had the same-shape bug (keyed by a column that's *supposed* to be unique but isn't enforced at the DB level for ApplicationUser.PersonId). The rest are safe:
- `AccountLinkingService` lines 106, 114, 136 → already `GroupBy → List` (many values per key).
- `AccountLinkingService` lines 311, 475, 486 → keyed by PKs (`u.Id`, `p.Id`, grouped `EntityId`) which are guaranteed unique.
- `IntegrationApiEndpoints.cs:692` → feeds from an EF-side `GroupBy + Select First`, so server-side dedup protects it.
- `PeopleReviewService.cs:61`, `UserAdministrationService.cs:40`, `Email/MailboxSyncService.cs:142,157` → all `GroupBy` first.
- `GameRolesViewService.cs:60` → keyed by `NormalizedEmail`; ASP.NET Identity enforces uniqueness via `EmailIndex`, so safe.

## Test plan

New tests (all passing):

- [x] `GameRolesViewServiceTests.BuildAdultViewsAsync_does_not_crash_when_duplicate_personid_links_exist` — regression for the prod crash.
- [x] `AccountLinkingServiceTests.LinkAsync_throws_when_person_already_linked_to_another_user`
- [x] `AccountLinkingServiceTests.AutoLinkHighConfidenceAsync_skips_proposals_whose_person_already_linked`
- [x] `AccountLinkingServiceTests.ProposeAsync_excludes_persons_already_linked_to_another_user`
- [x] Full test suite green: 282 passed, 0 failed (278 baseline + 4 new).
- [x] `dotnet build` clean: 0 warnings, 0 errors.