### PR TITLE
feat(admin): Konflikty tab + warning for duplicate account links (v0.9.23)

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/AccountLinking.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/AccountLinking.razor
@@ -27,6 +27,13 @@
                     @if (proposals is not null)
                     {
                         <div class="d-flex flex-wrap gap-4">
+                            @if (conflicts.Count > 0)
+                            {
+                                <div>
+                                    <div class="small text-secondary">Konflikty</div>
+                                    <div class="h4 mb-0 text-danger" data-testid="conflicts-count">@conflicts.Count</div>
+                                </div>
+                            }
                             <div>
                                 <div class="small text-secondary">Vysoká shoda</div>
                                 <div class="h4 mb-0" data-testid="high-confidence-count">@proposals.HighConfidence.Count</div>
@@ -56,12 +63,39 @@
                 {
                     <div class="alert alert-danger mb-0" role="alert" data-testid="error-message">@errorMessage</div>
                 }
+
+                @if (conflicts.Count > 0 && activeTab != Tab.Conflicts)
+                {
+                    <div class="alert alert-warning mt-3 mb-0 d-flex justify-content-between align-items-center" role="alert" data-testid="conflicts-warning">
+                        <div>
+                            <strong>@conflicts.Count</strong> @ConflictNoun(conflicts.Count) má propojený víc než jeden účet.
+                            Zobrazit a vyřešit v záložce Konflikty.
+                        </div>
+                        <button type="button"
+                                class="btn btn-sm btn-outline-dark"
+                                @onclick="() => SwitchTab(Tab.Conflicts)"
+                                data-testid="conflicts-warning-link">
+                            Otevřít Konflikty
+                        </button>
+                    </div>
+                }
             </div>
         </section>
     </div>
 
     <div class="col-12">
         <ul class="nav nav-tabs" role="tablist">
+            @if (conflicts.Count > 0)
+            {
+                <li class="nav-item" role="presentation">
+                    <button type="button"
+                            class="nav-link text-danger @(activeTab == Tab.Conflicts ? "active" : "")"
+                            @onclick="() => SwitchTab(Tab.Conflicts)"
+                            data-testid="tab-conflicts">
+                        Konflikty <span class="badge text-bg-danger">@conflicts.Count</span>
+                    </button>
+                </li>
+            }
             <li class="nav-item" role="presentation">
                 <button type="button"
                         class="nav-link @(activeTab == Tab.High ? "active" : "")"
@@ -108,6 +142,9 @@
                 {
                     @switch (activeTab)
                     {
+                        case Tab.Conflicts:
+                            @RenderConflictsTab()
+                            break;
                         case Tab.High:
                             @RenderHighTab()
                             break;
@@ -128,11 +165,12 @@
 </div>
 
 @code {
-    private enum Tab { High, Medium, Unlinked, Linked }
+    private enum Tab { Conflicts, High, Medium, Unlinked, Linked }
 
     private ProposalBucket? proposals;
     private IReadOnlyList<UnlinkedPersonView> unlinkedPersons = Array.Empty<UnlinkedPersonView>();
     private IReadOnlyList<AlreadyLinkedView> linkedViews = Array.Empty<AlreadyLinkedView>();
+    private IReadOnlyList<LinkConflict> conflicts = Array.Empty<LinkConflict>();
     private Tab activeTab = Tab.High;
     private string? statusMessage;
     private string? errorMessage;
@@ -158,6 +196,7 @@
         {
             activeTab = tab.ToString() switch
             {
+                "conflicts" => Tab.Conflicts,
                 "medium" => Tab.Medium,
                 "unlinked" => Tab.Unlinked,
                 "linked" => Tab.Linked,
@@ -189,6 +228,7 @@
         proposals = await LinkingService.ProposeAsync(CancellationToken.None);
         unlinkedPersons = await LinkingService.ListUnlinkedPersonsAsync(CancellationToken.None);
         linkedViews = await LinkingService.ListLinkedAsync(CancellationToken.None);
+        conflicts = await LinkingService.ListConflictsAsync(CancellationToken.None);
     }
 
     private void SwitchTab(Tab tab)
@@ -600,5 +640,146 @@
         LinkSignal.SubmissionPrimaryContactMatch => "Shoda přihlášky a jména",
         LinkSignal.FuzzyNameMatch => "Podobnost jména",
         _ => signal.ToString()
+    };
+
+    // Czech grammar helper for the warning banner.
+    // 1 = "osoba", 2-4 = "osoby", 5+/0 = "osob". Plural form also used for "má/mají" — caller picks "má" for ≤4.
+    private static string ConflictNoun(int count) => count switch
+    {
+        1 => "osoba",
+        >= 2 and <= 4 => "osoby",
+        _ => "osob"
+    };
+
+    private RenderFragment RenderConflictsTab() => builder =>
+    {
+        builder.OpenElement(0, "div");
+
+        // Info banner.
+        builder.OpenElement(1, "div");
+        builder.AddAttribute(2, "class", "alert alert-info");
+        builder.AddAttribute(3, "data-testid", "conflicts-info");
+        builder.OpenElement(4, "p");
+        builder.AddAttribute(5, "class", "mb-1");
+        builder.AddContent(6, "Každá osoba by měla mít nejvýše jeden propojený účet.");
+        builder.CloseElement();
+        builder.OpenElement(7, "p");
+        builder.AddAttribute(8, "class", "mb-1");
+        builder.AddContent(9, "Nechte ten, který uživatel skutečně používá, a ostatní odpojte.");
+        builder.CloseElement();
+        builder.OpenElement(10, "p");
+        builder.AddAttribute(11, "class", "mb-0 small text-secondary");
+        builder.AddContent(12, "Odpojením účtu se nesmaže — jen se odstraní jeho propojení na osobu.");
+        builder.CloseElement();
+        builder.CloseElement();
+
+        if (conflicts.Count == 0)
+        {
+            builder.OpenElement(20, "p");
+            builder.AddAttribute(21, "class", "text-secondary mb-0");
+            builder.AddContent(22, "Žádné konflikty — každá osoba má nejvýše jeden propojený účet.");
+            builder.CloseElement();
+            builder.CloseElement();
+            return;
+        }
+
+        var seq = 100;
+        foreach (var c in conflicts)
+        {
+            builder.OpenElement(seq++, "section");
+            builder.AddAttribute(seq++, "class", "card mb-3");
+            builder.AddAttribute(seq++, "data-testid", $"conflict-person-{c.PersonId}");
+
+            // Person header.
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "card-header bg-warning-subtle");
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "d-flex flex-wrap gap-3 align-items-baseline");
+            builder.OpenElement(seq++, "strong");
+            builder.AddContent(seq++, c.PersonFullName);
+            builder.CloseElement();
+            if (c.PersonBirthYear > 0)
+            {
+                builder.OpenElement(seq++, "span");
+                builder.AddAttribute(seq++, "class", "small text-secondary");
+                builder.AddContent(seq++, $"Ročník {c.PersonBirthYear}");
+                builder.CloseElement();
+            }
+            builder.OpenElement(seq++, "span");
+            builder.AddAttribute(seq++, "class", "small text-secondary");
+            builder.AddContent(seq++, string.IsNullOrWhiteSpace(c.PersonEmail) ? "—" : c.PersonEmail!);
+            builder.CloseElement();
+            builder.OpenElement(seq++, "span");
+            builder.AddAttribute(seq++, "class", "badge text-bg-danger ms-auto");
+            builder.AddContent(seq++, $"{c.LinkedUsers.Count} účty");
+            builder.CloseElement();
+            builder.CloseElement();
+            builder.CloseElement();
+
+            // Users table.
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "card-body p-0");
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "table-responsive");
+            builder.OpenElement(seq++, "table");
+            builder.AddAttribute(seq++, "class", "table table-sm align-middle mb-0");
+            builder.AddMarkupContent(seq++, "<thead><tr><th>Účet</th><th>Propojeno</th><th>Poslední přihlášení</th><th class=\"text-end\">Akce</th></tr></thead>");
+            builder.OpenElement(seq++, "tbody");
+
+            foreach (var u in c.LinkedUsers)
+            {
+                builder.OpenElement(seq++, "tr");
+                builder.AddAttribute(seq++, "data-testid", $"conflict-user-{c.PersonId}-{u.UserId}");
+
+                builder.OpenElement(seq++, "td");
+                builder.OpenElement(seq++, "div");
+                builder.AddAttribute(seq++, "class", "fw-semibold");
+                builder.AddContent(seq++, u.UserEmail);
+                builder.CloseElement();
+                builder.OpenElement(seq++, "div");
+                builder.AddAttribute(seq++, "class", "small text-secondary");
+                builder.AddContent(seq++, u.UserDisplayName ?? "");
+                builder.CloseElement();
+                builder.CloseElement();
+
+                builder.OpenElement(seq++, "td");
+                builder.AddContent(seq++, u.LinkedAtUtc.HasValue ? CzechTime.Format(u.LinkedAtUtc.Value.UtcDateTime) : "—");
+                builder.CloseElement();
+
+                builder.OpenElement(seq++, "td");
+                builder.AddContent(seq++, u.LastLoginAtUtc.HasValue ? CzechTime.Format(u.LastLoginAtUtc.Value.UtcDateTime) : "—");
+                builder.CloseElement();
+
+                builder.OpenElement(seq++, "td");
+                builder.AddAttribute(seq++, "class", "text-end");
+                builder.OpenElement(seq++, "form");
+                builder.AddAttribute(seq++, "method", "post");
+                builder.AddAttribute(seq++, "action", "/admin/propojit-ucty/odpojit");
+                builder.AddAttribute(seq++, "onsubmit", "return confirm('Opravdu odpojit tento účet od osoby?');");
+                builder.OpenComponent<AntiforgeryToken>(seq++);
+                builder.CloseComponent();
+                builder.AddMarkupContent(seq++,
+                    $"<input type=\"hidden\" name=\"userId\" value=\"{System.Net.WebUtility.HtmlEncode(u.UserId)}\" />" +
+                    "<input type=\"hidden\" name=\"returnTab\" value=\"conflicts\" />");
+                builder.OpenElement(seq++, "button");
+                builder.AddAttribute(seq++, "type", "submit");
+                builder.AddAttribute(seq++, "class", "btn btn-sm btn-outline-danger");
+                builder.AddAttribute(seq++, "data-testid", $"conflict-unlink-{c.PersonId}-{u.UserId}");
+                builder.AddContent(seq++, "Odpojit");
+                builder.CloseElement();
+                builder.CloseElement();
+                builder.CloseElement();
+
+                builder.CloseElement(); // </tr>
+            }
+
+            builder.CloseElement(); // </tbody>
+            builder.CloseElement(); // </table>
+            builder.CloseElement(); // </div>
+            builder.CloseElement(); // </div> card-body
+            builder.CloseElement(); // </section>
+        }
+
+        builder.CloseElement(); // outer div
     };
 }

--- a/src/RegistraceOvcina.Web/Features/AccountLinking/AccountLinkingService.cs
+++ b/src/RegistraceOvcina.Web/Features/AccountLinking/AccountLinkingService.cs
@@ -46,6 +46,20 @@ public sealed record UserPickerResult(
     string Email,
     string? DisplayName);
 
+public sealed record ConflictUser(
+    string UserId,
+    string UserEmail,
+    string? UserDisplayName,
+    DateTimeOffset? LinkedAtUtc,
+    DateTimeOffset? LastLoginAtUtc);
+
+public sealed record LinkConflict(
+    int PersonId,
+    string PersonFullName,
+    int PersonBirthYear,
+    string? PersonEmail,
+    IReadOnlyList<ConflictUser> LinkedUsers);
+
 public interface IAccountLinkingService
 {
     Task<ProposalBucket> ProposeAsync(CancellationToken ct);
@@ -55,6 +69,7 @@ public interface IAccountLinkingService
     Task<IReadOnlyList<AlreadyLinkedView>> ListLinkedAsync(CancellationToken ct);
     Task<IReadOnlyList<UnlinkedPersonView>> ListUnlinkedPersonsAsync(CancellationToken ct);
     Task<IReadOnlyList<UserPickerResult>> SearchUsersAsync(string query, int limit, CancellationToken ct);
+    Task<IReadOnlyList<LinkConflict>> ListConflictsAsync(CancellationToken ct);
 }
 
 public sealed class AccountLinkingService(
@@ -576,6 +591,93 @@ public sealed class AccountLinkingService(
             .ToListAsync(ct);
 
         return results;
+    }
+
+    public async Task<IReadOnlyList<LinkConflict>> ListConflictsAsync(CancellationToken ct)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
+        // A conflict is a Person with >1 ApplicationUser pointing at it via PersonId.
+        // Pull every linked user, group client-side by PersonId, and keep only groups of >= 2.
+        var linkedUsers = await db.Users.AsNoTracking()
+            .Where(u => u.PersonId != null)
+            .Select(u => new
+            {
+                u.Id,
+                Email = u.Email ?? "",
+                u.DisplayName,
+                PersonId = u.PersonId!.Value,
+                u.LastLoginAtUtc
+            })
+            .ToListAsync(ct);
+
+        var conflictGroups = linkedUsers
+            .GroupBy(u => u.PersonId)
+            .Where(g => g.Count() > 1)
+            .ToList();
+
+        if (conflictGroups.Count == 0) return Array.Empty<LinkConflict>();
+
+        var personIds = conflictGroups.Select(g => g.Key).ToList();
+        var persons = await db.People.AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(p => personIds.Contains(p.Id))
+            .Select(p => new { p.Id, p.FirstName, p.LastName, p.BirthYear, p.Email })
+            .ToListAsync(ct);
+        var personsById = persons.ToDictionary(p => p.Id, p => p);
+
+        // Pull latest LinkAccount audit timestamp per user for the conflicted users only.
+        var conflictUserIds = conflictGroups.SelectMany(g => g.Select(u => u.Id)).ToList();
+        var linkAuditDates = await db.AuditLogs.AsNoTracking()
+            .Where(a => a.EntityType == nameof(ApplicationUser)
+                        && a.Action == "LinkAccount"
+                        && conflictUserIds.Contains(a.EntityId))
+            .GroupBy(a => a.EntityId)
+            .Select(g => new { UserId = g.Key, LinkedAt = g.Max(x => x.CreatedAtUtc) })
+            .ToListAsync(ct);
+        var linkedAtByUser = linkAuditDates.ToDictionary(x => x.UserId, x => x.LinkedAt);
+
+        var conflicts = new List<LinkConflict>(conflictGroups.Count);
+        foreach (var group in conflictGroups)
+        {
+            var users = group
+                .Select(u =>
+                {
+                    DateTimeOffset? linkedAt = linkedAtByUser.TryGetValue(u.Id, out var dt)
+                        ? new DateTimeOffset(DateTime.SpecifyKind(dt, DateTimeKind.Utc))
+                        : null;
+                    DateTimeOffset? lastLogin = u.LastLoginAtUtc.HasValue
+                        ? new DateTimeOffset(DateTime.SpecifyKind(u.LastLoginAtUtc.Value, DateTimeKind.Utc))
+                        : null;
+                    return new ConflictUser(u.Id, u.Email, u.DisplayName, linkedAt, lastLogin);
+                })
+                // Most recent LinkedAt first; nulls go last. Stable tiebreaker on email.
+                .OrderByDescending(u => u.LinkedAtUtc ?? DateTimeOffset.MinValue)
+                .ThenBy(u => u.UserEmail, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            string personFullName;
+            int birthYear;
+            string? personEmail;
+            if (personsById.TryGetValue(group.Key, out var p))
+            {
+                personFullName = FullName(p.FirstName, p.LastName);
+                birthYear = p.BirthYear;
+                personEmail = p.Email;
+            }
+            else
+            {
+                personFullName = $"[Osoba #{group.Key}]";
+                birthYear = 0;
+                personEmail = null;
+            }
+
+            conflicts.Add(new LinkConflict(group.Key, personFullName, birthYear, personEmail, users));
+        }
+
+        return conflicts
+            .OrderBy(c => c.PersonFullName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 
     // ---- helpers ----

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -772,7 +772,7 @@ public class Program
             .RequireAuthorization(AuthorizationPolicies.AdminOnly);
         app.MapPost(
                 "/admin/propojit-ucty/odpojit",
-                async ([FromForm] string userId, HttpContext httpContext, UserManager<ApplicationUser> userManager, IAccountLinkingService accountLinkingService, CancellationToken ct) =>
+                async ([FromForm] string userId, [FromForm] string? returnTab, HttpContext httpContext, UserManager<ApplicationUser> userManager, IAccountLinkingService accountLinkingService, CancellationToken ct) =>
                 {
                     var user = await userManager.GetUserAsync(httpContext.User);
                     if (user is null)
@@ -783,7 +783,8 @@ public class Program
                     try
                     {
                         await accountLinkingService.UnlinkAsync(userId, user.Id, ct);
-                        return Results.LocalRedirect("/admin/propojit-ucty?status=unlinked&tab=linked");
+                        var tab = string.IsNullOrWhiteSpace(returnTab) ? "linked" : returnTab;
+                        return Results.LocalRedirect($"/admin/propojit-ucty?status=unlinked&tab={Uri.EscapeDataString(tab)}");
                     }
                     catch (ValidationException ex)
                     {

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.22</Version>
+    <Version>0.9.23</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/AccountLinking/AccountLinkingServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/AccountLinking/AccountLinkingServiceTests.cs
@@ -629,6 +629,253 @@ public sealed class AccountLinkingServiceTests
         Assert.Empty(bucket.MediumConfidence);
     }
 
+    // 16a -----------------------------------------------------------
+    // v0.9.23: ListConflictsAsync exposes Persons with >1 linked ApplicationUser
+    // so the admin can clean them up via the new Konflikty tab.
+    [Fact]
+    public async Task ListConflictsAsync_empty_when_no_duplicates()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var person = new Person
+            {
+                FirstName = "Alice",
+                LastName = "Solo",
+                BirthYear = 1990,
+                Email = "alice@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+
+            var user = CreateUser("user-1", "Alice", "alice@example.cz");
+            user.PersonId = person.Id;
+            db.Users.Add(user);
+            db.Users.Add(CreateUser("user-unlinked", "Nobody", "nobody@example.cz"));
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var conflicts = await service.ListConflictsAsync(CancellationToken.None);
+
+        Assert.Empty(conflicts);
+    }
+
+    // 16b -----------------------------------------------------------
+    [Fact]
+    public async Task ListConflictsAsync_returns_each_person_with_multiple_links()
+    {
+        var options = CreateOptions();
+        int personIdA, personIdB;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var personA = new Person
+            {
+                FirstName = "Alice",
+                LastName = "Conflicted",
+                BirthYear = 1990,
+                Email = "alice@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            var personB = new Person
+            {
+                FirstName = "Bob",
+                LastName = "AlsoConflicted",
+                BirthYear = 1985,
+                Email = null,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.AddRange(personA, personB);
+            await db.SaveChangesAsync();
+            personIdA = personA.Id;
+            personIdB = personB.Id;
+
+            // Two users on personA.
+            var a1 = CreateUser("user-a1", "Alice One", "a1@example.cz");
+            a1.PersonId = personIdA;
+            var a2 = CreateUser("user-a2", "Alice Two", "a2@example.cz");
+            a2.PersonId = personIdA;
+
+            // Three users on personB.
+            var b1 = CreateUser("user-b1", "Bob One", "b1@example.cz");
+            b1.PersonId = personIdB;
+            var b2 = CreateUser("user-b2", "Bob Two", "b2@example.cz");
+            b2.PersonId = personIdB;
+            var b3 = CreateUser("user-b3", "Bob Three", "b3@example.cz");
+            b3.PersonId = personIdB;
+
+            db.Users.AddRange(a1, a2, b1, b2, b3);
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var conflicts = await service.ListConflictsAsync(CancellationToken.None);
+
+        Assert.Equal(2, conflicts.Count);
+
+        var aliceConflict = Assert.Single(conflicts, c => c.PersonId == personIdA);
+        Assert.Equal("Alice Conflicted", aliceConflict.PersonFullName);
+        Assert.Equal(1990, aliceConflict.PersonBirthYear);
+        Assert.Equal("alice@example.cz", aliceConflict.PersonEmail);
+        Assert.Equal(2, aliceConflict.LinkedUsers.Count);
+
+        var bobConflict = Assert.Single(conflicts, c => c.PersonId == personIdB);
+        Assert.Equal(3, bobConflict.LinkedUsers.Count);
+        Assert.Null(bobConflict.PersonEmail);
+    }
+
+    // 16c -----------------------------------------------------------
+    [Fact]
+    public async Task ListConflictsAsync_includes_linkedat_from_auditlog()
+    {
+        var options = CreateOptions();
+        int personId;
+        var olderAudit = new DateTime(2026, 3, 1, 10, 0, 0, DateTimeKind.Utc);
+        var newerAudit = new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var person = new Person
+            {
+                FirstName = "Alice",
+                LastName = "WithAudit",
+                BirthYear = 1990,
+                Email = null,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+
+            var u1 = CreateUser("user-older", "Older", "older@example.cz");
+            u1.PersonId = personId;
+            var u2 = CreateUser("user-newer", "Newer", "newer@example.cz");
+            u2.PersonId = personId;
+            db.Users.AddRange(u1, u2);
+
+            db.AuditLogs.AddRange(
+                new AuditLog
+                {
+                    EntityType = "ApplicationUser",
+                    EntityId = "user-older",
+                    Action = "LinkAccount",
+                    ActorUserId = ActorId,
+                    CreatedAtUtc = olderAudit,
+                    DetailsJson = "{}"
+                },
+                new AuditLog
+                {
+                    EntityType = "ApplicationUser",
+                    EntityId = "user-newer",
+                    Action = "LinkAccount",
+                    ActorUserId = ActorId,
+                    CreatedAtUtc = newerAudit,
+                    DetailsJson = "{}"
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var conflicts = await service.ListConflictsAsync(CancellationToken.None);
+
+        var conflict = Assert.Single(conflicts);
+        var olderUser = Assert.Single(conflict.LinkedUsers, u => u.UserId == "user-older");
+        var newerUser = Assert.Single(conflict.LinkedUsers, u => u.UserId == "user-newer");
+        Assert.NotNull(olderUser.LinkedAtUtc);
+        Assert.NotNull(newerUser.LinkedAtUtc);
+        Assert.Equal(olderAudit, olderUser.LinkedAtUtc!.Value.UtcDateTime);
+        Assert.Equal(newerAudit, newerUser.LinkedAtUtc!.Value.UtcDateTime);
+    }
+
+    // 16d -----------------------------------------------------------
+    [Fact]
+    public async Task ListConflictsAsync_users_ordered_most_recent_first()
+    {
+        var options = CreateOptions();
+        int personId;
+        var oldest = new DateTime(2026, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+        var middle = new DateTime(2026, 3, 1, 10, 0, 0, DateTimeKind.Utc);
+        var newest = new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc);
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var person = new Person
+            {
+                FirstName = "Shared",
+                LastName = "Ordered",
+                BirthYear = 1990,
+                Email = null,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+
+            var u1 = CreateUser("user-oldest", "Old", "old@example.cz");
+            u1.PersonId = personId;
+            var u2 = CreateUser("user-middle", "Mid", "mid@example.cz");
+            u2.PersonId = personId;
+            var u3 = CreateUser("user-newest", "New", "new@example.cz");
+            u3.PersonId = personId;
+            db.Users.AddRange(u1, u2, u3);
+
+            db.AuditLogs.AddRange(
+                new AuditLog { EntityType = "ApplicationUser", EntityId = "user-oldest", Action = "LinkAccount", ActorUserId = ActorId, CreatedAtUtc = oldest, DetailsJson = "{}" },
+                new AuditLog { EntityType = "ApplicationUser", EntityId = "user-middle", Action = "LinkAccount", ActorUserId = ActorId, CreatedAtUtc = middle, DetailsJson = "{}" },
+                new AuditLog { EntityType = "ApplicationUser", EntityId = "user-newest", Action = "LinkAccount", ActorUserId = ActorId, CreatedAtUtc = newest, DetailsJson = "{}" });
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var conflicts = await service.ListConflictsAsync(CancellationToken.None);
+
+        var conflict = Assert.Single(conflicts);
+        var orderedIds = conflict.LinkedUsers.Select(u => u.UserId).ToList();
+        Assert.Equal(new[] { "user-newest", "user-middle", "user-oldest" }, orderedIds);
+    }
+
+    // 16e -----------------------------------------------------------
+    // Regression guard: a Person with exactly one linked user is the normal state,
+    // and must NEVER appear on the conflicts list.
+    [Fact]
+    public async Task ListConflictsAsync_single_linked_user_not_listed()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var person = new Person
+            {
+                FirstName = "Alice",
+                LastName = "Normal",
+                BirthYear = 1990,
+                Email = "alice@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+
+            var user = CreateUser("user-1", "Alice", "alice@example.cz");
+            user.PersonId = person.Id;
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var conflicts = await service.ListConflictsAsync(CancellationToken.None);
+
+        Assert.Empty(conflicts);
+    }
+
     // 15 -----------------------------------------------------------
     [Fact]
     public async Task SearchUsersAsync_matches_email_and_displayname()


### PR DESCRIPTION
## Summary
- Adds a new **Konflikty** tab to `/admin/propojit-ucty` so the organizer can resolve Persons with >1 linked ApplicationUser — the underlying data issue the v0.9.22 hotfix merely tolerated.
- New `IAccountLinkingService.ListConflictsAsync` returns each conflicting Person plus every linked user, ordered most-recent-link-first, with LinkedAt (from AuditLog) and LastLoginAt.
- Each row has an **Odpojit** button that reuses the existing `UnlinkAsync` flow; when only 1 user remains the conflict disappears naturally.
- Cross-tab warning banner shown above the tab nav whenever conflicts exist, with a button to jump to the Konflikty tab.
- Tab placement: **first** when conflicts exist (hidden entirely when zero) — most-urgent-issue-first.
- Bumps version to **0.9.23**.

## Service signature

```csharp
Task<IReadOnlyList<LinkConflict>> ListConflictsAsync(CancellationToken ct);

public sealed record LinkConflict(
    int PersonId,
    string PersonFullName,
    int PersonBirthYear,        // Person.BirthYear is non-nullable int in this codebase
    string? PersonEmail,
    IReadOnlyList<ConflictUser> LinkedUsers);

public sealed record ConflictUser(
    string UserId,
    string UserEmail,
    string? UserDisplayName,
    DateTimeOffset? LinkedAtUtc,
    DateTimeOffset? LastLoginAtUtc);  // sourced from ApplicationUser.LastLoginAtUtc
```

Note: `ApplicationUser.LastSignInAtUtc` does **not** exist in this codebase — the existing column is `LastLoginAtUtc`. Used that instead of fabricating.

## Test plan
- [x] Baseline + 5 new tests: `ListConflictsAsync_empty_when_no_duplicates`, `..._returns_each_person_with_multiple_links`, `..._includes_linkedat_from_auditlog`, `..._users_ordered_most_recent_first`, `..._single_linked_user_not_listed`
- [x] `dotnet test` on `RegistraceOvcina.Web.Tests`: **287 passed, 0 failed** (baseline 282 + 5 new)
- [x] Build clean, only pre-existing NU1903 warnings
- [ ] Manual: visit `/admin/propojit-ucty` on staging with seeded duplicate — confirm Konflikty tab appears, Odpojit works, warning banner jumps correctly