### PR TITLE
feat(roles): grouping mode toggle (Přidělené / Zvolené / Obě) (v0.9.25)

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameRoles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameRoles.razor
@@ -52,6 +52,24 @@ else
 
     @if (groupByRole)
     {
+        <div class="btn-group btn-group-sm mb-3" role="group" aria-label="Režim seskupení">
+            <button type="button" class="btn @(groupingMode == GroupingMode.Assigned ? "btn-primary" : "btn-outline-primary")"
+                    @onclick='() => SetGroupingMode(GroupingMode.Assigned)'>Přidělené</button>
+            <button type="button" class="btn @(groupingMode == GroupingMode.SelfDeclared ? "btn-primary" : "btn-outline-primary")"
+                    @onclick='() => SetGroupingMode(GroupingMode.SelfDeclared)'>Zvolené</button>
+            <button type="button" class="btn @(groupingMode == GroupingMode.Both ? "btn-primary" : "btn-outline-primary")"
+                    @onclick='() => SetGroupingMode(GroupingMode.Both)'>Obě</button>
+        </div>
+        <div class="text-secondary small mb-3">
+            @(groupingMode switch
+            {
+                GroupingMode.Assigned => "Zobrazuji jen dospělé s oficiálně přiřazenou rolí (GameRole).",
+                GroupingMode.SelfDeclared => "Zobrazuji jen dospělé, kteří si roli zvolili při registraci.",
+                GroupingMode.Both => "Zobrazuji union obou zdrojů.",
+                _ => ""
+            })
+        </div>
+
         @foreach (var group in GetRoleGroups())
         {
             <div class="mb-4">
@@ -213,6 +231,7 @@ else
     private List<AdultRoleView>? adults;
     private List<string> availableGameRoles = [];
     private bool groupByRole;
+    private GroupingMode groupingMode = GroupingMode.Assigned;
     private bool sortDescending;
     private string currentUserId = "";
 
@@ -296,12 +315,18 @@ else
     private List<RoleGroup> GetRoleGroups()
     {
         if (adults is null) return [];
-        return GameRolesViewService.GroupAdultsByRole(adults);
+        return GameRolesViewService.GroupAdultsByRole(adults, groupingMode);
     }
 
     private void ToggleSort() => sortDescending = !sortDescending;
 
     private void ToggleGrouping() => groupByRole = !groupByRole;
+
+    private void SetGroupingMode(GroupingMode mode)
+    {
+        groupingMode = mode;
+        StateHasChanged();
+    }
 
     private List<AdultRoleView> SortAdults(IEnumerable<AdultRoleView> source) =>
         sortDescending

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameRoles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameRoles.razor
@@ -54,10 +54,13 @@ else
     {
         <div class="btn-group btn-group-sm mb-3" role="group" aria-label="Režim seskupení">
             <button type="button" class="btn @(groupingMode == GroupingMode.Assigned ? "btn-primary" : "btn-outline-primary")"
+                    aria-pressed="@(groupingMode == GroupingMode.Assigned)"
                     @onclick='() => SetGroupingMode(GroupingMode.Assigned)'>Přidělené</button>
             <button type="button" class="btn @(groupingMode == GroupingMode.SelfDeclared ? "btn-primary" : "btn-outline-primary")"
+                    aria-pressed="@(groupingMode == GroupingMode.SelfDeclared)"
                     @onclick='() => SetGroupingMode(GroupingMode.SelfDeclared)'>Zvolené</button>
             <button type="button" class="btn @(groupingMode == GroupingMode.Both ? "btn-primary" : "btn-outline-primary")"
+                    aria-pressed="@(groupingMode == GroupingMode.Both)"
                     @onclick='() => SetGroupingMode(GroupingMode.Both)'>Obě</button>
         </div>
         <div class="text-secondary small mb-3">
@@ -322,11 +325,7 @@ else
 
     private void ToggleGrouping() => groupByRole = !groupByRole;
 
-    private void SetGroupingMode(GroupingMode mode)
-    {
-        groupingMode = mode;
-        StateHasChanged();
-    }
+    private void SetGroupingMode(GroupingMode mode) => groupingMode = mode;
 
     private List<AdultRoleView> SortAdults(IEnumerable<AdultRoleView> source) =>
         sortDescending

--- a/src/RegistraceOvcina.Web/Features/Roles/GameRolesViewService.cs
+++ b/src/RegistraceOvcina.Web/Features/Roles/GameRolesViewService.cs
@@ -210,7 +210,7 @@ public sealed class GameRolesViewService(
             GroupingMode.Assigned => assigned,
             GroupingMode.SelfDeclared => selfDeclared,
             GroupingMode.Both => selfDeclared || assigned,
-            _ => selfDeclared || assigned
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown GroupingMode.")
         };
     }
 
@@ -221,7 +221,7 @@ public sealed class GameRolesViewService(
             GroupingMode.Assigned => a.AssignedGameRoles.Count == 0,
             GroupingMode.SelfDeclared => a.AdultRoles == AdultRoleFlags.None,
             GroupingMode.Both => a.AdultRoles == AdultRoleFlags.None && a.AssignedGameRoles.Count == 0,
-            _ => a.AdultRoles == AdultRoleFlags.None && a.AssignedGameRoles.Count == 0
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown GroupingMode.")
         };
     }
 
@@ -267,7 +267,7 @@ public sealed record RoleGroup(string RoleName, List<AdultRoleView> Adults);
 /// </summary>
 public enum GroupingMode
 {
-    /// <summary>Only officially assigned GameRoles (operational view). Default.</summary>
+    /// <summary>Only officially assigned GameRoles (operational view). Page-level default on /organizace/role.</summary>
     Assigned,
 
     /// <summary>Only self-declared AdultRoles flags from registration (recruitment view).</summary>

--- a/src/RegistraceOvcina.Web/Features/Roles/GameRolesViewService.cs
+++ b/src/RegistraceOvcina.Web/Features/Roles/GameRolesViewService.cs
@@ -145,24 +145,40 @@ public sealed class GameRolesViewService(
     /// Groups adults by <see cref="AdultRoleFlags"/> using the 5 canonical labels
     /// (Příšera, Pomocník, Technická pomoc, Hraničář, Přihlížející).
     ///
-    /// For each of the 5 roles, an adult appears in the group if EITHER:
-    ///   - their AdultRoles flags include the matching flag (self-declared), OR
-    ///   - they have an officially assigned matching GameRole (mapped to the same label).
+    /// Overload kept for backwards compatibility — defaults to <see cref="GroupingMode.Both"/>
+    /// (the v0.9.20 union behavior).
+    /// </summary>
+    public static List<RoleGroup> GroupAdultsByRole(IReadOnlyList<AdultRoleView> adults)
+        => GroupAdultsByRole(adults, GroupingMode.Both);
+
+    /// <summary>
+    /// Groups adults by <see cref="AdultRoleFlags"/> using the 5 canonical labels
+    /// (Příšera, Pomocník, Technická pomoc, Hraničář, Přihlížející).
     ///
-    /// An adult with multiple flags appears in multiple groups.
-    /// Adults with neither a flag nor an assignment land in a 6th "Nezvoleno" group.
+    /// Per-role filter depends on <paramref name="mode"/>:
+    ///   - <see cref="GroupingMode.Assigned"/>: adult appears iff their AssignedGameRoles list
+    ///     contains a mapped role name (officially assigned; operational view).
+    ///   - <see cref="GroupingMode.SelfDeclared"/>: adult appears iff their AdultRoles flags
+    ///     include the matching flag (self-declared during registration; recruitment view).
+    ///   - <see cref="GroupingMode.Both"/>: union of the two (v0.9.20 behavior).
+    ///
+    /// Catch-all "Nezvoleno" bucket:
+    ///   - Assigned: adults with NO assigned game role (regardless of flags).
+    ///   - SelfDeclared: adults with NO self-declared flag (regardless of assignments).
+    ///   - Both: adults with NEITHER flag NOR assigned role.
+    ///
+    /// An adult with multiple qualifying flags/assignments appears in multiple groups.
     /// Each group is sorted by LastName, then FirstName (case-insensitive).
     /// Empty groups are dropped.
     /// </summary>
-    public static List<RoleGroup> GroupAdultsByRole(IReadOnlyList<AdultRoleView> adults)
+    public static List<RoleGroup> GroupAdultsByRole(IReadOnlyList<AdultRoleView> adults, GroupingMode mode)
     {
         var result = new List<RoleGroup>(6);
 
         foreach (var (label, flag, assignedRoleNames) in RoleMappings)
         {
             var inGroup = adults
-                .Where(a => a.AdultRoles.HasFlag(flag)
-                    || a.AssignedGameRoles.Any(r => assignedRoleNames.Contains(r, StringComparer.OrdinalIgnoreCase)))
+                .Where(a => Matches(a, flag, assignedRoleNames, mode))
                 .OrderBy(a => a.LastName, StringComparer.CurrentCultureIgnoreCase)
                 .ThenBy(a => a.FirstName, StringComparer.CurrentCultureIgnoreCase)
                 .ToList();
@@ -171,9 +187,9 @@ public sealed class GameRolesViewService(
                 result.Add(new RoleGroup(label, inGroup));
         }
 
-        // Catch-all bucket: no self-declared flag AND no assigned game role.
+        // Catch-all bucket depends on mode.
         var uncategorized = adults
-            .Where(a => a.AdultRoles == AdultRoleFlags.None && a.AssignedGameRoles.Count == 0)
+            .Where(a => IsUncategorized(a, mode))
             .OrderBy(a => a.LastName, StringComparer.CurrentCultureIgnoreCase)
             .ThenBy(a => a.FirstName, StringComparer.CurrentCultureIgnoreCase)
             .ToList();
@@ -182,6 +198,31 @@ public sealed class GameRolesViewService(
             result.Add(new RoleGroup("Nezvoleno", uncategorized));
 
         return result;
+    }
+
+    private static bool Matches(AdultRoleView a, AdultRoleFlags flag, string[] assignedRoleNames, GroupingMode mode)
+    {
+        var selfDeclared = a.AdultRoles.HasFlag(flag);
+        var assigned = a.AssignedGameRoles.Any(r => assignedRoleNames.Contains(r, StringComparer.OrdinalIgnoreCase));
+
+        return mode switch
+        {
+            GroupingMode.Assigned => assigned,
+            GroupingMode.SelfDeclared => selfDeclared,
+            GroupingMode.Both => selfDeclared || assigned,
+            _ => selfDeclared || assigned
+        };
+    }
+
+    private static bool IsUncategorized(AdultRoleView a, GroupingMode mode)
+    {
+        return mode switch
+        {
+            GroupingMode.Assigned => a.AssignedGameRoles.Count == 0,
+            GroupingMode.SelfDeclared => a.AdultRoles == AdultRoleFlags.None,
+            GroupingMode.Both => a.AdultRoles == AdultRoleFlags.None && a.AssignedGameRoles.Count == 0,
+            _ => a.AdultRoles == AdultRoleFlags.None && a.AssignedGameRoles.Count == 0
+        };
     }
 
     /// <summary>
@@ -220,3 +261,18 @@ public sealed class AdultRoleView
 }
 
 public sealed record RoleGroup(string RoleName, List<AdultRoleView> Adults);
+
+/// <summary>
+/// Selects which side of the "role" relationship the grouping on /organizace/role filters by.
+/// </summary>
+public enum GroupingMode
+{
+    /// <summary>Only officially assigned GameRoles (operational view). Default.</summary>
+    Assigned,
+
+    /// <summary>Only self-declared AdultRoles flags from registration (recruitment view).</summary>
+    SelfDeclared,
+
+    /// <summary>Union of Assigned and SelfDeclared (v0.9.20 behavior; fullest view).</summary>
+    Both
+}

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.24</Version>
+    <Version>0.9.25</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/Roles/GameRolesViewServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/Roles/GameRolesViewServiceTests.cs
@@ -273,6 +273,135 @@ public sealed class GameRolesViewServiceTests
     }
 
     // ---------------------------------------------------------------
+    // GroupAdultsByRole — GroupingMode (v0.9.25)
+    // ---------------------------------------------------------------
+
+    // Seed shared by the three mode-comparison tests:
+    //   A — self-declared PlayMonster only (no assignment)
+    //   B — assigned "npc" only (no flag)
+    //   C — both self-declared PlayMonster AND assigned "npc"
+    private static List<AdultRoleView> SeedABC() =>
+    [
+        new()
+        {
+            LastName = "Alpha", FirstName = "A",
+            AdultRoles = AdultRoleFlags.PlayMonster,
+            AssignedGameRoles = []
+        },
+        new()
+        {
+            LastName = "Beta", FirstName = "B",
+            AdultRoles = AdultRoleFlags.None,
+            AssignedGameRoles = ["npc"]
+        },
+        new()
+        {
+            LastName = "Ceta", FirstName = "C",
+            AdultRoles = AdultRoleFlags.PlayMonster,
+            AssignedGameRoles = ["npc"]
+        }
+    ];
+
+    [Fact]
+    public void GroupByRole_AssignedMode_only_shows_assigned()
+    {
+        var adults = SeedABC();
+
+        var groups = GameRolesViewService.GroupAdultsByRole(adults, GroupingMode.Assigned);
+
+        var monster = groups.Single(g => g.RoleName == "Příšera").Adults;
+        Assert.Equal(2, monster.Count);
+        Assert.Contains(monster, a => a.LastName == "Beta");
+        Assert.Contains(monster, a => a.LastName == "Ceta");
+        Assert.DoesNotContain(monster, a => a.LastName == "Alpha");
+    }
+
+    [Fact]
+    public void GroupByRole_SelfDeclaredMode_only_shows_selfdeclared()
+    {
+        var adults = SeedABC();
+
+        var groups = GameRolesViewService.GroupAdultsByRole(adults, GroupingMode.SelfDeclared);
+
+        var monster = groups.Single(g => g.RoleName == "Příšera").Adults;
+        Assert.Equal(2, monster.Count);
+        Assert.Contains(monster, a => a.LastName == "Alpha");
+        Assert.Contains(monster, a => a.LastName == "Ceta");
+        Assert.DoesNotContain(monster, a => a.LastName == "Beta");
+    }
+
+    [Fact]
+    public void GroupByRole_BothMode_union()
+    {
+        var adults = SeedABC();
+
+        var groups = GameRolesViewService.GroupAdultsByRole(adults, GroupingMode.Both);
+
+        var monster = groups.Single(g => g.RoleName == "Příšera").Adults;
+        Assert.Equal(3, monster.Count);
+        Assert.Contains(monster, a => a.LastName == "Alpha");
+        Assert.Contains(monster, a => a.LastName == "Beta");
+        Assert.Contains(monster, a => a.LastName == "Ceta");
+    }
+
+    [Fact]
+    public void GroupByRole_AssignedMode_catchall_is_adults_without_any_assignment()
+    {
+        // Self-declared PlayMonster adult with NO assignment must land in "Nezvoleno"
+        // under Assigned mode — because they have no officially assigned role yet.
+        // An adult with an assignment but no flag must NOT land in the catch-all.
+        var adults = new List<AdultRoleView>
+        {
+            new()
+            {
+                LastName = "Flagged", FirstName = "F",
+                AdultRoles = AdultRoleFlags.PlayMonster,
+                AssignedGameRoles = []
+            },
+            new()
+            {
+                LastName = "Assigned", FirstName = "A",
+                AdultRoles = AdultRoleFlags.None,
+                AssignedGameRoles = ["npc"]
+            }
+        };
+
+        var groups = GameRolesViewService.GroupAdultsByRole(adults, GroupingMode.Assigned);
+
+        var uncategorized = groups.Single(g => g.RoleName == "Nezvoleno").Adults;
+        Assert.Single(uncategorized);
+        Assert.Equal("Flagged", uncategorized[0].LastName);
+    }
+
+    [Fact]
+    public void GroupByRole_SelfDeclaredMode_catchall_is_adults_without_any_flag()
+    {
+        // Adult with assignment but NO flag must land in "Nezvoleno" under SelfDeclared mode.
+        // An adult with a flag but no assignment must NOT land in the catch-all.
+        var adults = new List<AdultRoleView>
+        {
+            new()
+            {
+                LastName = "Flagged", FirstName = "F",
+                AdultRoles = AdultRoleFlags.PlayMonster,
+                AssignedGameRoles = []
+            },
+            new()
+            {
+                LastName = "Assigned", FirstName = "A",
+                AdultRoles = AdultRoleFlags.None,
+                AssignedGameRoles = ["npc"]
+            }
+        };
+
+        var groups = GameRolesViewService.GroupAdultsByRole(adults, GroupingMode.SelfDeclared);
+
+        var uncategorized = groups.Single(g => g.RoleName == "Nezvoleno").Adults;
+        Assert.Single(uncategorized);
+        Assert.Equal("Assigned", uncategorized[0].LastName);
+    }
+
+    // ---------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- New 3-mode segmented toggle on `/organizace/role` replaces the v0.9.20 union-only grouping. Default is **Přidělené** (operational view — only adults with a GameRole assignment for this game). **Zvolené** shows the self-declared `AdultRoles` recruitment view. **Obě** preserves the v0.9.20 union behavior.
- `GameRolesViewService.GroupAdultsByRole` gains a `GroupingMode` parameter; the existing single-arg overload is kept (defaults to `Both`) so test and other callers keep working.
- Catch-all `Nezvoleno` bucket is mode-aware: Assigned = no assignment, SelfDeclared = no flag, Both = neither. Toggle state is page-local — not persisted across sessions.
- Version bump 0.9.24 → 0.9.25.

## UX decisions

- Segmented control lives **inside** the grouping section (only visible when grouping is on), not above the page header — keeps the dashboard clean when grouping is off.
- Default **Přidělené** matches the user's stated operational workflow: "who is officially playing which role right now."
- Czech info strings under the buttons explain each mode so the distinction between "přiřazená" (GameRole) and "zvolená" (AdultRoleFlags) is unambiguous.
- No persistence — each page load starts fresh on Přidělené.

## Test plan

- [x] `dotnet build` — succeeds
- [x] `dotnet test` — 304 pass (299 + 5 new), 0 fail
- [x] New tests: Assigned-only visibility, SelfDeclared-only visibility, Both-union regression guard, Assigned-mode catch-all, SelfDeclared-mode catch-all
- [ ] Manual smoke on `/organizace/role`: toggle grouping, switch modes, verify adults appear/disappear per mode, verify catch-all matches mode semantics