### PR TITLE
feat(admin): sortable columns on Osoby bez účtu tab (v0.9.27)

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/AccountLinking.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/AccountLinking.razor
@@ -218,16 +218,27 @@
         };
 
     // Null/empty values sort last regardless of direction, so empty cells don't dominate the top of the list.
+    // Primary key IsMissing=false sorts before IsMissing=true; secondary key is the value in the chosen direction.
+    // Keeps the sort key evaluated once per row.
     private static IEnumerable<T> SortByNullableString<T>(
         IEnumerable<T> rows, Func<T, string?> key, bool desc)
     {
-        var materialized = rows as IList<T> ?? rows.ToList();
-        var withValue = materialized.Where(r => !string.IsNullOrWhiteSpace(key(r)));
-        var withoutValue = materialized.Where(r => string.IsNullOrWhiteSpace(key(r)));
+        var projected = rows.Select(r =>
+        {
+            var value = key(r);
+            var isMissing = string.IsNullOrWhiteSpace(value);
+            return new { Row = r, IsMissing = isMissing, Value = isMissing ? null : value };
+        });
+
         var sorted = desc
-            ? withValue.OrderByDescending(r => key(r), StringComparer.OrdinalIgnoreCase)
-            : withValue.OrderBy(r => key(r), StringComparer.OrdinalIgnoreCase);
-        return sorted.Concat(withoutValue);
+            ? projected
+                .OrderBy(x => x.IsMissing)
+                .ThenByDescending(x => x.Value, StringComparer.OrdinalIgnoreCase)
+            : projected
+                .OrderBy(x => x.IsMissing)
+                .ThenBy(x => x.Value, StringComparer.OrdinalIgnoreCase);
+
+        return sorted.Select(x => x.Row);
     }
 
     // Picker state for "Osoby bez účtu" rows. Key is PersonId.
@@ -469,24 +480,47 @@
         builder.OpenElement(14, "thead");
         builder.OpenElement(15, "tr");
 
+        // Accessible sortable header: real <button> inside <th scope="col">, aria-sort reflects current state,
+        // aria-label describes what the next click will do — screen readers announce both.
         void SortableHeader(int baseSeq, UnlinkedSort key, string label, string? thClass = null)
         {
+            var indicator = UnlinkedSortIndicator(key);
+            var ariaSort = unlinkedSortKey == key
+                ? (unlinkedSortDesc ? "descending" : "ascending")
+                : "none";
+            var ariaLabel = ariaSort switch
+            {
+                "ascending" => $"{label}, seřazeno vzestupně. Aktivací změníte řazení na sestupné.",
+                "descending" => $"{label}, seřazeno sestupně. Aktivací změníte řazení na vzestupné.",
+                _ => $"{label}, není seřazeno. Aktivací seřadíte vzestupně."
+            };
+
             builder.OpenElement(baseSeq, "th");
-            builder.AddAttribute(baseSeq + 1, "role", "button");
-            builder.AddAttribute(baseSeq + 2, "class",
-                string.IsNullOrEmpty(thClass) ? "user-select-none" : $"{thClass} user-select-none");
-            builder.AddAttribute(baseSeq + 3, "data-testid", $"unlinked-sort-{key.ToString().ToLowerInvariant()}");
-            builder.AddAttribute(baseSeq + 4, "onclick",
+            builder.AddAttribute(baseSeq + 1, "scope", "col");
+            builder.AddAttribute(baseSeq + 2, "aria-sort", ariaSort);
+            if (!string.IsNullOrEmpty(thClass))
+            {
+                builder.AddAttribute(baseSeq + 3, "class", thClass);
+            }
+
+            builder.OpenElement(baseSeq + 4, "button");
+            builder.AddAttribute(baseSeq + 5, "type", "button");
+            builder.AddAttribute(baseSeq + 6, "class", "btn btn-link p-0 border-0 text-decoration-none text-reset user-select-none");
+            builder.AddAttribute(baseSeq + 7, "data-testid", $"unlinked-sort-{key.ToString().ToLowerInvariant()}");
+            builder.AddAttribute(baseSeq + 8, "aria-label", ariaLabel);
+            builder.AddAttribute(baseSeq + 9, "onclick",
                 EventCallback.Factory.Create<MouseEventArgs>(this, _ => ToggleUnlinkedSort(key)));
-            builder.AddContent(baseSeq + 5, $"{label} {UnlinkedSortIndicator(key)}");
+            builder.AddContent(baseSeq + 10, $"{label} {indicator}");
+            builder.CloseElement();
+
             builder.CloseElement();
         }
 
         SortableHeader(16, UnlinkedSort.Name, "Osoba");
-        SortableHeader(22, UnlinkedSort.BirthYear, "Rok narození");
-        SortableHeader(28, UnlinkedSort.Email, "E-mail");
-        SortableHeader(34, UnlinkedSort.Phone, "Telefon");
-        builder.AddMarkupContent(40, "<th>Vybrat účet</th><th class=\"text-end\">Akce</th>");
+        SortableHeader(28, UnlinkedSort.BirthYear, "Rok narození");
+        SortableHeader(40, UnlinkedSort.Email, "E-mail");
+        SortableHeader(52, UnlinkedSort.Phone, "Telefon");
+        builder.AddMarkupContent(64, "<th scope=\"col\">Vybrat účet</th><th scope=\"col\" class=\"text-end\">Akce</th>");
 
         builder.CloseElement(); // </tr>
         builder.CloseElement(); // </thead>

--- a/src/RegistraceOvcina.Web/Components/Pages/Admin/AccountLinking.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Admin/AccountLinking.razor
@@ -170,6 +170,11 @@
 @code {
     private enum Tab { Conflicts, High, Medium, Unlinked, Linked }
 
+    // Sort state for the "Osoby bez účtu" tab. Resets on reload — intentionally tab-local.
+    private enum UnlinkedSort { Name, BirthYear, Email, Phone }
+    private UnlinkedSort unlinkedSortKey = UnlinkedSort.Name;
+    private bool unlinkedSortDesc = false;
+
     private ProposalBucket? proposals;
     private IReadOnlyList<UnlinkedPersonView> unlinkedPersons = Array.Empty<UnlinkedPersonView>();
     private IReadOnlyList<AlreadyLinkedView> linkedViews = Array.Empty<AlreadyLinkedView>();
@@ -177,6 +182,53 @@
     private Tab activeTab = Tab.High;
     private string? statusMessage;
     private string? errorMessage;
+
+    private void ToggleUnlinkedSort(UnlinkedSort key)
+    {
+        if (unlinkedSortKey == key)
+        {
+            unlinkedSortDesc = !unlinkedSortDesc;
+        }
+        else
+        {
+            unlinkedSortKey = key;
+            unlinkedSortDesc = false;
+        }
+    }
+
+    private string UnlinkedSortIndicator(UnlinkedSort key) =>
+        unlinkedSortKey == key ? (unlinkedSortDesc ? "▼" : "▲") : "";
+
+    // Czech culture-aware comparer — "Česnek" sorts before "Dub", not after "Zemánek".
+    private static readonly StringComparer CzechNameComparer =
+        StringComparer.Create(new System.Globalization.CultureInfo("cs-CZ"), ignoreCase: true);
+
+    private IEnumerable<UnlinkedPersonView> SortedUnlinked(IEnumerable<UnlinkedPersonView> rows) =>
+        unlinkedSortKey switch
+        {
+            UnlinkedSort.Name => unlinkedSortDesc
+                ? rows.OrderByDescending(r => r.PersonFullName, CzechNameComparer)
+                : rows.OrderBy(r => r.PersonFullName, CzechNameComparer),
+            UnlinkedSort.BirthYear => unlinkedSortDesc
+                ? rows.OrderByDescending(r => r.BirthYear ?? int.MinValue)
+                : rows.OrderBy(r => r.BirthYear ?? int.MaxValue),
+            UnlinkedSort.Email => SortByNullableString(rows, r => r.Email, unlinkedSortDesc),
+            UnlinkedSort.Phone => SortByNullableString(rows, r => r.Phone, unlinkedSortDesc),
+            _ => rows
+        };
+
+    // Null/empty values sort last regardless of direction, so empty cells don't dominate the top of the list.
+    private static IEnumerable<T> SortByNullableString<T>(
+        IEnumerable<T> rows, Func<T, string?> key, bool desc)
+    {
+        var materialized = rows as IList<T> ?? rows.ToList();
+        var withValue = materialized.Where(r => !string.IsNullOrWhiteSpace(key(r)));
+        var withoutValue = materialized.Where(r => string.IsNullOrWhiteSpace(key(r)));
+        var sorted = desc
+            ? withValue.OrderByDescending(r => key(r), StringComparer.OrdinalIgnoreCase)
+            : withValue.OrderBy(r => key(r), StringComparer.OrdinalIgnoreCase);
+        return sorted.Concat(withoutValue);
+    }
 
     // Picker state for "Osoby bez účtu" rows. Key is PersonId.
     private readonly Dictionary<int, string> pickerQueries = new();
@@ -412,10 +464,36 @@
         builder.AddAttribute(11, "class", "table-responsive");
         builder.OpenElement(12, "table");
         builder.AddAttribute(13, "class", "table table-sm align-middle");
-        builder.AddMarkupContent(14, "<thead><tr><th>Osoba</th><th>Rok narození</th><th>E-mail</th><th>Vybrat účet</th><th class=\"text-end\">Akce</th></tr></thead>");
-        builder.OpenElement(15, "tbody");
+
+        // Sortable header — clicking cycles sort key / direction.
+        builder.OpenElement(14, "thead");
+        builder.OpenElement(15, "tr");
+
+        void SortableHeader(int baseSeq, UnlinkedSort key, string label, string? thClass = null)
+        {
+            builder.OpenElement(baseSeq, "th");
+            builder.AddAttribute(baseSeq + 1, "role", "button");
+            builder.AddAttribute(baseSeq + 2, "class",
+                string.IsNullOrEmpty(thClass) ? "user-select-none" : $"{thClass} user-select-none");
+            builder.AddAttribute(baseSeq + 3, "data-testid", $"unlinked-sort-{key.ToString().ToLowerInvariant()}");
+            builder.AddAttribute(baseSeq + 4, "onclick",
+                EventCallback.Factory.Create<MouseEventArgs>(this, _ => ToggleUnlinkedSort(key)));
+            builder.AddContent(baseSeq + 5, $"{label} {UnlinkedSortIndicator(key)}");
+            builder.CloseElement();
+        }
+
+        SortableHeader(16, UnlinkedSort.Name, "Osoba");
+        SortableHeader(22, UnlinkedSort.BirthYear, "Rok narození");
+        SortableHeader(28, UnlinkedSort.Email, "E-mail");
+        SortableHeader(34, UnlinkedSort.Phone, "Telefon");
+        builder.AddMarkupContent(40, "<th>Vybrat účet</th><th class=\"text-end\">Akce</th>");
+
+        builder.CloseElement(); // </tr>
+        builder.CloseElement(); // </thead>
+
+        builder.OpenElement(41, "tbody");
         var seq = 100;
-        foreach (var p in unlinkedPersons)
+        foreach (var p in SortedUnlinked(unlinkedPersons))
         {
             builder.OpenElement(seq++, "tr");
             builder.AddAttribute(seq++, "data-testid", $"unlinked-row-{p.PersonId}");
@@ -430,6 +508,10 @@
 
             builder.OpenElement(seq++, "td");
             builder.AddContent(seq++, p.Email ?? "");
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "td");
+            builder.AddContent(seq++, p.Phone ?? "");
             builder.CloseElement();
 
             // Picker cell

--- a/src/RegistraceOvcina.Web/Features/AccountLinking/AccountLinkingService.cs
+++ b/src/RegistraceOvcina.Web/Features/AccountLinking/AccountLinkingService.cs
@@ -39,7 +39,8 @@ public sealed record UnlinkedPersonView(
     int PersonId,
     string PersonFullName,
     int? BirthYear,
-    string? Email);
+    string? Email,
+    string? Phone);
 
 public sealed record UserPickerResult(
     string UserId,
@@ -546,7 +547,7 @@ public sealed class AccountLinkingService(
         var linkedSet = new HashSet<int>(linkedPersonIds);
 
         var persons = await db.People.AsNoTracking()
-            .Select(p => new UnlinkedPersonView(p.Id, p.FirstName + " " + p.LastName, p.BirthYear, p.Email))
+            .Select(p => new UnlinkedPersonView(p.Id, p.FirstName + " " + p.LastName, p.BirthYear, p.Email, p.Phone))
             .ToListAsync(ct);
 
         return persons

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.26</Version>
+    <Version>0.9.27</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/AccountLinking/AccountLinkingServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/AccountLinking/AccountLinkingServiceTests.cs
@@ -496,6 +496,49 @@ public sealed class AccountLinkingServiceTests
         Assert.Equal("Free Two", row.PersonFullName);
     }
 
+    // 13b -----------------------------------------------------------
+    // v0.9.27: UnlinkedPersonView now carries Phone so the admin tab can
+    // sort + display it. Make sure the projection actually reads it.
+    [Fact]
+    public async Task ListUnlinkedPersonsAsync_includes_phone_when_present()
+    {
+        var options = CreateOptions();
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.People.Add(new Person
+            {
+                FirstName = "Has",
+                LastName = "Phone",
+                BirthYear = 1990,
+                Email = "hp@x.cz",
+                Phone = "+420 123 456 789",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            });
+            db.People.Add(new Person
+            {
+                FirstName = "No",
+                LastName = "Phone",
+                BirthYear = 1991,
+                Email = "np@x.cz",
+                Phone = null,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var service = CreateService(options);
+        var list = await service.ListUnlinkedPersonsAsync(CancellationToken.None);
+
+        Assert.Equal(2, list.Count);
+        var withPhone = list.Single(r => r.PersonFullName == "Has Phone");
+        Assert.Equal("+420 123 456 789", withPhone.Phone);
+        var withoutPhone = list.Single(r => r.PersonFullName == "No Phone");
+        Assert.Null(withoutPhone.Phone);
+    }
+
     // 14a -----------------------------------------------------------
     // v0.9.22 hotfix: guard against creating duplicate PersonId links.
     [Fact]


### PR DESCRIPTION
## Summary
- Makes every column header on the "Osoby bez účtu" tab of `/admin/propojit-ucty` clickable to toggle ascending/descending sort (Jméno, Ročník, E-mail, Telefon).
- Adds a **Telefon** column to the tab; `UnlinkedPersonView` now projects `Person.Phone`.
- Name sort uses `cs-CZ` culture comparer so "Česnek" sorts before "Dub" (not OrdinalIgnoreCase which would mis-place ČŘŠŽ etc.). Empty/null email and phone cells always sink to the bottom, regardless of direction.
- Bumps version 0.9.26 → 0.9.27.

## Behaviour
- Default: **Jméno ascending** (reset on every reload / tab switch — sort is intentionally tab-local).
- Click current column → flip direction. Click different column → switch + default to ascending.
- `BirthYear` sorts numerically with null coalesced to `int.MaxValue` (asc) / `int.MinValue` (desc) so missing years also sink.
- Email / Phone use `StringComparer.OrdinalIgnoreCase` after splitting out empty values.

## Test plan
- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test RegistraceOvcina.Web.Tests` — 303 passed, 0 failed (was 302; added `ListUnlinkedPersonsAsync_includes_phone_when_present`)
- [ ] Smoke test after deploy: open `/admin/propojit-ucty` → "Osoby bez účtu" tab → click each header, verify arrow indicator flips and rows reorder; rows with empty e-mail/phone stay at the bottom in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)