### PR TITLE
feat(roles): link-or-create account action for adults (v0.9.28)

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameRoles.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/GameRoles.razor
@@ -8,6 +8,8 @@
 @inject GameService GameService
 @inject GameRoleService GameRoleService
 @inject GameRolesViewService GameRolesViewService
+@inject IGameRoleAccountService GameRoleAccountService
+@inject NavigationManager NavigationManager
 @inject AuthenticationStateProvider AuthStateProvider
 
 <PageTitle>Dospělí</PageTitle>
@@ -42,13 +44,42 @@ else if (adults.Count == 0)
 }
 else
 {
-    <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
         <div class="text-secondary small">Celkem: <strong>@adults.Count</strong> dospělých</div>
-        <button class="btn btn-sm @(groupByRole ? "btn-primary" : "btn-outline-secondary")"
-                @onclick="ToggleGrouping">
-            <i class="bi bi-collection me-1"></i>Seskupit podle role
-        </button>
+        <div class="d-flex align-items-center gap-2 flex-wrap">
+            @if (!groupByRole)
+            {
+                <button class="btn btn-sm btn-outline-primary"
+                        disabled="@(bulkEligibleCount == 0 || isBulkRunning)"
+                        @onclick="BulkLinkOrCreateAsync"
+                        data-testid="bulk-link-or-create">
+                    <i class="bi bi-person-plus me-1"></i>
+                    @if (isBulkRunning)
+                    {
+                        <span>Pracuji…</span>
+                    }
+                    else
+                    {
+                        <span>Vytvořit/propojit účty pro všechny dospělé s e-mailem (@bulkEligibleCount)</span>
+                    }
+                </button>
+            }
+            <button class="btn btn-sm @(groupByRole ? "btn-primary" : "btn-outline-secondary")"
+                    @onclick="ToggleGrouping">
+                <i class="bi bi-collection me-1"></i>Seskupit podle role
+            </button>
+        </div>
     </div>
+
+    @if (!string.IsNullOrWhiteSpace(statusMessage))
+    {
+        <div class="alert @statusAlertClass alert-dismissible fade show mb-3" role="status"
+             data-testid="link-or-create-status">
+            @statusMessage
+            <button type="button" class="btn-close" aria-label="Close"
+                    @onclick="() => statusMessage = null"></button>
+        </div>
+    }
 
     @if (groupByRole)
     {
@@ -126,7 +157,7 @@ else
                                             }
                                             else
                                             {
-                                                <span class="badge text-bg-warning">Bez účtu</span>
+                                                @NoAccountCell(adult)
                                             }
                                         </td>
                                     </tr>
@@ -200,7 +231,7 @@ else
                                 }
                                 else
                                 {
-                                    <span class="badge text-bg-warning">Bez účtu</span>
+                                    @NoAccountCell(adult)
                                 }
                             </td>
                         </tr>
@@ -219,8 +250,42 @@ else
     private bool groupByRole;
     private bool sortDescending;
     private string currentUserId = "";
+    private string? statusMessage;
+    private string statusAlertClass = "alert-success";
+    private readonly HashSet<int> busyPersonIds = new();
+    private bool isBulkRunning;
 
     private string SortIndicator => sortDescending ? "▼" : "▲";
+
+    private int bulkEligibleCount => adults?
+        .Count(a => !a.HasAccount && !string.IsNullOrWhiteSpace(a.Email)) ?? 0;
+
+    private bool IsRowBusy(int personId) => isBulkRunning || busyPersonIds.Contains(personId);
+
+    private RenderFragment<AdultRoleView> NoAccountCell => adult =>
+        @<text>
+            <span class="badge text-bg-warning me-1">Bez účtu</span>
+            @if (!string.IsNullOrWhiteSpace(adult.Email))
+            {
+                <button type="button" class="btn btn-sm btn-outline-primary mt-1"
+                        disabled="@IsRowBusy(adult.PersonId)"
+                        @onclick="() => LinkOrCreateAsync(adult)"
+                        data-testid="link-or-create-button">
+                    <i class="bi bi-person-plus me-1"></i>Vytvořit/propojit účet
+                </button>
+            }
+            else
+            {
+                <a class="btn btn-sm btn-outline-secondary mt-1"
+                   href="@($"/organizace/osoby/{adult.PersonId}")"
+                   data-testid="missing-email-link">
+                    <i class="bi bi-envelope-plus me-1"></i>Doplnit e-mail
+                </a>
+                <div class="text-secondary small mt-1">
+                    Bez e-mailu nemůžeme vytvořit ani propojit účet.
+                </div>
+            }
+        </text>;
 
     protected override async Task OnInitializedAsync()
     {
@@ -321,5 +386,88 @@ else
         if (flags.HasFlag(AdultRoleFlags.RangerLeader)) labels.Add("Hraničář");
         if (flags.HasFlag(AdultRoleFlags.Spectator)) labels.Add("Přihlížející");
         return labels;
+    }
+
+    private async Task LinkOrCreateAsync(AdultRoleView adult)
+    {
+        if (string.IsNullOrWhiteSpace(adult.Email) || string.IsNullOrEmpty(currentUserId))
+            return;
+
+        busyPersonIds.Add(adult.PersonId);
+        try
+        {
+            var result = await GameRoleAccountService.LinkOrCreateAccountAsync(
+                adult.PersonId, currentUserId, CancellationToken.None);
+
+            switch (result.Outcome)
+            {
+                case LinkOrCreateOutcome.Linked:
+                    SetStatus("Účet propojen.", success: true);
+                    break;
+                case LinkOrCreateOutcome.Created:
+                    SetStatus("Účet vytvořen.", success: true);
+                    break;
+                case LinkOrCreateOutcome.AlreadyLinked:
+                    SetStatus("Účet už byl propojen, obnov stránku.", success: false);
+                    break;
+                case LinkOrCreateOutcome.ConflictEmailUsedByAnotherPerson:
+                    SetStatus(
+                        "E-mail patří jiné osobě — zkontroluj v /admin/propojit-ucty",
+                        success: false);
+                    break;
+                case LinkOrCreateOutcome.MissingEmail:
+                    SetStatus("Osoba nemá vyplněný e-mail.", success: false);
+                    break;
+            }
+
+            // Refresh data so HasAccount/UserId update for the row.
+            await LoadDataAsync();
+        }
+        finally
+        {
+            busyPersonIds.Remove(adult.PersonId);
+        }
+    }
+
+    private async Task BulkLinkOrCreateAsync()
+    {
+        if (!selectedGameId.HasValue || string.IsNullOrEmpty(currentUserId) || bulkEligibleCount == 0)
+            return;
+
+        isBulkRunning = true;
+        try
+        {
+            var result = await GameRoleAccountService.LinkOrCreateAccountsForGameAsync(
+                selectedGameId.Value, currentUserId, CancellationToken.None);
+
+            var parts = new List<string>();
+            if (result.Linked > 0) parts.Add($"propojeno {result.Linked}");
+            if (result.Created > 0) parts.Add($"vytvořeno {result.Created}");
+            if (result.AlreadyLinked > 0) parts.Add($"již propojeno {result.AlreadyLinked}");
+            if (result.MissingEmail > 0) parts.Add($"bez e-mailu {result.MissingEmail}");
+            if (result.Conflicts > 0) parts.Add($"konflikty {result.Conflicts}");
+
+            var summary = parts.Count > 0
+                ? "Hotovo: " + string.Join(", ", parts) + "."
+                : "Žádní dospělí ke zpracování.";
+
+            if (result.FirstErrors.Count > 0)
+            {
+                summary += " Ukázky chyb: " + string.Join(" | ", result.FirstErrors);
+            }
+
+            SetStatus(summary, success: result.Conflicts == 0);
+            await LoadDataAsync();
+        }
+        finally
+        {
+            isBulkRunning = false;
+        }
+    }
+
+    private void SetStatus(string message, bool success)
+    {
+        statusMessage = message;
+        statusAlertClass = success ? "alert-success" : "alert-warning";
     }
 }

--- a/src/RegistraceOvcina.Web/Features/Roles/GameRoleAccountService.cs
+++ b/src/RegistraceOvcina.Web/Features/Roles/GameRoleAccountService.cs
@@ -1,0 +1,360 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Security;
+
+namespace RegistraceOvcina.Web.Features.Roles;
+
+/// <summary>
+/// Outcome of <see cref="GameRoleAccountService.LinkOrCreateAccountAsync"/> for a single Person.
+/// </summary>
+public enum LinkOrCreateOutcome
+{
+    /// <summary>An existing ApplicationUser was found by exact email match and <c>PersonId</c> was set on it.</summary>
+    Linked,
+
+    /// <summary>A new stub ApplicationUser was created (EmailConfirmed=false, random password) and <c>PersonId</c> was set.</summary>
+    Created,
+
+    /// <summary>The Person has no email (or is soft-deleted) — nothing was done. Organizer must fill the email in Person detail first.</summary>
+    MissingEmail,
+
+    /// <summary>The Person already has a linked ApplicationUser — no-op.</summary>
+    AlreadyLinked,
+
+    /// <summary>An ApplicationUser with that email exists but is already linked to a different Person. No change made.</summary>
+    ConflictEmailUsedByAnotherPerson
+}
+
+/// <summary>Result of <see cref="GameRoleAccountService.LinkOrCreateAccountAsync"/>.</summary>
+public sealed record LinkOrCreateResult(LinkOrCreateOutcome Outcome, string? UserId, string? Message);
+
+/// <summary>Aggregated outcome of <see cref="GameRoleAccountService.LinkOrCreateAccountsForGameAsync"/>.</summary>
+public sealed record BulkLinkOrCreateResult(
+    int Linked,
+    int Created,
+    int MissingEmail,
+    int Conflicts,
+    int AlreadyLinked,
+    IReadOnlyList<string> FirstErrors);
+
+/// <summary>
+/// Abstraction for the "create a new stub ApplicationUser" step. In production this is backed
+/// by <see cref="UserManager{TUser}"/>; in tests we stub it with a DbContext-only implementation.
+/// </summary>
+public interface IStubAccountCreator
+{
+    Task<StubAccountCreateResult> CreateStubAsync(
+        string email,
+        string displayName,
+        CancellationToken ct);
+}
+
+public sealed record StubAccountCreateResult(bool Succeeded, string? UserId, string? ErrorMessage);
+
+public interface IGameRoleAccountService
+{
+    Task<LinkOrCreateResult> LinkOrCreateAccountAsync(int personId, string actorUserId, CancellationToken ct);
+
+    Task<BulkLinkOrCreateResult> LinkOrCreateAccountsForGameAsync(
+        int gameId,
+        string actorUserId,
+        CancellationToken ct);
+}
+
+public sealed class GameRoleAccountService(
+    IDbContextFactory<ApplicationDbContext> dbContextFactory,
+    IStubAccountCreator stubCreator,
+    TimeProvider timeProvider,
+    ILogger<GameRoleAccountService> logger)
+    : IGameRoleAccountService
+{
+    public async Task<LinkOrCreateResult> LinkOrCreateAccountAsync(
+        int personId,
+        string actorUserId,
+        CancellationToken ct)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
+        // 1. Load Person. Soft-deleted rows are also treated as "not eligible" — return MissingEmail.
+        var person = await db.People.AsNoTracking()
+            .IgnoreQueryFilters()
+            .SingleOrDefaultAsync(p => p.Id == personId, ct);
+
+        if (person is null || person.IsDeleted || string.IsNullOrWhiteSpace(person.Email))
+        {
+            return new LinkOrCreateResult(LinkOrCreateOutcome.MissingEmail, null,
+                "Osoba nemá vyplněný e-mail.");
+        }
+
+        // 2. Already linked? Skip.
+        var alreadyLinkedUser = await db.Users.AsNoTracking()
+            .FirstOrDefaultAsync(u => u.PersonId == personId, ct);
+        if (alreadyLinkedUser is not null)
+        {
+            return new LinkOrCreateResult(LinkOrCreateOutcome.AlreadyLinked, alreadyLinkedUser.Id,
+                "Osoba už má propojený účet.");
+        }
+
+        var trimmedEmail = person.Email.Trim();
+        var normalizedEmail = trimmedEmail.ToUpperInvariant();
+        var nowUtc = timeProvider.GetUtcNow().UtcDateTime;
+
+        // 3. Look up ApplicationUser by NormalizedEmail.
+        var matchingUser = await db.Users
+            .FirstOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail, ct);
+
+        if (matchingUser is not null)
+        {
+            // 3a. Exists and unlinked → link.
+            if (matchingUser.PersonId is null)
+            {
+                matchingUser.PersonId = personId;
+
+                db.AuditLogs.Add(new AuditLog
+                {
+                    EntityType = nameof(ApplicationUser),
+                    EntityId = matchingUser.Id,
+                    Action = "LinkAccount",
+                    ActorUserId = actorUserId,
+                    CreatedAtUtc = nowUtc,
+                    DetailsJson = JsonSerializer.Serialize(new
+                    {
+                        PersonId = personId,
+                        PersonName = FullName(person.FirstName, person.LastName),
+                        Signal = "ExactEmailMatch",
+                        Source = "LinkOrCreate"
+                    })
+                });
+
+                await db.SaveChangesAsync(ct);
+                logger.LogInformation(
+                    "LinkOrCreate: linked existing user {UserId} to person {PersonId} (actor {ActorId}).",
+                    matchingUser.Id, personId, actorUserId);
+
+                return new LinkOrCreateResult(LinkOrCreateOutcome.Linked, matchingUser.Id,
+                    "Účet propojen.");
+            }
+
+            // 3b. Exists, linked to a different Person → conflict, do not modify.
+            if (matchingUser.PersonId != personId)
+            {
+                logger.LogWarning(
+                    "LinkOrCreate: email {Email} already belongs to user {UserId} linked to a different person {OtherPersonId} (requested by actor {ActorId} for person {PersonId}).",
+                    trimmedEmail, matchingUser.Id, matchingUser.PersonId, actorUserId, personId);
+
+                return new LinkOrCreateResult(LinkOrCreateOutcome.ConflictEmailUsedByAnotherPerson,
+                    matchingUser.Id,
+                    "E-mail patří jiné osobě.");
+            }
+
+            // Defensive: matches personId, treat as already-linked.
+            return new LinkOrCreateResult(LinkOrCreateOutcome.AlreadyLinked, matchingUser.Id,
+                "Osoba už má propojený účet.");
+        }
+
+        // 4. No matching user — create a new stub.
+        var displayName = FullName(person.FirstName, person.LastName);
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = trimmedEmail;
+        }
+
+        var createResult = await stubCreator.CreateStubAsync(trimmedEmail, displayName, ct);
+        if (!createResult.Succeeded || createResult.UserId is null)
+        {
+            logger.LogWarning(
+                "LinkOrCreate: stub account creation failed for person {PersonId} (email {Email}): {Error}",
+                personId, trimmedEmail, createResult.ErrorMessage);
+
+            return new LinkOrCreateResult(LinkOrCreateOutcome.ConflictEmailUsedByAnotherPerson, null,
+                createResult.ErrorMessage ?? "Nelze vytvořit účet.");
+        }
+
+        // Now load the fresh user, link and audit in this DbContext.
+        var freshUser = await db.Users.SingleOrDefaultAsync(u => u.Id == createResult.UserId, ct);
+        if (freshUser is null)
+        {
+            // Very unlikely — identity creation "succeeded" but the user is not visible. Bail safely.
+            logger.LogError(
+                "LinkOrCreate: stub creation reported success for user {UserId} but user not found in DB.",
+                createResult.UserId);
+            return new LinkOrCreateResult(LinkOrCreateOutcome.ConflictEmailUsedByAnotherPerson, null,
+                "Účet byl vytvořen, ale nepodařilo se ho dohledat pro propojení.");
+        }
+
+        freshUser.PersonId = personId;
+
+        db.AuditLogs.Add(new AuditLog
+        {
+            EntityType = nameof(ApplicationUser),
+            EntityId = freshUser.Id,
+            Action = "CreateAccount",
+            ActorUserId = actorUserId,
+            CreatedAtUtc = nowUtc,
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                PersonId = personId,
+                PersonName = FullName(person.FirstName, person.LastName),
+                Method = "LinkOrCreate stub"
+            })
+        });
+
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation(
+            "LinkOrCreate: created stub user {UserId} for person {PersonId} (actor {ActorId}).",
+            freshUser.Id, personId, actorUserId);
+
+        return new LinkOrCreateResult(LinkOrCreateOutcome.Created, freshUser.Id, "Účet vytvořen.");
+    }
+
+    public async Task<BulkLinkOrCreateResult> LinkOrCreateAccountsForGameAsync(
+        int gameId,
+        string actorUserId,
+        CancellationToken ct)
+    {
+        // Snapshot the target Person IDs up front so iteration is deterministic and not affected
+        // by the per-iteration DbContexts opened by LinkOrCreateAccountAsync.
+        List<int> targetPersonIds;
+        await using (var db = await dbContextFactory.CreateDbContextAsync(ct))
+        {
+            // All adults in the game whose Person has a non-empty email and whose Person is not
+            // yet linked to any ApplicationUser. Soft-deleted persons are filtered by the query
+            // filter on Person.
+            var linkedPersonIds = await db.Users.AsNoTracking()
+                .Where(u => u.PersonId != null)
+                .Select(u => u.PersonId!.Value)
+                .ToListAsync(ct);
+            var linkedSet = new HashSet<int>(linkedPersonIds);
+
+            targetPersonIds = await db.Registrations.AsNoTracking()
+                .Where(r => r.Submission.GameId == gameId
+                    && r.AttendeeType == AttendeeType.Adult
+                    && r.Status == RegistrationStatus.Active
+                    && !r.Submission.IsDeleted
+                    && !string.IsNullOrWhiteSpace(r.Person.Email))
+                .Select(r => r.Person.Id)
+                .Distinct()
+                .ToListAsync(ct);
+
+            targetPersonIds = targetPersonIds.Where(id => !linkedSet.Contains(id)).ToList();
+        }
+
+        var linked = 0;
+        var created = 0;
+        var missingEmail = 0;
+        var alreadyLinked = 0;
+        var conflicts = 0;
+        var errors = new List<string>();
+
+        foreach (var personId in targetPersonIds)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            try
+            {
+                var result = await LinkOrCreateAccountAsync(personId, actorUserId, ct);
+                switch (result.Outcome)
+                {
+                    case LinkOrCreateOutcome.Linked: linked++; break;
+                    case LinkOrCreateOutcome.Created: created++; break;
+                    case LinkOrCreateOutcome.MissingEmail: missingEmail++; break;
+                    case LinkOrCreateOutcome.AlreadyLinked: alreadyLinked++; break;
+                    case LinkOrCreateOutcome.ConflictEmailUsedByAnotherPerson:
+                        conflicts++;
+                        if (errors.Count < 3 && !string.IsNullOrWhiteSpace(result.Message))
+                            errors.Add($"Osoba #{personId}: {result.Message}");
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                conflicts++;
+                if (errors.Count < 3)
+                    errors.Add($"Osoba #{personId}: {ex.Message}");
+                logger.LogError(ex,
+                    "LinkOrCreateAccountsForGame: unexpected error for person {PersonId} (actor {ActorId}).",
+                    personId, actorUserId);
+            }
+        }
+
+        logger.LogInformation(
+            "LinkOrCreateAccountsForGame: game {GameId} — linked={Linked} created={Created} missingEmail={MissingEmail} alreadyLinked={AlreadyLinked} conflicts={Conflicts} (actor {ActorId}).",
+            gameId, linked, created, missingEmail, alreadyLinked, conflicts, actorUserId);
+
+        return new BulkLinkOrCreateResult(linked, created, missingEmail, conflicts, alreadyLinked, errors);
+    }
+
+    private static string FullName(string first, string last)
+    {
+        first = (first ?? "").Trim();
+        last = (last ?? "").Trim();
+        return string.Join(" ", new[] { first, last }.Where(s => s.Length > 0));
+    }
+}
+
+/// <summary>
+/// Production implementation of <see cref="IStubAccountCreator"/> — creates ApplicationUser via
+/// <see cref="UserManager{TUser}"/>, assigns a strong random password, and adds the Registrant role
+/// so the user can finish onboarding by simply signing in with their email (magic link, etc.).
+/// </summary>
+public sealed class IdentityStubAccountCreator(
+    UserManager<ApplicationUser> userManager,
+    TimeProvider timeProvider,
+    ILogger<IdentityStubAccountCreator> logger)
+    : IStubAccountCreator
+{
+    public async Task<StubAccountCreateResult> CreateStubAsync(
+        string email,
+        string displayName,
+        CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var user = new ApplicationUser
+        {
+            UserName = email,
+            Email = email,
+            EmailConfirmed = false,
+            DisplayName = displayName,
+            IsActive = true,
+            CreatedAtUtc = timeProvider.GetUtcNow().UtcDateTime
+        };
+
+        var password = GenerateRandomPassword();
+        var createResult = await userManager.CreateAsync(user, password);
+        if (!createResult.Succeeded)
+        {
+            var message = string.Join("; ", createResult.Errors.Select(e => e.Description));
+            logger.LogWarning(
+                "IdentityStubAccountCreator: CreateAsync failed for email {Email}: {Error}",
+                email, message);
+            return new StubAccountCreateResult(false, null, message);
+        }
+
+        // Registrant role mirrors what the magic-link auto-creation path does, so future sign-ins
+        // get the expected claims. Missing role is non-fatal — log it and carry on.
+        var addRoleResult = await userManager.AddToRoleAsync(user, RoleNames.Registrant);
+        if (!addRoleResult.Succeeded)
+        {
+            logger.LogWarning(
+                "IdentityStubAccountCreator: failed to add Registrant role to user {UserId}: {Error}",
+                user.Id, string.Join("; ", addRoleResult.Errors.Select(e => e.Description)));
+        }
+
+        return new StubAccountCreateResult(true, user.Id, null);
+    }
+
+    private static string GenerateRandomPassword()
+    {
+        // 32 random bytes → ~43 Base64Url chars. Add a fixed suffix to guarantee Identity's
+        // default complexity rules are met (lower + upper + digit + symbol) without rejecting
+        // the "no matching class" error. The user never uses this password — they sign in via
+        // the email flow — so we just need to pass Identity's validator.
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return Base64UrlTextEncoder.Encode(bytes) + "Aa1!";
+    }
+}

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -271,6 +271,8 @@ public class Program
         builder.Services.AddScoped<IAccountLinkingService, AccountLinkingService>();
         builder.Services.AddScoped<GameRoleService>();
         builder.Services.AddScoped<GameRolesViewService>();
+        builder.Services.AddScoped<IStubAccountCreator, IdentityStubAccountCreator>();
+        builder.Services.AddScoped<IGameRoleAccountService, GameRoleAccountService>();
         builder.Services.AddScoped<AnnouncementService>();
         builder.Services.AddScoped<GameStatsService>();
         builder.Services.Configure<IntegrationApiOptions>(

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.27</Version>
+    <Version>0.9.28</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/Roles/GameRoleAccountServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/Roles/GameRoleAccountServiceTests.cs
@@ -1,0 +1,550 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.Roles;
+
+namespace RegistraceOvcina.Web.Tests.Features.Roles;
+
+public sealed class GameRoleAccountServiceTests
+{
+    private const string ActorId = "actor-1";
+
+    // 1 ----------------------------------------------------------------------------------------
+    [Fact]
+    public async Task LinkOrCreateAccountAsync_missing_email_returns_MissingEmail()
+    {
+        var options = CreateOptions();
+        int personId;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var person = new Person
+            {
+                FirstName = "Alice",
+                LastName = "NoEmail",
+                BirthYear = 1990,
+                Email = null,
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+        }
+
+        var creator = new FakeStubAccountCreator(options);
+        var service = CreateService(options, creator);
+
+        var result = await service.LinkOrCreateAccountAsync(personId, ActorId, CancellationToken.None);
+
+        Assert.Equal(LinkOrCreateOutcome.MissingEmail, result.Outcome);
+        Assert.Null(result.UserId);
+        Assert.Equal(0, creator.CallCount);
+
+        await using var verify = new ApplicationDbContext(options);
+        Assert.Empty(verify.AuditLogs);
+    }
+
+    // 2 ----------------------------------------------------------------------------------------
+    [Fact]
+    public async Task LinkOrCreateAccountAsync_existing_matching_user_sets_PersonId_and_returns_Linked()
+    {
+        var options = CreateOptions();
+        int personId;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Alice Existing", "alice@example.cz"));
+            var person = new Person
+            {
+                FirstName = "Alice",
+                LastName = "Existing",
+                BirthYear = 1990,
+                Email = "alice@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+        }
+
+        var creator = new FakeStubAccountCreator(options);
+        var service = CreateService(options, creator);
+
+        var result = await service.LinkOrCreateAccountAsync(personId, ActorId, CancellationToken.None);
+
+        Assert.Equal(LinkOrCreateOutcome.Linked, result.Outcome);
+        Assert.Equal("user-1", result.UserId);
+        Assert.Equal(0, creator.CallCount);
+
+        await using var verify = new ApplicationDbContext(options);
+        var user = await verify.Users.SingleAsync(u => u.Id == "user-1");
+        Assert.Equal(personId, user.PersonId);
+    }
+
+    // 3 ----------------------------------------------------------------------------------------
+    [Fact]
+    public async Task LinkOrCreateAccountAsync_no_matching_user_creates_new_one_with_EmailConfirmed_false()
+    {
+        var options = CreateOptions();
+        int personId;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var person = new Person
+            {
+                FirstName = "Bob",
+                LastName = "NewStub",
+                BirthYear = 1985,
+                Email = "bob@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+        }
+
+        var creator = new FakeStubAccountCreator(options);
+        var service = CreateService(options, creator);
+
+        var result = await service.LinkOrCreateAccountAsync(personId, ActorId, CancellationToken.None);
+
+        Assert.Equal(LinkOrCreateOutcome.Created, result.Outcome);
+        Assert.NotNull(result.UserId);
+        Assert.Equal(1, creator.CallCount);
+
+        await using var verify = new ApplicationDbContext(options);
+        var user = await verify.Users.SingleAsync(u => u.Id == result.UserId);
+        Assert.False(user.EmailConfirmed);
+        Assert.Equal(personId, user.PersonId);
+        Assert.Equal("bob@example.cz", user.Email);
+        Assert.Equal("BOB@EXAMPLE.CZ", user.NormalizedEmail);
+    }
+
+    // 4 ----------------------------------------------------------------------------------------
+    [Fact]
+    public async Task LinkOrCreateAccountAsync_existing_user_linked_to_other_Person_returns_Conflict()
+    {
+        var options = CreateOptions();
+        int targetPersonId;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            // An unrelated "other" Person owns the existing user.
+            var otherPerson = new Person
+            {
+                FirstName = "Owner",
+                LastName = "OfEmail",
+                BirthYear = 1975,
+                Email = "shared@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(otherPerson);
+            await db.SaveChangesAsync();
+
+            var user = CreateUser("user-1", "Owner OfEmail", "shared@example.cz");
+            user.PersonId = otherPerson.Id;
+            db.Users.Add(user);
+
+            // Target Person that happens to share the email with the other person.
+            var targetPerson = new Person
+            {
+                FirstName = "Target",
+                LastName = "SameEmail",
+                BirthYear = 1990,
+                Email = "shared@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(targetPerson);
+            await db.SaveChangesAsync();
+            targetPersonId = targetPerson.Id;
+        }
+
+        var creator = new FakeStubAccountCreator(options);
+        var service = CreateService(options, creator);
+
+        var result = await service.LinkOrCreateAccountAsync(targetPersonId, ActorId, CancellationToken.None);
+
+        Assert.Equal(LinkOrCreateOutcome.ConflictEmailUsedByAnotherPerson, result.Outcome);
+        Assert.Equal(0, creator.CallCount);
+
+        // No state mutation on the existing user.
+        await using var verify = new ApplicationDbContext(options);
+        var existing = await verify.Users.SingleAsync(u => u.Id == "user-1");
+        Assert.NotEqual(targetPersonId, existing.PersonId);
+        Assert.Empty(verify.AuditLogs);
+    }
+
+    // 5 ----------------------------------------------------------------------------------------
+    [Fact]
+    public async Task LinkOrCreateAccountAsync_person_already_linked_returns_AlreadyLinked()
+    {
+        var options = CreateOptions();
+        int personId;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var person = new Person
+            {
+                FirstName = "Carla",
+                LastName = "Linked",
+                BirthYear = 1990,
+                Email = "carla@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(person);
+            await db.SaveChangesAsync();
+            personId = person.Id;
+
+            var user = CreateUser("user-1", "Carla Linked", "carla@example.cz");
+            user.PersonId = personId;
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+        }
+
+        var creator = new FakeStubAccountCreator(options);
+        var service = CreateService(options, creator);
+
+        var result = await service.LinkOrCreateAccountAsync(personId, ActorId, CancellationToken.None);
+
+        Assert.Equal(LinkOrCreateOutcome.AlreadyLinked, result.Outcome);
+        Assert.Equal("user-1", result.UserId);
+        Assert.Equal(0, creator.CallCount);
+
+        await using var verify = new ApplicationDbContext(options);
+        Assert.Empty(verify.AuditLogs);
+    }
+
+    // 6 ----------------------------------------------------------------------------------------
+    [Fact]
+    public async Task LinkOrCreateAccountAsync_writes_auditlog_for_both_Linked_and_Created()
+    {
+        var options = CreateOptions();
+        int linkedPersonId;
+        int createdPersonId;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Users.Add(CreateUser("user-1", "Alice L", "alice@example.cz"));
+            var linkedPerson = new Person
+            {
+                FirstName = "Alice",
+                LastName = "Linked",
+                BirthYear = 1990,
+                Email = "alice@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(linkedPerson);
+
+            var newPerson = new Person
+            {
+                FirstName = "Bob",
+                LastName = "Created",
+                BirthYear = 1985,
+                Email = "bob@example.cz",
+                CreatedAtUtc = FixedDate(),
+                UpdatedAtUtc = FixedDate()
+            };
+            db.People.Add(newPerson);
+
+            await db.SaveChangesAsync();
+            linkedPersonId = linkedPerson.Id;
+            createdPersonId = newPerson.Id;
+        }
+
+        var creator = new FakeStubAccountCreator(options);
+        var service = CreateService(options, creator);
+
+        var linkResult = await service.LinkOrCreateAccountAsync(linkedPersonId, ActorId, CancellationToken.None);
+        var createResult = await service.LinkOrCreateAccountAsync(createdPersonId, ActorId, CancellationToken.None);
+
+        Assert.Equal(LinkOrCreateOutcome.Linked, linkResult.Outcome);
+        Assert.Equal(LinkOrCreateOutcome.Created, createResult.Outcome);
+
+        await using var verify = new ApplicationDbContext(options);
+        var audits = await verify.AuditLogs
+            .OrderBy(a => a.Id)
+            .ToListAsync();
+
+        Assert.Equal(2, audits.Count);
+
+        var linkAudit = audits[0];
+        Assert.Equal("ApplicationUser", linkAudit.EntityType);
+        Assert.Equal("user-1", linkAudit.EntityId);
+        Assert.Equal("LinkAccount", linkAudit.Action);
+        Assert.Equal(ActorId, linkAudit.ActorUserId);
+        Assert.Contains("ExactEmailMatch", linkAudit.DetailsJson!);
+
+        var createAudit = audits[1];
+        Assert.Equal("ApplicationUser", createAudit.EntityType);
+        Assert.Equal("CreateAccount", createAudit.Action);
+        Assert.Equal(ActorId, createAudit.ActorUserId);
+        Assert.Contains("LinkOrCreate stub", createAudit.DetailsJson!);
+    }
+
+    // 7 ----------------------------------------------------------------------------------------
+    [Fact]
+    public async Task LinkOrCreateAccountsForGameAsync_aggregates_outcomes_correctly()
+    {
+        var options = CreateOptions();
+        const int gameId = 42;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Games.Add(CreateGame(gameId));
+
+            // Three adults:
+            //  - adult A: email matches existing unlinked user → Linked
+            //  - adult B: email with no matching user → Created
+            //  - adult C: no email → skipped upfront (not counted anywhere)
+            var adultA = SeedAdult(db, gameId, "Aneta", "Matching", "aneta@example.cz");
+            var adultB = SeedAdult(db, gameId, "Bohuslav", "New", "bohu@example.cz");
+            _ = SeedAdult(db, gameId, "Cecilia", "NoEmail", null);
+
+            db.Users.Add(CreateUser("user-matches-A", "Aneta Matching", "aneta@example.cz"));
+            await db.SaveChangesAsync();
+            _ = adultA;
+            _ = adultB;
+        }
+
+        var creator = new FakeStubAccountCreator(options);
+        var service = CreateService(options, creator);
+
+        var bulk = await service.LinkOrCreateAccountsForGameAsync(gameId, ActorId, CancellationToken.None);
+
+        Assert.Equal(1, bulk.Linked);
+        Assert.Equal(1, bulk.Created);
+        Assert.Equal(0, bulk.AlreadyLinked);
+        Assert.Equal(0, bulk.Conflicts);
+        // Adults without email are filtered out of the target set entirely, so MissingEmail stays 0.
+        Assert.Equal(0, bulk.MissingEmail);
+        Assert.Empty(bulk.FirstErrors);
+    }
+
+    // 8 ----------------------------------------------------------------------------------------
+    [Fact]
+    public async Task LinkOrCreateAccountsForGameAsync_skips_adults_without_email()
+    {
+        var options = CreateOptions();
+        const int gameId = 42;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Games.Add(CreateGame(gameId));
+            _ = SeedAdult(db, gameId, "OnlyOne", "NoEmail", null);
+            await db.SaveChangesAsync();
+        }
+
+        var creator = new FakeStubAccountCreator(options);
+        var service = CreateService(options, creator);
+
+        var bulk = await service.LinkOrCreateAccountsForGameAsync(gameId, ActorId, CancellationToken.None);
+
+        Assert.Equal(0, bulk.Linked);
+        Assert.Equal(0, bulk.Created);
+        Assert.Equal(0, bulk.AlreadyLinked);
+        Assert.Equal(0, bulk.MissingEmail);
+        Assert.Equal(0, bulk.Conflicts);
+        Assert.Equal(0, creator.CallCount);
+
+        await using var verify = new ApplicationDbContext(options);
+        Assert.Empty(verify.Users);
+        Assert.Empty(verify.AuditLogs);
+    }
+
+    // 9 ----------------------------------------------------------------------------------------
+    [Fact]
+    public async Task LinkOrCreateAccountsForGameAsync_skips_adults_already_linked()
+    {
+        var options = CreateOptions();
+        const int gameId = 42;
+
+        await using (var db = new ApplicationDbContext(options))
+        {
+            db.Games.Add(CreateGame(gameId));
+            var person = SeedAdult(db, gameId, "Already", "Linked", "already@example.cz");
+            await db.SaveChangesAsync();
+
+            var user = CreateUser("user-1", "Already Linked", "already@example.cz");
+            user.PersonId = person.Id;
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+        }
+
+        var creator = new FakeStubAccountCreator(options);
+        var service = CreateService(options, creator);
+
+        var bulk = await service.LinkOrCreateAccountsForGameAsync(gameId, ActorId, CancellationToken.None);
+
+        // Already-linked adults are filtered out before iteration, so no counters move at all.
+        Assert.Equal(0, bulk.Linked);
+        Assert.Equal(0, bulk.Created);
+        Assert.Equal(0, bulk.AlreadyLinked);
+        Assert.Equal(0, creator.CallCount);
+
+        await using var verify = new ApplicationDbContext(options);
+        Assert.Empty(verify.AuditLogs);
+    }
+
+    // -------- helpers --------
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static GameRoleAccountService CreateService(
+        DbContextOptions<ApplicationDbContext> options,
+        IStubAccountCreator creator)
+        => new(
+            new TestDbContextFactory(options),
+            creator,
+            new FixedTimeProvider(),
+            NullLogger<GameRoleAccountService>.Instance);
+
+    private static ApplicationUser CreateUser(string id, string displayName, string email) => new()
+    {
+        Id = id,
+        DisplayName = displayName,
+        Email = email,
+        NormalizedEmail = email.ToUpperInvariant(),
+        UserName = email,
+        NormalizedUserName = email.ToUpperInvariant(),
+        EmailConfirmed = true,
+        IsActive = true,
+        SecurityStamp = "initial-stamp",
+        CreatedAtUtc = FixedDate()
+    };
+
+    private static Game CreateGame(int id) => new()
+    {
+        Id = id,
+        Name = "Test Game",
+        Description = "",
+        BankAccount = "1234/5678",
+        BankAccountName = "Pořadatel",
+        StartsAtUtc = FixedDate().AddMonths(2),
+        EndsAtUtc = FixedDate().AddMonths(2).AddDays(2),
+        RegistrationClosesAtUtc = FixedDate().AddMonths(1),
+        MealOrderingClosesAtUtc = FixedDate().AddMonths(1),
+        PaymentDueAtUtc = FixedDate().AddMonths(1),
+        PlayerBasePrice = 100m,
+        SecondChildPrice = 80m,
+        ThirdPlusChildPrice = 60m,
+        AdultHelperBasePrice = 50m,
+        LodgingIndoorPrice = 0m,
+        LodgingOutdoorPrice = 0m,
+        VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId
+    };
+
+    private static Person SeedAdult(
+        ApplicationDbContext db,
+        int gameId,
+        string first,
+        string last,
+        string? email)
+    {
+        var person = new Person
+        {
+            FirstName = first,
+            LastName = last,
+            BirthYear = 1990,
+            Email = email,
+            CreatedAtUtc = FixedDate(),
+            UpdatedAtUtc = FixedDate()
+        };
+        db.People.Add(person);
+        db.SaveChanges();
+
+        var submission = new RegistrationSubmission
+        {
+            GameId = gameId,
+            RegistrantUserId = "registrant-" + Guid.NewGuid().ToString("N"),
+            PrimaryContactName = $"{first} {last}",
+            GroupName = $"Rodina {last}",
+            PrimaryEmail = email ?? "nobody@example.cz",
+            PrimaryPhone = "+420 111 222 333",
+            Status = SubmissionStatus.Submitted,
+            LastEditedAtUtc = FixedDate()
+        };
+        db.RegistrationSubmissions.Add(submission);
+        db.SaveChanges();
+
+        db.Registrations.Add(new Registration
+        {
+            SubmissionId = submission.Id,
+            PersonId = person.Id,
+            AttendeeType = AttendeeType.Adult,
+            Status = RegistrationStatus.Active,
+            CreatedAtUtc = FixedDate(),
+            UpdatedAtUtc = FixedDate()
+        });
+        db.SaveChanges();
+
+        return person;
+    }
+
+    private static DateTime FixedDate() => new(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now = new(new DateTime(2026, 4, 5, 12, 0, 0, DateTimeKind.Utc));
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    /// <summary>
+    /// Test stub: creates an ApplicationUser directly in the DbContext so we don't need to spin
+    /// up the full ASP.NET Core Identity stack (UserManager, UserStore, PasswordHasher, etc.)
+    /// in unit tests. Mirrors the behavior of <see cref="IdentityStubAccountCreator"/> in prod.
+    /// </summary>
+    private sealed class FakeStubAccountCreator(DbContextOptions<ApplicationDbContext> options)
+        : IStubAccountCreator
+    {
+        public int CallCount { get; private set; }
+
+        public async Task<StubAccountCreateResult> CreateStubAsync(
+            string email,
+            string displayName,
+            CancellationToken ct)
+        {
+            CallCount++;
+
+            await using var db = new ApplicationDbContext(options);
+            var id = Guid.NewGuid().ToString("N");
+            var user = new ApplicationUser
+            {
+                Id = id,
+                UserName = email,
+                NormalizedUserName = email.ToUpperInvariant(),
+                Email = email,
+                NormalizedEmail = email.ToUpperInvariant(),
+                DisplayName = displayName,
+                EmailConfirmed = false,
+                IsActive = true,
+                SecurityStamp = Guid.NewGuid().ToString("N"),
+                ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+                CreatedAtUtc = FixedDate(),
+                PasswordHash = "stub-password-hash"
+            };
+            db.Users.Add(user);
+            await db.SaveChangesAsync(ct);
+
+            return new StubAccountCreateResult(true, user.Id, null);
+        }
+    }
+}


### PR DESCRIPTION
Enables role assignment for adults with Person.Email but no ApplicationUser. Matches existing user by email or creates stub (EmailConfirmed=false). Bulk + per-row variants. Adults without email intentionally skipped.