### PR TITLE
feat(people): editable contact on PersonDetail (v0.9.29)

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/PersonDetail.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/PersonDetail.razor
@@ -48,6 +48,36 @@ else
             <div class="alert alert-danger mb-0">@errorMessage</div>
         }
 
+        <form method="post" action="/organizace/osoby/@PersonId/kontakt" class="card card-body border-0 bg-light" data-testid="person-contact-editor">
+            <AntiforgeryToken />
+            <h2 class="h6 mb-2">Kontakt</h2>
+            <div class="row g-2">
+                <div class="col-md-6">
+                    <label class="form-label small" for="email-input">E-mail</label>
+                    <input id="email-input" type="email" name="email" class="form-control" value="@model.Email" placeholder="jmeno@domena.cz" />
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label small" for="phone-input">Telefon</label>
+                    <input id="phone-input" type="tel" name="phone" class="form-control" value="@model.Phone" placeholder="+420 ..." />
+                </div>
+                <div class="col-md-2 d-flex align-items-end">
+                    <button type="submit" class="btn btn-primary w-100">Uložit</button>
+                </div>
+            </div>
+            @if (!string.IsNullOrWhiteSpace(contactMessage))
+            {
+                <div class="small mt-2 @(contactOk ? "text-success" : contactNeutral ? "text-secondary" : "text-danger")" data-testid="contact-status">
+                    @contactMessage
+                </div>
+            }
+            @if (showLinkOrCreateHint)
+            {
+                <div class="small mt-2 text-secondary" data-testid="contact-link-hint">
+                    Tip: V sekci <a href="/organizace/role">/organizace/role</a> nyní klikni "Vytvořit/propojit účet" u této osoby.
+                </div>
+            }
+        </form>
+
         <div class="row g-4">
             <div class="col-xl-5">
                 <section class="card shadow-sm border-0 h-100">
@@ -438,12 +468,19 @@ else
     [SupplyParameterFromQuery(Name = "confirmMerge")]
     private int? ConfirmMerge { get; set; }
 
+    [SupplyParameterFromQuery(Name = "contact")]
+    private string? ContactStatus { get; set; }
+
     private PersonReviewDetailPageModel? model;
     private string? statusMessage;
     private string? errorMessage;
     private bool isLoaded;
     private List<PersonSearchResultItem>? searchResults;
     private int? confirmingMergePersonId;
+    private string? contactMessage;
+    private bool contactOk;
+    private bool contactNeutral;
+    private bool showLinkOrCreateHint;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -464,6 +501,22 @@ else
             searchResults = await PeopleReviewService.SearchPersonsAsync(SearchMerge, PersonId);
             confirmingMergePersonId = ConfirmMerge;
         }
+
+        (contactMessage, contactOk, contactNeutral) = ContactStatus switch
+        {
+            "updated" => ("Kontakt uložen.", true, false),
+            "email-conflict" => ("E-mail už používá jiná osoba. Pokud to je ta stejná, zkus nejprve sloučit osoby.", false, false),
+            "no-change" => ("Nebyly uloženy žádné změny.", false, true),
+            _ => (null, false, false)
+        };
+
+        // After a successful save, nudge the organizer toward the link-or-create step
+        // — it's the usual next move when filling in an email for a legacy Person that
+        // doesn't yet have a User account attached.
+        showLinkOrCreateHint = model is not null
+            && ContactStatus == "updated"
+            && !string.IsNullOrWhiteSpace(model.Email)
+            && model.LinkedAccounts.Count == 0;
 
         isLoaded = true;
     }

--- a/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
+++ b/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
@@ -477,6 +477,109 @@ public sealed class PeopleReviewService(
         await db.SaveChangesAsync(cancellationToken);
     }
 
+    /// <summary>
+    /// Updates contact info (email + phone) on a Person. Organizer flow for filling in
+    /// contact details on Persons imported without them (common for legacy imports),
+    /// unblocking the v0.9.28 link-or-create-account step which requires an email.
+    /// </summary>
+    /// <remarks>
+    /// Respects the partial unique index on Person.Email (filtered to non-deleted rows
+    /// with non-empty email). Soft-deleted Persons don't appear because the global
+    /// IsDeleted query filter excludes them — they return <see cref="UpdateContactOutcome.NotFound"/>.
+    /// </remarks>
+    public async Task<UpdateContactResult> UpdateContactAsync(
+        int personId,
+        string? email,
+        string? phone,
+        string actorUserId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var person = await db.People
+            .FirstOrDefaultAsync(x => x.Id == personId, cancellationToken);
+
+        if (person is null)
+        {
+            // Soft-deleted Persons are filtered out by HasQueryFilter, so they land here too.
+            return new UpdateContactResult(UpdateContactOutcome.NotFound, null, null, null);
+        }
+
+        // Normalize: empty/whitespace -> null so unique index sees NULL (permitted by partial filter)
+        // and downstream matching uses the same canonical form as import/search.
+        var trimmedEmail = string.IsNullOrWhiteSpace(email) ? null : email.Trim().ToLowerInvariant();
+        var normalizedPhoneDigits = PersonIdentityNormalizer.NormalizePhone(phone);
+        var trimmedPhone = string.IsNullOrWhiteSpace(normalizedPhoneDigits) ? null : normalizedPhoneDigits;
+
+        // Check email uniqueness against OTHER active Persons only.
+        // Global query filter already excludes soft-deleted, so this naturally matches
+        // the scope of the partial unique index ("Email" IS NOT NULL AND "Email" != '').
+        if (!string.IsNullOrWhiteSpace(trimmedEmail)
+            && !string.Equals(trimmedEmail, person.Email, StringComparison.OrdinalIgnoreCase))
+        {
+            var collision = await db.People
+                .AsNoTracking()
+                .AnyAsync(x => x.Id != personId && x.Email == trimmedEmail, cancellationToken);
+
+            if (collision)
+            {
+                return new UpdateContactResult(
+                    UpdateContactOutcome.EmailAlreadyUsedByOtherPerson,
+                    "E-mail už používá jiná osoba.",
+                    trimmedEmail,
+                    trimmedPhone);
+            }
+        }
+
+        var oldEmail = person.Email;
+        var oldPhone = person.Phone;
+
+        var emailChanged = !string.Equals(oldEmail, trimmedEmail, StringComparison.Ordinal);
+        var phoneChanged = !string.Equals(oldPhone, trimmedPhone, StringComparison.Ordinal);
+
+        if (!emailChanged && !phoneChanged)
+        {
+            return new UpdateContactResult(
+                UpdateContactOutcome.NoChange,
+                null,
+                trimmedEmail,
+                trimmedPhone);
+        }
+
+        person.Email = trimmedEmail;
+        person.Phone = trimmedPhone;
+        person.UpdatedAtUtc = timeProvider.GetUtcNow().UtcDateTime;
+
+        var changedFields = new List<string>();
+        if (emailChanged) changedFields.Add(nameof(Person.Email));
+        if (phoneChanged) changedFields.Add(nameof(Person.Phone));
+
+        db.AuditLogs.Add(new AuditLog
+        {
+            EntityType = nameof(Person),
+            EntityId = personId.ToString(),
+            Action = "UpdateContact",
+            ActorUserId = actorUserId,
+            CreatedAtUtc = timeProvider.GetUtcNow().UtcDateTime,
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                OldEmail = oldEmail,
+                NewEmail = trimmedEmail,
+                OldPhone = oldPhone,
+                NewPhone = trimmedPhone,
+                ChangedFields = changedFields
+            })
+        });
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return new UpdateContactResult(
+            UpdateContactOutcome.Updated,
+            null,
+            trimmedEmail,
+            trimmedPhone);
+    }
+
     public async Task<List<PersonSearchResultItem>> SearchPersonsAsync(
         string query,
         int excludePersonId,
@@ -870,3 +973,17 @@ public sealed record PersonSearchResultItem(
     int RegistrationCount,
     DateTime? LastSeenAtUtc,
     string? LastSeenGameName);
+
+public sealed record UpdateContactResult(
+    UpdateContactOutcome Outcome,
+    string? Message,
+    string? NormalizedEmail,
+    string? NormalizedPhone);
+
+public enum UpdateContactOutcome
+{
+    Updated,
+    NotFound,
+    EmailAlreadyUsedByOtherPerson,
+    NoChange
+}

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -1258,6 +1258,29 @@ public class Program
                 })
             .RequireAuthorization(AuthorizationPolicies.StaffOnly);
         app.MapPost(
+                "/organizace/osoby/{personId:int}/kontakt",
+                async ([FromForm] string? email, [FromForm] string? phone, int personId, HttpContext httpContext, UserManager<ApplicationUser> userManager, PeopleReviewService peopleReviewService) =>
+                {
+                    var user = await userManager.GetUserAsync(httpContext.User);
+                    if (user is null)
+                    {
+                        return Results.LocalRedirect($"/Account/Login?ReturnUrl={Uri.EscapeDataString($"/organizace/osoby/{personId}")}");
+                    }
+
+                    var result = await peopleReviewService.UpdateContactAsync(personId, email, phone, user.Id);
+
+                    return result.Outcome switch
+                    {
+                        UpdateContactOutcome.NotFound => Results.NotFound(),
+                        UpdateContactOutcome.EmailAlreadyUsedByOtherPerson =>
+                            Results.LocalRedirect($"/organizace/osoby/{personId}?contact=email-conflict"),
+                        UpdateContactOutcome.NoChange =>
+                            Results.LocalRedirect($"/organizace/osoby/{personId}?contact=no-change"),
+                        _ => Results.LocalRedirect($"/organizace/osoby/{personId}?contact=updated")
+                    };
+                })
+            .RequireAuthorization(AuthorizationPolicies.StaffOnly);
+        app.MapPost(
                 "/organizace/prihlasky/{submissionId:int}/poznamka",
                 async ([FromForm] string note, HttpContext httpContext, int submissionId, UserManager<ApplicationUser> userManager, OrganizerSubmissionService organizerSubmissionService) =>
                 {

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.28</Version>
+    <Version>0.9.29</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/People/PeopleReviewServiceContactTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/People/PeopleReviewServiceContactTests.cs
@@ -1,0 +1,244 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.People;
+using Testcontainers.PostgreSql;
+
+namespace RegistraceOvcina.Web.Tests.Features.People;
+
+/// <summary>
+/// Integration tests for v0.9.29: organizer-editable contact info on PersonDetail.
+///
+/// Covers <see cref="PeopleReviewService.UpdateContactAsync"/>: normalization, the
+/// partial unique-email collision check, NoChange shortcut, soft-deleted lookup,
+/// and AuditLog emission. Runs against real Postgres so the partial unique index
+/// ("Email" IS NOT NULL AND "Email" != '') behaves the same way it does in prod.
+/// </summary>
+public sealed class PeopleReviewServiceContactTests : IAsyncLifetime
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 19, 12, 0, 0, DateTimeKind.Utc);
+    private const string ActorUserId = "test-organizer";
+
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:16-alpine")
+        .WithDatabase($"registrace_ovcina_people_contact_{Guid.NewGuid():N}")
+        .WithUsername("postgres")
+        .WithPassword("postgres")
+        .Build();
+
+    private DbContextOptions<ApplicationDbContext> _options = default!;
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync();
+
+        _options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_postgres.GetConnectionString())
+            .Options;
+
+        await using var db = new ApplicationDbContext(_options);
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _postgres.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task UpdateContactAsync_updates_email_and_phone()
+    {
+        await SeedAsync(CreatePerson(1, "Jakub", "Fila", 2010, null, null));
+
+        var service = CreateService();
+
+        var result = await service.UpdateContactAsync(1, "  Jakub@Example.CZ ", "+420 608 123 456", ActorUserId);
+
+        Assert.Equal(UpdateContactOutcome.Updated, result.Outcome);
+        Assert.Equal("jakub@example.cz", result.NormalizedEmail);
+        Assert.Equal("420608123456", result.NormalizedPhone);
+
+        await using var db = new ApplicationDbContext(_options);
+        var person = await db.People.SingleAsync();
+        Assert.Equal("jakub@example.cz", person.Email);
+        Assert.Equal("420608123456", person.Phone);
+        Assert.Equal(FixedUtc, person.UpdatedAtUtc);
+    }
+
+    [Fact]
+    public async Task UpdateContactAsync_email_conflict_returns_error_and_does_not_save()
+    {
+        await SeedAsync(
+            CreatePerson(1, "Jakub", "Fila", 2010, null, "111"),
+            CreatePerson(2, "Martin", "Fila", 2012, "taken@example.cz", "222"));
+
+        var service = CreateService();
+
+        var result = await service.UpdateContactAsync(1, "taken@example.cz", "999", ActorUserId);
+
+        Assert.Equal(UpdateContactOutcome.EmailAlreadyUsedByOtherPerson, result.Outcome);
+        Assert.False(string.IsNullOrWhiteSpace(result.Message));
+
+        await using var db = new ApplicationDbContext(_options);
+        var person = await db.People.SingleAsync(x => x.Id == 1);
+        Assert.Null(person.Email);
+        Assert.Equal("111", person.Phone);
+
+        Assert.Equal(0, await db.AuditLogs.CountAsync());
+    }
+
+    [Fact]
+    public async Task UpdateContactAsync_null_input_clears_fields()
+    {
+        await SeedAsync(CreatePerson(1, "Jakub", "Fila", 2010, "old@example.cz", "123456789"));
+
+        var service = CreateService();
+
+        var result = await service.UpdateContactAsync(1, "", "   ", ActorUserId);
+
+        Assert.Equal(UpdateContactOutcome.Updated, result.Outcome);
+        Assert.Null(result.NormalizedEmail);
+        Assert.Null(result.NormalizedPhone);
+
+        await using var db = new ApplicationDbContext(_options);
+        var person = await db.People.SingleAsync();
+        Assert.Null(person.Email);
+        Assert.Null(person.Phone);
+    }
+
+    [Fact]
+    public async Task UpdateContactAsync_identical_input_returns_NoChange()
+    {
+        await SeedAsync(CreatePerson(1, "Jakub", "Fila", 2010, "same@example.cz", "608123456"));
+
+        var service = CreateService();
+
+        // Input normalizes to the exact stored values — no work to do, no audit row.
+        var result = await service.UpdateContactAsync(1, "same@example.cz", "608123456", ActorUserId);
+
+        Assert.Equal(UpdateContactOutcome.NoChange, result.Outcome);
+
+        await using var db = new ApplicationDbContext(_options);
+        Assert.Equal(0, await db.AuditLogs.CountAsync());
+    }
+
+    [Fact]
+    public async Task UpdateContactAsync_person_not_found_returns_NotFound()
+    {
+        var service = CreateService();
+
+        var result = await service.UpdateContactAsync(9999, "x@y.cz", "608000000", ActorUserId);
+
+        Assert.Equal(UpdateContactOutcome.NotFound, result.Outcome);
+    }
+
+    [Fact]
+    public async Task UpdateContactAsync_soft_deleted_person_returns_NotFound()
+    {
+        // Soft-deleted Persons are hidden by the global query filter. The organizer
+        // should not be able to edit their contact by guessing the id.
+        await using (var seedDb = new ApplicationDbContext(_options))
+        {
+            seedDb.People.Add(new Person
+            {
+                Id = 1,
+                FirstName = "Deleted",
+                LastName = "Person",
+                BirthYear = 2010,
+                IsDeleted = true,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+            await seedDb.SaveChangesAsync();
+        }
+
+        var service = CreateService();
+
+        var result = await service.UpdateContactAsync(1, "x@y.cz", null, ActorUserId);
+
+        Assert.Equal(UpdateContactOutcome.NotFound, result.Outcome);
+    }
+
+    [Fact]
+    public async Task UpdateContactAsync_writes_AuditLog()
+    {
+        await SeedAsync(CreatePerson(1, "Jakub", "Fila", 2010, "old@example.cz", "111"));
+
+        var service = CreateService();
+
+        var result = await service.UpdateContactAsync(1, "new@example.cz", "222", ActorUserId);
+        Assert.Equal(UpdateContactOutcome.Updated, result.Outcome);
+
+        await using var db = new ApplicationDbContext(_options);
+        var audit = await db.AuditLogs.SingleAsync();
+
+        Assert.Equal("Person", audit.EntityType);
+        Assert.Equal("1", audit.EntityId);
+        Assert.Equal("UpdateContact", audit.Action);
+        Assert.Equal(ActorUserId, audit.ActorUserId);
+        Assert.Equal(FixedUtc, audit.CreatedAtUtc);
+        Assert.NotNull(audit.DetailsJson);
+        Assert.Contains("old@example.cz", audit.DetailsJson);
+        Assert.Contains("new@example.cz", audit.DetailsJson);
+        Assert.Contains("Email", audit.DetailsJson);
+        Assert.Contains("Phone", audit.DetailsJson);
+    }
+
+    [Fact]
+    public async Task UpdateContactAsync_same_email_different_case_is_not_a_conflict_with_self()
+    {
+        // A Person updating their own email to the same value with different casing
+        // should not trip the uniqueness check.
+        await SeedAsync(CreatePerson(1, "Jakub", "Fila", 2010, "same@example.cz", "111"));
+
+        var service = CreateService();
+
+        var result = await service.UpdateContactAsync(1, "SAME@EXAMPLE.CZ", "111", ActorUserId);
+
+        // Normalization lowercases → matches stored value → NoChange (no audit, no conflict).
+        Assert.Equal(UpdateContactOutcome.NoChange, result.Outcome);
+    }
+
+    private PeopleReviewService CreateService() =>
+        new(new TestDbContextFactory(_options), new FixedTimeProvider());
+
+    private async Task SeedAsync(params Person[] people)
+    {
+        await using var db = new ApplicationDbContext(_options);
+        db.People.AddRange(people);
+        await db.SaveChangesAsync();
+    }
+
+    private static Person CreatePerson(
+        int id,
+        string firstName,
+        string lastName,
+        int birthYear,
+        string? email,
+        string? phone) =>
+        new()
+        {
+            Id = id,
+            FirstName = firstName,
+            LastName = lastName,
+            BirthYear = birthYear,
+            Email = email,
+            Phone = phone,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        };
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now = new(FixedUtc);
+
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an always-visible email + phone editor card to `/organizace/osoby/{id}` so the organizer can fill in contact details before the v0.9.28 link-or-create-account flow runs.
- New `PeopleReviewService.UpdateContactAsync` normalizes input, checks the partial unique-email index (`"Email" IS NOT NULL AND "Email" != ''`) against other active Persons, emits an `AuditLog` row (`EntityType=Person`, `Action=UpdateContact`) with before/after values, and returns an `UpdateContactOutcome` (Updated / NoChange / EmailAlreadyUsedByOtherPerson / NotFound).
- New `POST /organizace/osoby/{id}/kontakt` endpoint (StaffOnly) redirects back to the page with `?contact=updated|email-conflict|no-change`. PersonDetail surfaces the right Czech status line and, after a successful save of a Person with no linked account, nudges the organizer toward the `/organizace/role` "Vytvořit/propojit účet" button.
- Bumps `<Version>` 0.9.28 → 0.9.29.

## Unblocks
The "set Person.Email before linking an account" scenario that came up when trying to manually link Petr Bartoš to `petr.match@gmail.com` — the page only displayed the email, it couldn't be edited.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 320 passed (baseline 312 + 8 new)
  - `UpdateContactAsync_updates_email_and_phone`
  - `UpdateContactAsync_email_conflict_returns_error_and_does_not_save`
  - `UpdateContactAsync_null_input_clears_fields`
  - `UpdateContactAsync_identical_input_returns_NoChange`
  - `UpdateContactAsync_person_not_found_returns_NotFound`
  - `UpdateContactAsync_soft_deleted_person_returns_NotFound`
  - `UpdateContactAsync_writes_AuditLog`
  - `UpdateContactAsync_same_email_different_case_is_not_a_conflict_with_self`
- [ ] Manual: edit an imported Person with no email, see the success banner and the link-or-create hint appear
- [ ] Manual: try the email already used by another active Person — red conflict banner points to merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)