### PR TITLE
fix(people): Copilot followups on contact editor (v0.9.30)

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/PersonDetail.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/PersonDetail.razor
@@ -13,8 +13,18 @@
 }
 else if (model is null)
 {
+    @* When the POST /kontakt endpoint returned NotFound it redirects here with
+       ?contact=not-found. Show the fuller, action-oriented message in that case
+       (Copilot v0.9.30 followup). Otherwise fall back to the generic warning. *@
     <div class="alert alert-warning" data-testid="person-detail-missing">
-        Osoba nebyla nalezena.
+        @if (ContactStatus == "not-found")
+        {
+            @("Osoba nebyla nalezena — možná byla smazána. Obnov stránku.")
+        }
+        else
+        {
+            @("Osoba nebyla nalezena.")
+        }
     </div>
 }
 else

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/PersonDetail.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/PersonDetail.razor
@@ -507,6 +507,7 @@ else
             "updated" => ("Kontakt uložen.", true, false),
             "email-conflict" => ("E-mail už používá jiná osoba. Pokud to je ta stejná, zkus nejprve sloučit osoby.", false, false),
             "no-change" => ("Nebyly uloženy žádné změny.", false, true),
+            "not-found" => ("Osoba nebyla nalezena — možná byla smazána. Obnov stránku.", false, false),
             _ => (null, false, false)
         };
 

--- a/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
+++ b/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using RegistraceOvcina.Web.Data;
 
 namespace RegistraceOvcina.Web.Features.People;
@@ -514,12 +515,18 @@ public sealed class PeopleReviewService(
         // Check email uniqueness against OTHER active Persons only.
         // Global query filter already excludes soft-deleted, so this naturally matches
         // the scope of the partial unique index ("Email" IS NOT NULL AND "Email" != '').
+        //
+        // Case-insensitive compare to match SubmissionService.UpdateAttendeeAsync — legacy
+        // imports have stored emails with mixed casing (e.g. "TEST@X.CZ"). Uses .ToLower()
+        // (Npgsql translates to LOWER()); do NOT use ToLowerInvariant() which Npgsql cannot
+        // translate — that pattern caused the v0.9.18 prod outage.
         if (!string.IsNullOrWhiteSpace(trimmedEmail)
             && !string.Equals(trimmedEmail, person.Email, StringComparison.OrdinalIgnoreCase))
         {
+            var normalizedEmail = trimmedEmail.ToLowerInvariant();
             var collision = await db.People
                 .AsNoTracking()
-                .AnyAsync(x => x.Id != personId && x.Email == trimmedEmail, cancellationToken);
+                .AnyAsync(x => x.Id != personId && x.Email != null && x.Email.ToLower() == normalizedEmail, cancellationToken);
 
             if (collision)
             {
@@ -571,7 +578,21 @@ public sealed class PeopleReviewService(
             })
         });
 
-        await db.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsUniqueEmailViolation(ex))
+        {
+            // Race between the application-level collision check above and SaveChangesAsync
+            // — another transaction claimed this email. Translate to the standard outcome so
+            // the organizer sees the expected "email already used" banner instead of a 500.
+            return new UpdateContactResult(
+                UpdateContactOutcome.EmailAlreadyUsedByOtherPerson,
+                "E-mail už používá jiná osoba (souběžná úprava).",
+                trimmedEmail,
+                trimmedPhone);
+        }
 
         return new UpdateContactResult(
             UpdateContactOutcome.Updated,
@@ -579,6 +600,11 @@ public sealed class PeopleReviewService(
             trimmedEmail,
             trimmedPhone);
     }
+
+    private static bool IsUniqueEmailViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException pg
+        && pg.SqlState == PostgresErrorCodes.UniqueViolation
+        && (pg.ConstraintName?.Contains("Email", StringComparison.OrdinalIgnoreCase) ?? false);
 
     public async Task<List<PersonSearchResultItem>> SearchPersonsAsync(
         string query,

--- a/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
+++ b/src/RegistraceOvcina.Web/Features/People/PeopleReviewService.cs
@@ -523,10 +523,12 @@ public sealed class PeopleReviewService(
         if (!string.IsNullOrWhiteSpace(trimmedEmail)
             && !string.Equals(trimmedEmail, person.Email, StringComparison.OrdinalIgnoreCase))
         {
-            var normalizedEmail = trimmedEmail.ToLowerInvariant();
+            // trimmedEmail is already lowercased upstream (Trim().ToLowerInvariant()),
+            // so use it directly as the normalized form. ToLower() on the column side
+            // is translated by Npgsql to Postgres LOWER() for case-insensitive compare.
             var collision = await db.People
                 .AsNoTracking()
-                .AnyAsync(x => x.Id != personId && x.Email != null && x.Email.ToLower() == normalizedEmail, cancellationToken);
+                .AnyAsync(x => x.Id != personId && x.Email != null && x.Email.ToLower() == trimmedEmail, cancellationToken);
 
             if (collision)
             {

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -1271,7 +1271,8 @@ public class Program
 
                     return result.Outcome switch
                     {
-                        UpdateContactOutcome.NotFound => Results.NotFound(),
+                        UpdateContactOutcome.NotFound =>
+                            Results.LocalRedirect($"/organizace/osoby/{personId}?contact=not-found"),
                         UpdateContactOutcome.EmailAlreadyUsedByOtherPerson =>
                             Results.LocalRedirect($"/organizace/osoby/{personId}?contact=email-conflict"),
                         UpdateContactOutcome.NoChange =>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.29</Version>
+    <Version>0.9.30</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/People/PeopleReviewServiceContactTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/People/PeopleReviewServiceContactTests.cs
@@ -197,6 +197,51 @@ public sealed class PeopleReviewServiceContactTests : IAsyncLifetime
         Assert.Equal(UpdateContactOutcome.NoChange, result.Outcome);
     }
 
+    [Fact]
+    public async Task UpdateContactAsync_case_insensitive_email_collision_detected()
+    {
+        // Copilot followup (v0.9.30): legacy imports have stored emails in mixed case.
+        // Person A's email is "TEST@X.CZ"; Person B tries to claim "test@x.cz".
+        // A case-sensitive Postgres `=` would miss this and surface a 500 at SaveChanges
+        // via the partial unique index. Collision MUST be detected at the app layer.
+        //
+        // Use direct SQL to seed A's email in uppercase — the normal UpdateContactAsync
+        // path lowercases on write, so we bypass it to reproduce the legacy-data shape.
+        await SeedAsync(
+            CreatePerson(1, "Anna", "Import", 2010, null, "111"),
+            CreatePerson(2, "Bedřich", "Novák", 2011, null, "222"));
+
+        await using (var seedDb = new ApplicationDbContext(_options))
+        {
+            await seedDb.Database.ExecuteSqlRawAsync(
+                """UPDATE "People" SET "Email" = 'TEST@X.CZ' WHERE "Id" = 1""");
+        }
+
+        var service = CreateService();
+
+        var result = await service.UpdateContactAsync(2, "test@x.cz", "222", ActorUserId);
+
+        Assert.Equal(UpdateContactOutcome.EmailAlreadyUsedByOtherPerson, result.Outcome);
+
+        // Person B's email should NOT have been written.
+        await using var db = new ApplicationDbContext(_options);
+        var b = await db.People.SingleAsync(x => x.Id == 2);
+        Assert.Null(b.Email);
+    }
+
+    // NOTE (v0.9.30 — Copilot followup #3):
+    // A test for the DbUpdateException race translation was considered but skipped
+    // per the plan's explicit allowance ("or skip this test and just rely on the
+    // hand-rolled logic"). Reasons:
+    //   1. Reproducing the real race requires a SaveChanges interceptor that holds
+    //      the app-level check's snapshot, which is brittle and slow.
+    //   2. Npgsql's `PostgresException.ConstraintName` is read-only with no public
+    //      constructor that sets it, so a hand-built fake can't exercise the
+    //      `IsUniqueEmailViolation` constraint-name check.
+    //   3. Manual QA on staging exercises the end-to-end path.
+    // The hand-rolled predicate in PeopleReviewService.IsUniqueEmailViolation is
+    // tight: SqlState == 23505 AND ConstraintName contains "Email".
+
     private PeopleReviewService CreateService() =>
         new(new TestDbContextFactory(_options), new FixedTimeProvider());
 


### PR DESCRIPTION
## Summary

Three follow-up fixes on v0.9.29's contact-editor, all flagged by Copilot post-merge of #179.

- **NotFound redirect**: `/kontakt` POST now redirects to `/organizace/osoby/{id}?contact=not-found` instead of returning a bare 404 that would navigate the organizer away from the UI. `PersonDetail.razor` renders a red banner for that case.
- **Case-insensitive email collision**: `UpdateContactAsync` now compares `x.Email.ToLower() == normalized` to match `SubmissionService.UpdateAttendeeAsync`. Uses `.ToLower()` (translates to Postgres `LOWER`), not `ToLowerInvariant()` on the column (would not translate; caused the v0.9.18 prod outage).
- **DbUpdateException race**: wraps `SaveChangesAsync` in a `try/catch` that translates a Postgres `23505` unique-violation on an Email constraint into `EmailAlreadyUsedByOtherPerson`, so the organizer sees the standard banner instead of a 500 if the check/save window loses a race.

Bumps version 0.9.29 -> 0.9.30.

## Test plan

- [x] `dotnet build` clean (0 warnings on Web project)
- [x] `dotnet test` full suite: 321 passing (baseline 318 + tests shipped in #179 that weren't in the count yet + 1 new)
- [x] New test: `UpdateContactAsync_case_insensitive_email_collision_detected` -- seeds legacy uppercase email via raw SQL, verifies lowercase input still detects the collision
- [ ] Manual QA on staging: NotFound banner appears when editing a just-deleted Person; case-insensitive conflict blocks save; no 500 on retried save
- **Skipped** (per plan's explicit allowance): race-translation unit test -- `Npgsql.PostgresException.ConstraintName` is read-only, no public constructor sets it, and a real race needs a test-only `SaveChanges` interceptor

## Notes

- `SubmissionService.UpdateAttendeeAsync` (line 526-531) uses `newEmail.ToLowerInvariant()` on the input and `p.Email.ToLower() == normalizedEmail` on the column. This PR matches that pattern exactly.
- The 3 Copilot threads on #179 (IDs 3126253816, 3126253858, 3126253885) will be resolved via GraphQL after merge since they are pinned to #179's diff.

Generated with [Claude Code](https://claude.com/claude-code)