### PR TITLE
Fix #181: recompute expected total from active registrations [v0.9.31]

### DIFF
--- a/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
+++ b/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
@@ -157,13 +157,17 @@ public sealed class GameStatsService(
         // cancelled (Registration.Status → Cancelled) without a re-save of the
         // submission. /organizace/platby (PaymentService) does the same recompute,
         // so dashboard and payments view can't disagree (issue #181).
+        //
+        // We reuse the `game` instance and the `registrations` list loaded above
+        // (already filtered to Status == Active), grouped by SubmissionId — no need
+        // to round-trip Game / Registrations / Person / FoodOrders again.
+        var registrationsBySubmission = registrations
+            .GroupBy(r => r.SubmissionId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
         var submittedSubmissions = await db.RegistrationSubmissions
             .AsNoTracking()
-            .Include(x => x.Game)
-            .Include(x => x.Registrations).ThenInclude(r => r.Person)
-            .Include(x => x.Registrations).ThenInclude(r => r.FoodOrders)
             .Include(x => x.Payments)
-            .AsSplitQuery()
             .Where(x => x.GameId == gameId && x.Status == SubmissionStatus.Submitted)
             .ToListAsync(cancellationToken);
 
@@ -175,7 +179,8 @@ public sealed class GameStatsService(
 
         foreach (var sub in submittedSubmissions)
         {
-            var computedExpected = pricingService.CalculateExpectedTotal(sub.Game, sub.Registrations, sub.VoluntaryDonation);
+            var subRegistrations = registrationsBySubmission.GetValueOrDefault(sub.Id, []);
+            var computedExpected = pricingService.CalculateExpectedTotal(game, subRegistrations, sub.VoluntaryDonation);
             var paid = sub.Payments.Sum(p => p.Amount);
 
             expectedTotal += computedExpected;

--- a/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
+++ b/src/RegistraceOvcina.Web/Features/Stats/GameStatsService.cs
@@ -1,9 +1,12 @@
 using Microsoft.EntityFrameworkCore;
 using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.Submissions;
 
 namespace RegistraceOvcina.Web.Features.Stats;
 
-public sealed class GameStatsService(IDbContextFactory<ApplicationDbContext> dbContextFactory)
+public sealed class GameStatsService(
+    IDbContextFactory<ApplicationDbContext> dbContextFactory,
+    SubmissionPricingService pricingService)
 {
     public async Task<GameStats?> GetGameStatsAsync(int gameId, CancellationToken cancellationToken = default)
     {
@@ -149,29 +152,55 @@ public sealed class GameStatsService(IDbContextFactory<ApplicationDbContext> dbC
         var kingdomUnassigned = playerCount - totalAssignedPlayers;
 
         // --- Financial ---
+        // Recompute expected total per submission from active registrations on every
+        // load — the persisted ExpectedTotalAmount drifts when an attendee is
+        // cancelled (Registration.Status → Cancelled) without a re-save of the
+        // submission. /organizace/platby (PaymentService) does the same recompute,
+        // so dashboard and payments view can't disagree (issue #181).
         var submittedSubmissions = await db.RegistrationSubmissions
             .AsNoTracking()
+            .Include(x => x.Game)
+            .Include(x => x.Registrations).ThenInclude(r => r.Person)
+            .Include(x => x.Registrations).ThenInclude(r => r.FoodOrders)
             .Include(x => x.Payments)
+            .AsSplitQuery()
             .Where(x => x.GameId == gameId && x.Status == SubmissionStatus.Submitted)
             .ToListAsync(cancellationToken);
 
-        var expectedTotal = submittedSubmissions.Sum(x => x.ExpectedTotalAmount);
-        var paidTotal = submittedSubmissions.Sum(x => x.Payments.Sum(p => p.Amount));
-        var donationTotal = submittedSubmissions.Sum(x => x.VoluntaryDonation);
-        var unpaidSubmissionCount = submittedSubmissions
-            .Count(x => x.Payments.Sum(p => p.Amount) < x.ExpectedTotalAmount && x.ExpectedTotalAmount > 0);
+        var expectedTotal = 0m;
+        var paidTotal = 0m;
+        var donationTotal = 0m;
+        var unpaidSubmissionCount = 0;
+        var donorEntries = new List<DonorEntry>();
 
-        // Named donor breakdown, sorted largest-first. Only submissions with an
-        // actual voluntary contribution are included.
-        var donors = submittedSubmissions
-            .Where(x => x.VoluntaryDonation > 0m)
-            .OrderByDescending(x => x.VoluntaryDonation)
-            .ThenBy(x => x.PrimaryContactName, StringComparer.CurrentCulture)
-            .Select(x => new DonorEntry(
-                x.Id,
-                string.IsNullOrWhiteSpace(x.PrimaryContactName) ? "(bez jména)" : x.PrimaryContactName,
-                x.PrimaryEmail,
-                x.VoluntaryDonation))
+        foreach (var sub in submittedSubmissions)
+        {
+            var computedExpected = pricingService.CalculateExpectedTotal(sub.Game, sub.Registrations, sub.VoluntaryDonation);
+            var paid = sub.Payments.Sum(p => p.Amount);
+
+            expectedTotal += computedExpected;
+            paidTotal += paid;
+            donationTotal += sub.VoluntaryDonation;
+
+            if (computedExpected > 0 && paid < computedExpected)
+            {
+                unpaidSubmissionCount++;
+            }
+
+            if (sub.VoluntaryDonation > 0m)
+            {
+                donorEntries.Add(new DonorEntry(
+                    sub.Id,
+                    string.IsNullOrWhiteSpace(sub.PrimaryContactName) ? "(bez jména)" : sub.PrimaryContactName,
+                    sub.PrimaryEmail,
+                    sub.VoluntaryDonation));
+            }
+        }
+
+        // Named donor breakdown, sorted largest-first.
+        var donors = donorEntries
+            .OrderByDescending(x => x.Amount)
+            .ThenBy(x => x.ContactName, StringComparer.CurrentCulture)
             .ToList();
 
         // --- Food / Meals ---

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.30</Version>
+    <Version>0.9.31</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/GameStatsCharacterPrepWidgetTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/GameStatsCharacterPrepWidgetTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using RegistraceOvcina.Web.Data;
 using RegistraceOvcina.Web.Features.Stats;
+using RegistraceOvcina.Web.Features.Submissions;
 
 namespace RegistraceOvcina.Web.Tests.Features.CharacterPrep;
 
@@ -35,7 +36,7 @@ public sealed class GameStatsCharacterPrepWidgetTests
         await AddSubmissionAsync(options, submissionId: 3,
             players: new[] { new PlayerSpec(hasName: true, hasEquipment: false) });
 
-        var service = new GameStatsService(new TestDbContextFactory(options));
+        var service = new GameStatsService(new TestDbContextFactory(options), new SubmissionPricingService(TimeProvider.System));
         var stats = await service.GetGameStatsAsync(GameId);
 
         Assert.NotNull(stats);
@@ -63,7 +64,7 @@ public sealed class GameStatsCharacterPrepWidgetTests
             players: new[] { new PlayerSpec(hasName: true, hasEquipment: true) },
             isDeleted: true);
 
-        var service = new GameStatsService(new TestDbContextFactory(options));
+        var service = new GameStatsService(new TestDbContextFactory(options), new SubmissionPricingService(TimeProvider.System));
         var stats = await service.GetGameStatsAsync(GameId);
 
         Assert.NotNull(stats);
@@ -77,7 +78,7 @@ public sealed class GameStatsCharacterPrepWidgetTests
         var options = CreateOptions();
         await SeedGameAsync(options);
 
-        var service = new GameStatsService(new TestDbContextFactory(options));
+        var service = new GameStatsService(new TestDbContextFactory(options), new SubmissionPricingService(TimeProvider.System));
         var stats = await service.GetGameStatsAsync(GameId);
 
         Assert.NotNull(stats);

--- a/tests/RegistraceOvcina.Web.Tests/Features/Stats/GameStatsFinancialTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/Stats/GameStatsFinancialTests.cs
@@ -1,0 +1,226 @@
+using Microsoft.EntityFrameworkCore;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.Stats;
+using RegistraceOvcina.Web.Features.Submissions;
+
+namespace RegistraceOvcina.Web.Tests.Features.Stats;
+
+/// <summary>
+/// Regression coverage for issue #181 — the dashboard's "bez plné platby"
+/// counter and ExpectedTotal must reflect the same on-the-fly pricing recompute
+/// that /organizace/platby uses, so a cancelled attendee doesn't make a fully
+/// paid submission look unpaid.
+/// </summary>
+public sealed class GameStatsFinancialTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 24, 12, 0, 0, DateTimeKind.Utc);
+    private const int GameId = 1;
+
+    [Fact]
+    public async Task UnpaidCount_ignores_cancelled_attendees_when_remaining_active_is_paid()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        // Original household: 3 players → frozen ExpectedTotalAmount = 3600
+        // After 1 cancellation: only 2 active, real cost = 2400, parent paid 2400.
+        // Buggy code counts this as unpaid (2400 < 3600). Fixed code does not.
+        await AddSubmissionAsync(options,
+            submissionId: 1,
+            persistedExpectedTotal: 3600m,
+            activePlayers: 2,
+            cancelledPlayers: 1,
+            paidAmount: 2400m);
+
+        var stats = await BuildStatsAsync(options);
+
+        Assert.NotNull(stats);
+        Assert.Equal(0, stats!.UnpaidSubmissionCount);
+        Assert.Equal(2400m, stats.ExpectedTotal);
+        Assert.Equal(2400m, stats.PaidTotal);
+    }
+
+    [Fact]
+    public async Task UnpaidCount_still_counts_genuinely_underpaid_submission()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        // 2 active players, only half paid → must show as unpaid.
+        await AddSubmissionAsync(options,
+            submissionId: 1,
+            persistedExpectedTotal: 2400m,
+            activePlayers: 2,
+            cancelledPlayers: 0,
+            paidAmount: 1200m);
+
+        var stats = await BuildStatsAsync(options);
+
+        Assert.NotNull(stats);
+        Assert.Equal(1, stats!.UnpaidSubmissionCount);
+        Assert.Equal(2400m, stats.ExpectedTotal);
+        Assert.Equal(1200m, stats.PaidTotal);
+    }
+
+    [Fact]
+    public async Task ExpectedTotal_recomputes_when_all_attendees_cancelled()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+
+        // Whole household cancelled but submission still Submitted.
+        // Frozen ExpectedTotalAmount=1200 must NOT show in dashboard total.
+        await AddSubmissionAsync(options,
+            submissionId: 1,
+            persistedExpectedTotal: 1200m,
+            activePlayers: 0,
+            cancelledPlayers: 1,
+            paidAmount: 0m);
+
+        var stats = await BuildStatsAsync(options);
+
+        Assert.NotNull(stats);
+        Assert.Equal(0m, stats!.ExpectedTotal);
+        Assert.Equal(0, stats.UnpaidSubmissionCount);
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static async Task<GameStats?> BuildStatsAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        var pricing = new SubmissionPricingService(TimeProvider.System);
+        var service = new GameStatsService(new TestDbContextFactory(options), pricing);
+        return await service.GetGameStatsAsync(GameId);
+    }
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedGameAsync(DbContextOptions<ApplicationDbContext> options)
+    {
+        await using var db = new ApplicationDbContext(options);
+        db.Games.Add(new Game
+        {
+            Id = GameId,
+            Name = "Ovčina 2026",
+            StartsAtUtc = FixedUtc.AddDays(7),
+            EndsAtUtc = FixedUtc.AddDays(9),
+            RegistrationClosesAtUtc = FixedUtc.AddDays(-2),
+            MealOrderingClosesAtUtc = FixedUtc.AddDays(-5),
+            PaymentDueAtUtc = FixedUtc.AddDays(5),
+            PlayerBasePrice = 1200m,
+            AdultHelperBasePrice = 800m,
+            BankAccount = "x",
+            BankAccountName = "y",
+            VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+            IsPublished = true,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task AddSubmissionAsync(
+        DbContextOptions<ApplicationDbContext> options,
+        int submissionId,
+        decimal persistedExpectedTotal,
+        int activePlayers,
+        int cancelledPlayers,
+        decimal paidAmount)
+    {
+        await using var db = new ApplicationDbContext(options);
+        var userId = "user-" + submissionId;
+        db.Users.Add(new ApplicationUser
+        {
+            Id = userId,
+            DisplayName = "U" + submissionId,
+            Email = $"u{submissionId}@example.cz",
+            NormalizedEmail = $"U{submissionId}@EXAMPLE.CZ",
+            UserName = $"u{submissionId}@example.cz",
+            NormalizedUserName = $"U{submissionId}@EXAMPLE.CZ",
+            EmailConfirmed = true,
+            IsActive = true,
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            CreatedAtUtc = FixedUtc
+        });
+        db.RegistrationSubmissions.Add(new RegistrationSubmission
+        {
+            Id = submissionId,
+            GameId = GameId,
+            RegistrantUserId = userId,
+            PrimaryContactName = "Domácnost " + submissionId,
+            PrimaryEmail = $"u{submissionId}@example.cz",
+            PrimaryPhone = "777000000",
+            Status = SubmissionStatus.Submitted,
+            SubmittedAtUtc = FixedUtc,
+            LastEditedAtUtc = FixedUtc,
+            ExpectedTotalAmount = persistedExpectedTotal
+        });
+        await db.SaveChangesAsync();
+
+        var personSeq = 0;
+        for (var i = 0; i < activePlayers; i++)
+        {
+            personSeq++;
+            AddPlayer(db, submissionId, personSeq, RegistrationStatus.Active);
+        }
+        for (var i = 0; i < cancelledPlayers; i++)
+        {
+            personSeq++;
+            AddPlayer(db, submissionId, personSeq, RegistrationStatus.Cancelled);
+        }
+
+        if (paidAmount != 0m)
+        {
+            db.Payments.Add(new Payment
+            {
+                SubmissionId = submissionId,
+                Amount = paidAmount,
+                Currency = "CZK",
+                RecordedAtUtc = FixedUtc,
+                Method = PaymentMethod.BankTransfer
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+
+    private static void AddPlayer(ApplicationDbContext db, int submissionId, int personSeq, RegistrationStatus status)
+    {
+        var pid = submissionId * 100 + personSeq;
+        // Distinct surnames so each player is the "first child" in its family group
+        // and gets PlayerBasePrice unconditionally — keeps the test free of
+        // tiered-pricing math.
+        db.People.Add(new Person
+        {
+            Id = pid,
+            FirstName = "Kid" + personSeq,
+            LastName = "Family" + pid,
+            BirthYear = 2015,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+        db.Registrations.Add(new Registration
+        {
+            Id = pid,
+            SubmissionId = submissionId,
+            PersonId = pid,
+            AttendeeType = AttendeeType.Player,
+            Status = status,
+            CreatedAtUtc = FixedUtc,
+            UpdatedAtUtc = FixedUtc
+        });
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}


### PR DESCRIPTION
## Summary

- Dashboard "bez plné platby" counter and ExpectedTotal now recompute on every load using `SubmissionPricingService.CalculateExpectedTotal`, mirroring how `/organizace/platby` (PaymentService) already works.
- Persisted `Submission.ExpectedTotalAmount` was the source of truth before — but it freezes at submission time and goes stale when an attendee is later cancelled (`Registration.Status -> Cancelled` doesn't trigger a price re-save). Result: paid-up households flagged as unpaid (16 reported vs 4 reality).
- 3 new regression tests in `GameStatsFinancialTests`.
- v0.9.30 → v0.9.31. No migration.

Fixes #181.

## Test plan

- [x] `dotnet test` — 324/324 pass (was 321 + 3 new)
- [ ] After deploy: open `/organizace/hry/1/statistiky`, confirm action-items banner now matches `/organizace/platby` (3 nedoplatek + 1 neuhrazena = 4)
- [ ] Confirm hero KPI "X / Y Kč zaplaceno" total looks plausible (was inflated by stale frozen totals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)