### PR TITLE
Add #183: bulk-email selection UI on /organizace/posta [v0.9.33]

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
@@ -61,6 +61,11 @@ else
                             {
                                 <span class="badge bg-danger align-self-center">Odeslání se nezdařilo.</span>
                             }
+                            @if (bulkSent.HasValue)
+                            {
+                                var failedNote = bulkFailed is > 0 ? $" (selhalo {bulkFailed})" : "";
+                                <span class="badge bg-success align-self-center" data-testid="bulk-send-result">Hromadně odesláno: @bulkSent zpráv@(failedNote)</span>
+                            }
                             <form method="post" action="/organizace/posta/sync">
                                 <AntiforgeryToken />
                                 <button type="submit" class="btn btn-outline-primary" data-testid="inbox-sync-button">Synchronizovat</button>
@@ -74,9 +79,14 @@ else
         @if (InboxService.CanReply)
         {
             <div class="col-12">
-                <button type="button" class="btn btn-primary mb-3" @onclick="ToggleCompose">
-                    @(showCompose ? "Skrýt" : "Nová zpráva")
-                </button>
+                <div class="d-flex gap-2 mb-3">
+                    <button type="button" class="btn btn-primary" @onclick="ToggleCompose" data-testid="inbox-compose-toggle">
+                        @(showCompose ? "Skrýt" : "Nová zpráva")
+                    </button>
+                    <button type="button" class="btn btn-outline-primary" @onclick="ToggleBulkCompose" data-testid="inbox-bulk-compose-toggle">
+                        @(showBulkCompose ? "Skrýt hromadnou" : "Hromadná zpráva")
+                    </button>
+                </div>
 
                 @if (showCompose)
                 {
@@ -98,6 +108,62 @@ else
                                     <textarea name="Body" class="form-control" rows="5" placeholder="Dobrý den,..." required></textarea>
                                 </div>
                                 <button type="submit" class="btn btn-primary">Odeslat</button>
+                            </form>
+                        </div>
+                    </div>
+                }
+
+                @if (showBulkCompose)
+                {
+                    <div class="card shadow-sm mb-4 border-primary-subtle" data-testid="inbox-bulk-compose-card">
+                        <div class="card-body p-4">
+                            <h3 class="h5 mb-3">Hromadná zpráva</h3>
+                            <p class="text-secondary small mb-3">
+                                Odešle stejnou zprávu všem vybraným příjemcům. Adresy se deduplikují &mdash; jedna domácnost dostane zprávu jen jednou, i když je přihlášena na více her.
+                            </p>
+                            <form method="post" action="/organizace/posta/hromadne"
+                                  onsubmit="return confirm('Opravdu odeslat zprávu všem vybraným příjemcům? Tato akce nelze vrátit.');">
+                                <AntiforgeryToken />
+
+                                <div class="mb-3">
+                                    <label class="form-label fw-semibold">Příjemci</label>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="radio" name="recipientMode" id="bulk-mode-game" value="game" checked />
+                                        <label class="form-check-label" for="bulk-mode-game">
+                                            Účastníci konkrétní hry
+                                        </label>
+                                    </div>
+                                    <div class="ms-4 mb-2">
+                                        <select name="gameId" class="form-select" data-testid="inbox-bulk-game">
+                                            @if (bulkGames.Count == 0)
+                                            {
+                                                <option value="">(Žádné hry)</option>
+                                            }
+                                            @foreach (var g in bulkGames)
+                                            {
+                                                var c = bulkRecipientCounts is not null && bulkRecipientCounts.CountByGameId.TryGetValue(g.Id, out var n) ? n : 0;
+                                                <option value="@g.Id">@g.Name (@c příjemců)</option>
+                                            }
+                                        </select>
+                                    </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="radio" name="recipientMode" id="bulk-mode-all" value="all" />
+                                        <label class="form-check-label" for="bulk-mode-all">
+                                            Všichni registrovaní účastníci
+                                            <span class="text-muted small">(@(bulkRecipientCounts?.AllCount ?? 0) příjemců)</span>
+                                        </label>
+                                    </div>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label class="form-label">Předmět</label>
+                                    <input name="Subject" class="form-control" placeholder="Ovčina — ..." required />
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Text zprávy</label>
+                                    <textarea name="Body" class="form-control" rows="6" placeholder="Dobrý den,..." required></textarea>
+                                </div>
+                                <button type="submit" class="btn btn-primary" data-testid="inbox-bulk-submit">Odeslat hromadně</button>
                             </form>
                         </div>
                     </div>
@@ -232,13 +298,27 @@ else
     [SupplyParameterFromQuery(Name = "sendError")]
     private int? sendError { get; set; }
 
+    [SupplyParameterFromQuery(Name = "bulkSent")]
+    private int? bulkSent { get; set; }
+
+    [SupplyParameterFromQuery(Name = "bulkFailed")]
+    private int? bulkFailed { get; set; }
+
     private InboxPageResult? result;
     private bool showCompose;
+    private bool showBulkCompose;
     private bool autoSynced;
+    private List<GameLookupItem> bulkGames = new();
+    private BulkRecipientCounts? bulkRecipientCounts;
 
     private void ToggleCompose()
     {
         showCompose = !showCompose;
+    }
+
+    private void ToggleBulkCompose()
+    {
+        showBulkCompose = !showBulkCompose;
     }
 
     private EmailDirection? GetDirectionFilter() => tab switch
@@ -270,5 +350,12 @@ else
         }
 
         result = await InboxService.GetMessagesAsync(page, directionFilter: GetDirectionFilter());
+
+        // Load bulk-compose data only when the organizer can actually send (mailbox configured).
+        if (InboxService.CanReply)
+        {
+            bulkGames = await InboxService.GetGamesForBulkEmailAsync();
+            bulkRecipientCounts = await InboxService.GetBulkRecipientCountsAsync();
+        }
     }
 }

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
@@ -122,20 +122,29 @@ else
                                 Odešle stejnou zprávu všem vybraným příjemcům. Adresy se deduplikují &mdash; jedna domácnost dostane zprávu jen jednou, i když je přihlášena na více her.
                             </p>
                             <form method="post" action="/organizace/posta/hromadne"
-                                  onsubmit="return confirm('Opravdu odeslat zprávu všem vybraným příjemcům? Tato akce nelze vrátit.');">
+                                  onsubmit="return confirm('Opravdu odeslat zprávu všem vybraným příjemcům? Tuto akci nelze vrátit.');">
                                 <AntiforgeryToken />
 
+                                @{
+                                    // Default to "all" when there are no games — otherwise the
+                                    // "game" radio is checked but the gameId select is empty,
+                                    // and a strict server check would reject the submit. Server
+                                    // also enforces this; the UI default just keeps the
+                                    // happy path obvious.
+                                    var hasGames = bulkGames.Count > 0;
+                                    var defaultGameMode = hasGames;
+                                }
                                 <div class="mb-3">
                                     <label class="form-label fw-semibold">Příjemci</label>
                                     <div class="form-check">
-                                        <input class="form-check-input" type="radio" name="recipientMode" id="bulk-mode-game" value="game" checked />
+                                        <input class="form-check-input" type="radio" name="recipientMode" id="bulk-mode-game" value="game" checked="@defaultGameMode" disabled="@(!hasGames)" />
                                         <label class="form-check-label" for="bulk-mode-game">
                                             Účastníci konkrétní hry
                                         </label>
                                     </div>
                                     <div class="ms-4 mb-2">
-                                        <select name="gameId" class="form-select" data-testid="inbox-bulk-game">
-                                            @if (bulkGames.Count == 0)
+                                        <select name="gameId" class="form-select" data-testid="inbox-bulk-game" disabled="@(!hasGames)">
+                                            @if (!hasGames)
                                             {
                                                 <option value="">(Žádné hry)</option>
                                             }
@@ -147,7 +156,7 @@ else
                                         </select>
                                     </div>
                                     <div class="form-check">
-                                        <input class="form-check-input" type="radio" name="recipientMode" id="bulk-mode-all" value="all" />
+                                        <input class="form-check-input" type="radio" name="recipientMode" id="bulk-mode-all" value="all" checked="@(!hasGames)" />
                                         <label class="form-check-label" for="bulk-mode-all">
                                             Všichni registrovaní účastníci
                                             <span class="text-muted small">(@(bulkRecipientCounts?.AllCount ?? 0) příjemců)</span>

--- a/src/RegistraceOvcina.Web/Features/Email/InboxService.cs
+++ b/src/RegistraceOvcina.Web/Features/Email/InboxService.cs
@@ -469,6 +469,25 @@ public sealed class InboxService(
             .ToList();
     }
 
+    /// <summary>
+    /// Returns recipient counts for the bulk-compose UI so organizers can see
+    /// how many addresses each scope hits before they send. The "all" count
+    /// is computed via the same DISTINCT pipeline as <see cref="GetBulkRecipientsAsync"/>,
+    /// so it equals the actual send target — not a naive sum of per-game counts
+    /// (a household registered for two games is a single recipient).
+    /// </summary>
+    public async Task<BulkRecipientCounts> GetBulkRecipientCountsAsync(CancellationToken ct = default)
+    {
+        var allCount = (await GetBulkRecipientsAsync(null, ct)).Count;
+        var games = await GetGamesForBulkEmailAsync(ct);
+        var perGame = new Dictionary<int, int>(games.Count);
+        foreach (var g in games)
+        {
+            perGame[g.Id] = (await GetBulkRecipientsAsync(g.Id, ct)).Count;
+        }
+        return new BulkRecipientCounts(allCount, perGame);
+    }
+
     public async Task<(int Sent, int Failed)> SendBulkEmailAsync(
         List<string> recipients,
         string subject,
@@ -512,3 +531,5 @@ public sealed record InboxPageResult(
 public sealed record SubmissionLookupItem(int Id, string Label);
 public sealed record PersonLookupItem(int Id, string Name);
 public sealed record GameLookupItem(int Id, string Name);
+
+public sealed record BulkRecipientCounts(int AllCount, IReadOnlyDictionary<int, int> CountByGameId);

--- a/src/RegistraceOvcina.Web/Features/Email/InboxService.cs
+++ b/src/RegistraceOvcina.Web/Features/Email/InboxService.cs
@@ -471,21 +471,64 @@ public sealed class InboxService(
 
     /// <summary>
     /// Returns recipient counts for the bulk-compose UI so organizers can see
-    /// how many addresses each scope hits before they send. The "all" count
-    /// is computed via the same DISTINCT pipeline as <see cref="GetBulkRecipientsAsync"/>,
-    /// so it equals the actual send target — not a naive sum of per-game counts
-    /// (a household registered for two games is a single recipient).
+    /// how many addresses each scope hits before they send. The counts equal
+    /// the actual send target (same DISTINCT-after-trim+lower pipeline as
+    /// <see cref="GetBulkRecipientsAsync"/>), so a household registered for
+    /// two games is counted once in "all" but once per game it appears in.
+    /// Counts are computed server-side via <c>UNION</c> + <c>CountAsync</c>
+    /// over a single shared DbContext — no full lists are materialized.
     /// </summary>
     public async Task<BulkRecipientCounts> GetBulkRecipientCountsAsync(CancellationToken ct = default)
     {
-        var allCount = (await GetBulkRecipientsAsync(null, ct)).Count;
-        var games = await GetGamesForBulkEmailAsync(ct);
-        var perGame = new Dictionary<int, int>(games.Count);
-        foreach (var g in games)
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+
+        var allCount = await ComputeRecipientCountAsync(db, gameId: null, ct);
+
+        var gameIds = await db.Games
+            .Where(g => g.IsPublished)
+            .OrderByDescending(g => g.StartsAtUtc)
+            .Select(g => g.Id)
+            .ToListAsync(ct);
+
+        var perGame = new Dictionary<int, int>(gameIds.Count);
+        foreach (var gid in gameIds)
         {
-            perGame[g.Id] = (await GetBulkRecipientsAsync(g.Id, ct)).Count;
+            perGame[gid] = await ComputeRecipientCountAsync(db, gid, ct);
         }
         return new BulkRecipientCounts(allCount, perGame);
+    }
+
+    private static async Task<int> ComputeRecipientCountAsync(ApplicationDbContext db, int? gameId, CancellationToken ct)
+    {
+        // Trim + ToLower (NOT ToLowerInvariant — Npgsql can't translate that;
+        // see MEMORY.md / v0.9.18 outage) push to SQL; Union becomes UNION
+        // which is implicitly DISTINCT, and CountAsync stays server-side.
+        if (gameId is { } gid)
+        {
+            var submissionEmails = db.RegistrationSubmissions
+                .Where(s => s.GameId == gid && !s.IsDeleted && s.Status != SubmissionStatus.Cancelled
+                    && s.PrimaryEmail != null && s.PrimaryEmail != "")
+                .Select(s => s.PrimaryEmail.Trim().ToLower());
+
+            var registrationEmails = db.Registrations
+                .Where(r => r.Submission.GameId == gid && !r.Submission.IsDeleted
+                    && r.Submission.Status != SubmissionStatus.Cancelled
+                    && r.ContactEmail != null && r.ContactEmail != "")
+                .Select(r => r.ContactEmail!.Trim().ToLower());
+
+            return await submissionEmails.Union(registrationEmails).CountAsync(ct);
+        }
+
+        var personEmails = db.People
+            .Where(p => !p.IsDeleted && p.Email != null && p.Email != "")
+            .Select(p => p.Email!.Trim().ToLower());
+
+        var allSubmissionEmails = db.RegistrationSubmissions
+            .Where(s => !s.IsDeleted && s.Status != SubmissionStatus.Cancelled
+                && s.PrimaryEmail != null && s.PrimaryEmail != "")
+            .Select(s => s.PrimaryEmail.Trim().ToLower());
+
+        return await personEmails.Union(allSubmissionEmails).CountAsync(ct);
     }
 
     public async Task<(int Sent, int Failed)> SendBulkEmailAsync(

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -1176,9 +1176,23 @@ public class Program
                         return Results.LocalRedirect("/organizace/posta?sendError=1");
                     }
 
-                    // recipientMode == "all" → null (every registered household);
-                    // otherwise scope to the chosen game.
-                    var scopeGameId = string.Equals(recipientMode, "all", StringComparison.Ordinal) ? null : gameId;
+                    // Strict mode validation: only "all" or "game" are accepted, and
+                    // "game" requires a non-null gameId. A missing/garbled mode must
+                    // NOT silently fall through to "send to everyone" — that's the
+                    // worst-case footgun for a bulk-email button.
+                    int? scopeGameId;
+                    if (string.Equals(recipientMode, "all", StringComparison.Ordinal))
+                    {
+                        scopeGameId = null;
+                    }
+                    else if (string.Equals(recipientMode, "game", StringComparison.Ordinal) && gameId.HasValue)
+                    {
+                        scopeGameId = gameId;
+                    }
+                    else
+                    {
+                        return Results.LocalRedirect("/organizace/posta?sendError=1");
+                    }
 
                     var recipients = await inboxService.GetBulkRecipientsAsync(scopeGameId, httpContext.RequestAborted);
                     if (recipients.Count == 0)

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -1163,7 +1163,7 @@ public class Program
             .RequireAuthorization(AuthorizationPolicies.StaffOnly);
         app.MapPost(
                 "/organizace/posta/hromadne",
-                async ([FromForm] string subject, [FromForm] string body, [FromForm] int? gameId, HttpContext httpContext, UserManager<ApplicationUser> userManager, InboxService inboxService) =>
+                async ([FromForm] string subject, [FromForm] string body, [FromForm] string? recipientMode, [FromForm] int? gameId, HttpContext httpContext, UserManager<ApplicationUser> userManager, InboxService inboxService) =>
                 {
                     var user = await userManager.GetUserAsync(httpContext.User);
                     if (user is null)
@@ -1176,7 +1176,11 @@ public class Program
                         return Results.LocalRedirect("/organizace/posta?sendError=1");
                     }
 
-                    var recipients = await inboxService.GetBulkRecipientsAsync(gameId, httpContext.RequestAborted);
+                    // recipientMode == "all" → null (every registered household);
+                    // otherwise scope to the chosen game.
+                    var scopeGameId = string.Equals(recipientMode, "all", StringComparison.Ordinal) ? null : gameId;
+
+                    var recipients = await inboxService.GetBulkRecipientsAsync(scopeGameId, httpContext.RequestAborted);
                     if (recipients.Count == 0)
                     {
                         return Results.LocalRedirect("/organizace/posta?sendError=1");

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.30</Version>
+    <Version>0.9.33</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/Email/InboxBulkRecipientsTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/Email/InboxBulkRecipientsTests.cs
@@ -1,0 +1,173 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using RegistraceOvcina.Web.Data;
+using RegistraceOvcina.Web.Features.Email;
+
+namespace RegistraceOvcina.Web.Tests.Features.Email;
+
+/// <summary>
+/// Issue #183 — bulk-compose UI on /organizace/posta needs accurate per-game
+/// and "all" recipient counts so organizers can see who they're about to email
+/// before they confirm. Counts must dedup households shared across games and
+/// must skip cancelled / soft-deleted submissions.
+/// </summary>
+public sealed class InboxBulkRecipientsTests
+{
+    private static readonly DateTime FixedUtc = new(2026, 4, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task Counts_dedup_household_shared_between_two_games()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options, builder =>
+        {
+            builder.AddGame(1, "Ovčina 2026");
+            builder.AddGame(2, "Ovčina 2027");
+            // Same household submits to both games with the same primary email.
+            builder.AddSubmission(gameId: 1, primaryEmail: "rodina@example.cz");
+            builder.AddSubmission(gameId: 2, primaryEmail: "rodina@example.cz");
+            // Distinct household for game 1 only.
+            builder.AddSubmission(gameId: 1, primaryEmail: "druha@example.cz");
+        });
+
+        var service = BuildService(options);
+        var counts = await service.GetBulkRecipientCountsAsync();
+
+        Assert.Equal(2, counts.AllCount); // dedup across games
+        Assert.Equal(2, counts.CountByGameId[1]);
+        Assert.Equal(1, counts.CountByGameId[2]);
+    }
+
+    [Fact]
+    public async Task Counts_exclude_cancelled_and_soft_deleted_submissions()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options, builder =>
+        {
+            builder.AddGame(1, "Ovčina 2026");
+            builder.AddSubmission(gameId: 1, primaryEmail: "active@example.cz");
+            builder.AddSubmission(gameId: 1, primaryEmail: "cancelled@example.cz", status: SubmissionStatus.Cancelled);
+            builder.AddSubmission(gameId: 1, primaryEmail: "deleted@example.cz", isDeleted: true);
+        });
+
+        var service = BuildService(options);
+        var counts = await service.GetBulkRecipientCountsAsync();
+
+        Assert.Equal(1, counts.AllCount);
+        Assert.Equal(1, counts.CountByGameId[1]);
+    }
+
+    [Fact]
+    public async Task GetBulkRecipientsAsync_normalizes_emails_to_lowercase()
+    {
+        var options = CreateOptions();
+        await SeedAsync(options, builder =>
+        {
+            builder.AddGame(1, "Ovčina 2026");
+            builder.AddSubmission(gameId: 1, primaryEmail: "Mixed.Case@Example.CZ");
+            builder.AddSubmission(gameId: 1, primaryEmail: "mixed.case@example.cz");
+        });
+
+        var service = BuildService(options);
+        var recipients = await service.GetBulkRecipientsAsync(gameId: 1);
+
+        Assert.Single(recipients);
+        Assert.Equal("mixed.case@example.cz", recipients[0]);
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static InboxService BuildService(DbContextOptions<ApplicationDbContext> options) =>
+        // Bulk-recipients queries don't touch Graph or HttpClient, so the optional
+        // graph dependencies stay null. Mailbox config doesn't matter here either.
+        new(
+            new TestDbContextFactory(options),
+            Options.Create(new MailboxEmailOptions()));
+
+    private static DbContextOptions<ApplicationDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+    private static async Task SeedAsync(DbContextOptions<ApplicationDbContext> options, Action<SeedBuilder> configure)
+    {
+        await using var db = new ApplicationDbContext(options);
+        var builder = new SeedBuilder(db);
+        configure(builder);
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class SeedBuilder(ApplicationDbContext db)
+    {
+        private int _submissionSeq = 1;
+        private int _userSeq = 1;
+
+        public void AddGame(int id, string name)
+        {
+            db.Games.Add(new Game
+            {
+                Id = id,
+                Name = name,
+                StartsAtUtc = FixedUtc.AddDays(7),
+                EndsAtUtc = FixedUtc.AddDays(9),
+                RegistrationClosesAtUtc = FixedUtc.AddDays(-2),
+                MealOrderingClosesAtUtc = FixedUtc.AddDays(-5),
+                PaymentDueAtUtc = FixedUtc.AddDays(5),
+                PlayerBasePrice = 1500m,
+                AdultHelperBasePrice = 800m,
+                BankAccount = "x",
+                BankAccountName = "y",
+                VariableSymbolStrategy = VariableSymbolStrategy.PerSubmissionId,
+                IsPublished = true,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc
+            });
+        }
+
+        public void AddSubmission(
+            int gameId,
+            string primaryEmail,
+            SubmissionStatus status = SubmissionStatus.Submitted,
+            bool isDeleted = false)
+        {
+            var userId = $"user-{_userSeq++}";
+            db.Users.Add(new ApplicationUser
+            {
+                Id = userId,
+                DisplayName = userId,
+                Email = $"{userId}@x.cz",
+                NormalizedEmail = $"{userId.ToUpperInvariant()}@X.CZ",
+                UserName = $"{userId}@x.cz",
+                NormalizedUserName = $"{userId.ToUpperInvariant()}@X.CZ",
+                EmailConfirmed = true,
+                IsActive = true,
+                SecurityStamp = Guid.NewGuid().ToString("N"),
+                ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+                CreatedAtUtc = FixedUtc
+            });
+            db.RegistrationSubmissions.Add(new RegistrationSubmission
+            {
+                Id = _submissionSeq++,
+                GameId = gameId,
+                RegistrantUserId = userId,
+                PrimaryContactName = "HH " + _submissionSeq,
+                PrimaryEmail = primaryEmail,
+                PrimaryPhone = "777000000",
+                Status = status,
+                SubmittedAtUtc = FixedUtc,
+                LastEditedAtUtc = FixedUtc,
+                ExpectedTotalAmount = 1500m,
+                IsDeleted = isDeleted
+            });
+        }
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+        : IDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext() => new(options);
+
+        public ValueTask<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new ApplicationDbContext(options));
+    }
+}


### PR DESCRIPTION
## Summary

- The bulk-send endpoint (`/organizace/posta/hromadne`) and the underlying `InboxService.GetBulkRecipientsAsync` / `SendBulkEmailAsync` methods already existed — they just had no UI. This PR adds the missing selection form on `/organizace/posta`.
- Organizer can now target either **all participants of a specific game** or **all registered participants across every game**. Recipient counts are visible in the form before submit (one DB pass per game via the new `GetBulkRecipientCountsAsync` helper), so they know exactly how many addresses they're about to email.
- Endpoint now reads a `recipientMode` field — `"all"` overrides any stale `gameId` to `null`, preventing accidental narrowing.
- JS `confirm("Opravdu odeslat zprávu všem vybraným příjemcům?")` guards the submit button.
- Result banner reads `?bulkSent=X&bulkFailed=Y` redirect params and shows the count.
- 3 new regression tests in `InboxBulkRecipientsTests` (dedup across games, cancelled/soft-deleted exclusion, lowercase normalization).
- v0.9.30 → v0.9.33 (PRs #184 / #185 take 0.9.31 / 0.9.32).

Fixes #183.

## Test plan

- [x] `dotnet test` — 324/324 pass (321 baseline + 3 new bulk-recipient tests)
- [ ] After deploy: open `/organizace/posta`, click **Hromadná zpráva**, confirm the game dropdown shows counts and the "Všichni" radio shows the deduped total
- [ ] Send a test message to a single-game scope, confirm the success banner reads "Hromadně odesláno: N zpráv"
- [ ] Confirm the existing `Nová zpráva` (single-recipient) compose still works untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)