### PR TITLE
feat(cors): allow Glejt SPA on /connect/* OIDC endpoints [v0.9.37]

### DIFF
--- a/src/RegistraceOvcina.Web/Endpoints/AuthorizationEndpoints.cs
+++ b/src/RegistraceOvcina.Web/Endpoints/AuthorizationEndpoints.cs
@@ -11,13 +11,16 @@ namespace RegistraceOvcina.Web.Endpoints;
 
 public static class AuthorizationEndpoints
 {
+    public const string OidcSpaCorsPolicy = "OidcSpa";
+
     public static void MapAuthorizationEndpoints(this WebApplication app)
     {
-        app.MapGet("/connect/authorize", (Delegate)HandleAuthorize);
-        app.MapPost("/connect/authorize", (Delegate)HandleAuthorize);
-        app.MapPost("/connect/token", (Delegate)HandleToken);
-        app.MapGet("/connect/userinfo", (Delegate)HandleUserinfo);
-        app.MapPost("/connect/logout", (Delegate)HandleLogout);
+        var group = app.MapGroup("/connect").RequireCors(OidcSpaCorsPolicy);
+        group.MapGet("/authorize", (Delegate)HandleAuthorize);
+        group.MapPost("/authorize", (Delegate)HandleAuthorize);
+        group.MapPost("/token", (Delegate)HandleToken);
+        group.MapGet("/userinfo", (Delegate)HandleUserinfo);
+        group.MapPost("/logout", (Delegate)HandleLogout);
     }
 
     private static async Task<IResult> HandleAuthorize(HttpContext context)

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -364,7 +364,7 @@ public class Program
             });
         }
 
-        app.UseCors(AuthorizationEndpoints.OidcSpaCorsPolicy);
+        app.UseCors();
         app.UseAuthentication();
         app.UseAuthorization();
         app.UseAntiforgery();

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -292,6 +292,13 @@ public class Program
             builder.Services.AddScoped<ICharacterPrepEmailSender, UnconfiguredCharacterPrepEmailSender>();
         }
 
+        builder.Services.AddCors(options =>
+            options.AddPolicy(AuthorizationEndpoints.OidcSpaCorsPolicy, policy => policy
+                .WithOrigins(builder.Configuration
+                    .GetSection("Cors:OidcOrigins").Get<string[]>() ?? [])
+                .WithMethods("GET", "POST")
+                .WithHeaders("Content-Type", "Authorization")));
+
         var app = builder.Build();
 
         app.UseForwardedHeaders();
@@ -357,6 +364,7 @@ public class Program
             });
         }
 
+        app.UseCors(AuthorizationEndpoints.OidcSpaCorsPolicy);
         app.UseAuthentication();
         app.UseAuthorization();
         app.UseAntiforgery();

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.36</Version>
+    <Version>0.9.37</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/appsettings.Development.json
+++ b/src/RegistraceOvcina.Web/appsettings.Development.json
@@ -28,5 +28,12 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Cors": {
+    "OidcOrigins": [
+      "https://glejt.ovcina.cz",
+      "http://localhost:5193",
+      "https://localhost:5193"
+    ]
   }
 }

--- a/src/RegistraceOvcina.Web/appsettings.json
+++ b/src/RegistraceOvcina.Web/appsettings.json
@@ -40,5 +40,8 @@
   "CharacterPrep": {
     "PublicBaseUrl": "https://registrace.ovcina.cz",
     "OrganizerContactEmail": ""
+  },
+  "Cors": {
+    "OidcOrigins": [ "https://glejt.ovcina.cz" ]
   }
 }


### PR DESCRIPTION
Closes #190.

## Summary

- Adds named `OidcSpa` CORS policy backed by `Cors:OidcOrigins` config (origin-explicit allowlist, no wildcard, no credentials)
- Refactors `MapAuthorizationEndpoints` to use `MapGroup("/connect").RequireCors(OidcSpaCorsPolicy)` so all current and future `/connect/*` routes inherit CORS uniformly
- Wires `app.UseCors(...)` between routing and `app.UseAuthentication()` per ASP.NET Core endpoint-routing CORS placement
- Allows `GET, POST` + `Content-Type, Authorization` headers (covers `/connect/token` POST + `/connect/userinfo` GET with bearer)
- Bumps `0.9.36 → 0.9.37`

## Note on issue scope

Issue #190 mentions `/connect/end_session`, `/connect/introspect`, `/connect/revoke` — none exist in this codebase. The actual endpoints are `/connect/authorize` (GET+POST), `/connect/token` (POST), `/connect/userinfo` (GET), `/connect/logout` (POST). The `MapGroup` refactor covers all four cleanly and any future endpoints added under `/connect`.

## Config

- `appsettings.json` — prod allowlist: `https://glejt.ovcina.cz`
- `appsettings.Development.json` — adds `http://localhost:5193` and `https://localhost:5193` for local Glejt dev
- Override per-environment via `Cors__OidcOrigins__0` etc. env vars in Azure if more origins are needed later

## Verification

- `dotnet build` — clean (0 warnings, 0 errors)
- `dotnet test` (Web.Tests) — **335 passed**, 0 failed

## Test plan

- [ ] Run registrace locally with the dev config; from Glejt at `localhost:5193` complete the full sign-in flow. Confirm `POST /connect/token` returns 200 with `Access-Control-Allow-Origin: http://localhost:5193`.
- [ ] After deploy, confirm `glejt.ovcina.cz` sign-in completes end-to-end and tokens land in `localStorage.glejt.tokens`.
- [ ] Smoke-test that an unlisted origin still gets 200 from the token endpoint but **without** the `ACAO` header (so the SPA fetch in that origin would block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)