### PR TITLE
feat(posta): HTML editor for compose + bulk send [v0.9.39]

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/Inbox.razor
@@ -90,92 +90,14 @@ else
 
                 @if (showCompose)
                 {
-                    <div class="card shadow-sm mb-4">
-                        <div class="card-body p-4">
-                            <h3 class="h5 mb-3">Nová zpráva</h3>
-                            <form method="post" action="/organizace/posta/odeslat">
-                                <AntiforgeryToken />
-                                <div class="mb-3">
-                                    <label class="form-label">Příjemce (e-mail)</label>
-                                    <input name="ToEmail" type="email" class="form-control" placeholder="jan@example.cz" required />
-                                </div>
-                                <div class="mb-3">
-                                    <label class="form-label">Předmět</label>
-                                    <input name="Subject" class="form-control" placeholder="Ovčina — ..." required />
-                                </div>
-                                <div class="mb-3">
-                                    <label class="form-label">Text zprávy</label>
-                                    <textarea name="Body" class="form-control" rows="5" placeholder="Dobrý den,..." required></textarea>
-                                </div>
-                                <button type="submit" class="btn btn-primary">Odeslat</button>
-                            </form>
-                        </div>
-                    </div>
+                    <EmailComposeCard Mode="EmailComposeCard.ComposeMode.Single" />
                 }
 
                 @if (showBulkCompose)
                 {
-                    <div class="card shadow-sm mb-4 border-primary-subtle" data-testid="inbox-bulk-compose-card">
-                        <div class="card-body p-4">
-                            <h3 class="h5 mb-3">Hromadná zpráva</h3>
-                            <p class="text-secondary small mb-3">
-                                Odešle stejnou zprávu všem vybraným příjemcům. Adresy se deduplikují &mdash; jedna domácnost dostane zprávu jen jednou, i když je přihlášena na více her.
-                            </p>
-                            <form method="post" action="/organizace/posta/hromadne"
-                                  onsubmit="return confirm('Opravdu odeslat zprávu všem vybraným příjemcům? Tuto akci nelze vrátit.');">
-                                <AntiforgeryToken />
-
-                                @{
-                                    // Default to "all" when there are no games — otherwise the
-                                    // "game" radio is checked but the gameId select is empty,
-                                    // and a strict server check would reject the submit. Server
-                                    // also enforces this; the UI default just keeps the
-                                    // happy path obvious.
-                                    var hasGames = bulkGames.Count > 0;
-                                    var defaultGameMode = hasGames;
-                                }
-                                <div class="mb-3">
-                                    <label class="form-label fw-semibold">Příjemci</label>
-                                    <div class="form-check">
-                                        <input class="form-check-input" type="radio" name="recipientMode" id="bulk-mode-game" value="game" checked="@defaultGameMode" disabled="@(!hasGames)" />
-                                        <label class="form-check-label" for="bulk-mode-game">
-                                            Účastníci konkrétní hry
-                                        </label>
-                                    </div>
-                                    <div class="ms-4 mb-2">
-                                        <select name="gameId" class="form-select" data-testid="inbox-bulk-game" disabled="@(!hasGames)">
-                                            @if (!hasGames)
-                                            {
-                                                <option value="">(Žádné hry)</option>
-                                            }
-                                            @foreach (var g in bulkGames)
-                                            {
-                                                var c = bulkRecipientCounts is not null && bulkRecipientCounts.CountByGameId.TryGetValue(g.Id, out var n) ? n : 0;
-                                                <option value="@g.Id">@g.Name (@c příjemců)</option>
-                                            }
-                                        </select>
-                                    </div>
-                                    <div class="form-check">
-                                        <input class="form-check-input" type="radio" name="recipientMode" id="bulk-mode-all" value="all" checked="@(!hasGames)" />
-                                        <label class="form-check-label" for="bulk-mode-all">
-                                            Všichni registrovaní účastníci
-                                            <span class="text-muted small">(@(bulkRecipientCounts?.AllCount ?? 0) příjemců)</span>
-                                        </label>
-                                    </div>
-                                </div>
-
-                                <div class="mb-3">
-                                    <label class="form-label">Předmět</label>
-                                    <input name="Subject" class="form-control" placeholder="Ovčina — ..." required />
-                                </div>
-                                <div class="mb-3">
-                                    <label class="form-label">Text zprávy</label>
-                                    <textarea name="Body" class="form-control" rows="6" placeholder="Dobrý den,..." required></textarea>
-                                </div>
-                                <button type="submit" class="btn btn-primary" data-testid="inbox-bulk-submit">Odeslat hromadně</button>
-                            </form>
-                        </div>
-                    </div>
+                    <EmailComposeCard Mode="EmailComposeCard.ComposeMode.Bulk"
+                                       BulkGames="bulkGames"
+                                       BulkCounts="bulkRecipientCounts" />
                 }
             </div>
         }

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/InboxMessage.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/InboxMessage.razor
@@ -45,8 +45,12 @@ else
                     <h2 class="h5 mb-3">Obsah zprávy</h2>
                     @if (LooksLikeHtml(message.BodyText))
                     {
-                        <div class="border rounded p-3 bg-white" data-testid="message-body">
-                            @((MarkupString)(message.BodyText ?? ""))
+                        @* Sandbox the iframe — even our heuristic is wrong, scripts/forms/navigation cannot run. *@
+                        <div class="border rounded bg-white overflow-hidden" data-testid="message-body">
+                            <iframe title="Obsah HTML zprávy"
+                                    sandbox=""
+                                    srcdoc="@(message.BodyText ?? "")"
+                                    style="width: 100%; min-height: 30rem; border: 0; display: block;"></iframe>
                         </div>
                     }
                     else

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/InboxMessage.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/InboxMessage.razor
@@ -43,7 +43,16 @@ else
             <section class="card shadow-sm">
                 <div class="card-body p-4">
                     <h2 class="h5 mb-3">Obsah zprávy</h2>
-                    <pre class="mb-0" style="white-space: pre-wrap; font-family: inherit;" data-testid="message-body">@(message.BodyText ?? "")</pre>
+                    @if (LooksLikeHtml(message.BodyText))
+                    {
+                        <div class="border rounded p-3 bg-white" data-testid="message-body">
+                            @((MarkupString)(message.BodyText ?? ""))
+                        </div>
+                    }
+                    else
+                    {
+                        <pre class="mb-0" style="white-space: pre-wrap; font-family: inherit;" data-testid="message-body">@(message.BodyText ?? "")</pre>
+                    }
                 </div>
             </section>
         </div>
@@ -221,5 +230,23 @@ else
     {
         var text = e.Value?.ToString();
         selectedPersonId = people?.FirstOrDefault(p => p.Name == text)?.Id;
+    }
+
+    private static bool LooksLikeHtml(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return false;
+        }
+
+        var trimmed = body.AsSpan().TrimStart();
+        if (trimmed.Length == 0 || trimmed[0] != '<')
+        {
+            return false;
+        }
+
+        return body.Contains("</", StringComparison.Ordinal)
+            || body.Contains("<br", StringComparison.OrdinalIgnoreCase)
+            || body.Contains("<!doctype", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/RegistraceOvcina.Web/Components/Shared/EmailComposeCard.razor
+++ b/src/RegistraceOvcina.Web/Components/Shared/EmailComposeCard.razor
@@ -1,0 +1,222 @@
+@rendermode InteractiveServer
+
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Identity
+@using RegistraceOvcina.Web.Data
+@using RegistraceOvcina.Web.Features.Email
+@using RegistraceOvcina.Web.Security
+
+@inject InboxService InboxService
+@inject AuthenticationStateProvider AuthState
+@inject UserManager<ApplicationUser> UserManager
+@inject NavigationManager Nav
+
+<div class="card shadow-sm mb-4 @(Mode == ComposeMode.Bulk ? "border-primary-subtle" : "")"
+     data-testid="@(Mode == ComposeMode.Bulk ? "inbox-bulk-compose-card" : "inbox-compose-card")">
+    <div class="card-body p-4">
+        <h3 class="h5 mb-3">@(Mode == ComposeMode.Bulk ? "Hromadná zpráva" : "Nová zpráva")</h3>
+
+        @if (Mode == ComposeMode.Bulk)
+        {
+            <p class="text-secondary small mb-3">
+                Odešle stejnou zprávu všem vybraným příjemcům. Adresy se deduplikují &mdash; jedna domácnost dostane zprávu jen jednou, i když je přihlášena na více her.
+            </p>
+
+            var hasGames = BulkGames.Count > 0;
+            <div class="mb-3">
+                <label class="form-label fw-semibold">Příjemci</label>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio"
+                           name="@($"recipientMode-{instanceId}")"
+                           id="@($"bulk-mode-game-{instanceId}")"
+                           checked="@(recipientMode == "game")"
+                           disabled="@(!hasGames)"
+                           @onchange="@(() => recipientMode = "game")" />
+                    <label class="form-check-label" for="@($"bulk-mode-game-{instanceId}")">
+                        Účastníci konkrétní hry
+                    </label>
+                </div>
+                <div class="ms-4 mb-2">
+                    <select class="form-select" data-testid="inbox-bulk-game"
+                            disabled="@(!hasGames)"
+                            value="@(gameId?.ToString() ?? "")"
+                            @onchange="OnGameChanged">
+                        @if (!hasGames)
+                        {
+                            <option value="">(Žádné hry)</option>
+                        }
+                        @foreach (var g in BulkGames)
+                        {
+                            var c = BulkCounts is not null && BulkCounts.CountByGameId.TryGetValue(g.Id, out var n) ? n : 0;
+                            <option value="@g.Id">@g.Name (@c příjemců)</option>
+                        }
+                    </select>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio"
+                           name="@($"recipientMode-{instanceId}")"
+                           id="@($"bulk-mode-all-{instanceId}")"
+                           checked="@(recipientMode == "all")"
+                           @onchange="@(() => recipientMode = "all")" />
+                    <label class="form-check-label" for="@($"bulk-mode-all-{instanceId}")">
+                        Všichni registrovaní účastníci
+                        <span class="text-muted small">(@(BulkCounts?.AllCount ?? 0) příjemců)</span>
+                    </label>
+                </div>
+            </div>
+        }
+        else
+        {
+            <div class="mb-3">
+                <label class="form-label">Příjemce (e-mail)</label>
+                <input @bind="toEmail" type="email" class="form-control" placeholder="jan@example.cz" />
+            </div>
+        }
+
+        <div class="mb-3">
+            <label class="form-label">Předmět</label>
+            <input @bind="subject" class="form-control" placeholder="Ovčina — ..." />
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label">Text zprávy</label>
+            <RichTextEditor @ref="editor" Value="@bodyHtml" MinHeight="@(Mode == ComposeMode.Bulk ? 240 : 200)" />
+            <div class="form-text">
+                Editor má záložky <strong>HTML</strong> (vlož ručně připravenou šablonu), <strong>Náhled</strong> a vizuální <strong>Editor</strong>. Zpráva se odešle jako HTML.
+            </div>
+        </div>
+
+        @if (errorMessage is not null)
+        {
+            <div class="alert alert-danger" role="alert">@errorMessage</div>
+        }
+
+        <button type="button" class="btn btn-primary"
+                disabled="@isSending"
+                data-testid="@(Mode == ComposeMode.Bulk ? "inbox-bulk-submit" : "inbox-compose-submit")"
+                @onclick="SubmitAsync">
+            @if (isSending)
+            {
+                <span class="spinner-border spinner-border-sm me-1" role="status"></span>
+                <text>Odesílám...</text>
+            }
+            else
+            {
+                @(Mode == ComposeMode.Bulk ? "Odeslat hromadně" : "Odeslat")
+            }
+        </button>
+    </div>
+</div>
+
+@code {
+    public enum ComposeMode { Single, Bulk }
+
+    [Parameter] public ComposeMode Mode { get; set; }
+    [Parameter] public IReadOnlyList<GameLookupItem> BulkGames { get; set; } = Array.Empty<GameLookupItem>();
+    [Parameter] public BulkRecipientCounts? BulkCounts { get; set; }
+    [Parameter] public int? DefaultGameId { get; set; }
+
+    private readonly string instanceId = Guid.NewGuid().ToString("N")[..8];
+
+    private string toEmail = "";
+    private string subject = "";
+    private string bodyHtml = "";
+    private string recipientMode = "game";
+    private int? gameId;
+    private RichTextEditor? editor;
+    private bool isSending;
+    private string? errorMessage;
+
+    protected override void OnInitialized()
+    {
+        if (Mode == ComposeMode.Bulk)
+        {
+            recipientMode = BulkGames.Count > 0 ? "game" : "all";
+            gameId = DefaultGameId ?? BulkGames.FirstOrDefault()?.Id;
+        }
+    }
+
+    private void OnGameChanged(ChangeEventArgs e)
+    {
+        gameId = int.TryParse(e.Value?.ToString(), out var id) ? id : null;
+    }
+
+    private async Task SubmitAsync()
+    {
+        errorMessage = null;
+
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            errorMessage = "Vyplňte předmět zprávy.";
+            return;
+        }
+
+        var html = editor is not null ? await editor.GetHtmlAsync() : bodyHtml;
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            errorMessage = "Vyplňte text zprávy.";
+            return;
+        }
+
+        var authState = await AuthState.GetAuthenticationStateAsync();
+        var user = await UserManager.GetUserAsync(authState.User);
+        if (user is null)
+        {
+            errorMessage = "Nepodařilo se ověřit uživatele. Přihlaste se znovu.";
+            return;
+        }
+
+        isSending = true;
+        try
+        {
+            if (Mode == ComposeMode.Single)
+            {
+                if (string.IsNullOrWhiteSpace(toEmail))
+                {
+                    errorMessage = "Vyplňte e-mail příjemce.";
+                    return;
+                }
+
+                await InboxService.SendNewMessageAsync(
+                    toEmail.Trim(), subject.Trim(), html, null, user.Id, isHtml: true);
+                Nav.NavigateTo("/organizace/posta?sent=1", forceLoad: true);
+            }
+            else
+            {
+                int? scopeGameId;
+                if (recipientMode == "all")
+                {
+                    scopeGameId = null;
+                }
+                else if (recipientMode == "game" && gameId.HasValue)
+                {
+                    scopeGameId = gameId;
+                }
+                else
+                {
+                    errorMessage = "Vyberte hru nebo zvolte všechny účastníky.";
+                    return;
+                }
+
+                var recipients = await InboxService.GetBulkRecipientsAsync(scopeGameId);
+                if (recipients.Count == 0)
+                {
+                    errorMessage = "Žádní příjemci ke kterým by se zpráva odeslala.";
+                    return;
+                }
+
+                var (sent, failed) = await InboxService.SendBulkEmailAsync(
+                    recipients, subject.Trim(), html, user.Id, isHtml: true);
+                Nav.NavigateTo($"/organizace/posta?bulkSent={sent}&bulkFailed={failed}", forceLoad: true);
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException or TaskCanceledException)
+        {
+            errorMessage = "Odeslání selhalo: " + ex.Message;
+        }
+        finally
+        {
+            isSending = false;
+        }
+    }
+}

--- a/src/RegistraceOvcina.Web/Components/Shared/EmailComposeCard.razor
+++ b/src/RegistraceOvcina.Web/Components/Shared/EmailComposeCard.razor
@@ -10,6 +10,7 @@
 @inject AuthenticationStateProvider AuthState
 @inject UserManager<ApplicationUser> UserManager
 @inject NavigationManager Nav
+@inject IJSRuntime JS
 
 <div class="card shadow-sm mb-4 @(Mode == ComposeMode.Bulk ? "border-primary-subtle" : "")"
      data-testid="@(Mode == ComposeMode.Bulk ? "inbox-bulk-compose-card" : "inbox-compose-card")">
@@ -31,7 +32,7 @@
                            id="@($"bulk-mode-game-{instanceId}")"
                            checked="@(recipientMode == "game")"
                            disabled="@(!hasGames)"
-                           @onchange="@(() => recipientMode = "game")" />
+                           @onchange="@(() => OnRecipientModeChanged("game"))" />
                     <label class="form-check-label" for="@($"bulk-mode-game-{instanceId}")">
                         Účastníci konkrétní hry
                     </label>
@@ -57,7 +58,7 @@
                            name="@($"recipientMode-{instanceId}")"
                            id="@($"bulk-mode-all-{instanceId}")"
                            checked="@(recipientMode == "all")"
-                           @onchange="@(() => recipientMode = "all")" />
+                           @onchange="@(() => OnRecipientModeChanged("all"))" />
                     <label class="form-check-label" for="@($"bulk-mode-all-{instanceId}")">
                         Všichni registrovaní účastníci
                         <span class="text-muted small">(@(BulkCounts?.AllCount ?? 0) příjemců)</span>
@@ -123,21 +124,36 @@
     private string bodyHtml = "";
     private string recipientMode = "game";
     private int? gameId;
+    private bool userPickedRecipientMode;
+    private bool userPickedGameId;
     private RichTextEditor? editor;
     private bool isSending;
     private string? errorMessage;
 
-    protected override void OnInitialized()
+    protected override void OnParametersSet()
     {
-        if (Mode == ComposeMode.Bulk)
+        if (Mode != ComposeMode.Bulk) return;
+
+        // Re-derive defaults whenever parent params change, but never clobber a user pick.
+        if (!userPickedRecipientMode)
         {
             recipientMode = BulkGames.Count > 0 ? "game" : "all";
+        }
+        if (!userPickedGameId)
+        {
             gameId = DefaultGameId ?? BulkGames.FirstOrDefault()?.Id;
         }
     }
 
+    private void OnRecipientModeChanged(string value)
+    {
+        userPickedRecipientMode = true;
+        recipientMode = value;
+    }
+
     private void OnGameChanged(ChangeEventArgs e)
     {
+        userPickedGameId = true;
         gameId = int.TryParse(e.Value?.ToString(), out var id) ? id : null;
     }
 
@@ -201,7 +217,15 @@
                 var recipients = await InboxService.GetBulkRecipientsAsync(scopeGameId);
                 if (recipients.Count == 0)
                 {
-                    errorMessage = "Žádní příjemci ke kterým by se zpráva odeslala.";
+                    errorMessage = "Žádní příjemci, kterým by se zpráva odeslala.";
+                    return;
+                }
+
+                var confirmed = await JS.InvokeAsync<bool>(
+                    "confirm",
+                    $"Opravdu odeslat zprávu {recipients.Count} příjemcům? Tuto akci nelze vrátit.");
+                if (!confirmed)
+                {
                     return;
                 }
 

--- a/src/RegistraceOvcina.Web/Features/Email/InboxService.cs
+++ b/src/RegistraceOvcina.Web/Features/Email/InboxService.cs
@@ -212,6 +212,7 @@ public sealed class InboxService(
         string body,
         int? linkToPersonId,
         string actorUserId,
+        bool isHtml = false,
         CancellationToken ct = default)
     {
         var emailOptions = mailboxOptions.Value;
@@ -236,7 +237,7 @@ public sealed class InboxService(
                 subject,
                 body = new
                 {
-                    contentType = "Text",
+                    contentType = isHtml ? "HTML" : "Text",
                     content = body
                 },
                 toRecipients = new[]
@@ -536,6 +537,7 @@ public sealed class InboxService(
         string subject,
         string body,
         string actorUserId,
+        bool isHtml = false,
         CancellationToken ct = default)
     {
         var sent = 0;
@@ -545,7 +547,7 @@ public sealed class InboxService(
         {
             try
             {
-                await SendNewMessageAsync(email, subject, body, null, actorUserId, ct);
+                await SendNewMessageAsync(email, subject, body, null, actorUserId, isHtml, ct);
                 sent++;
             }
             catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException or TaskCanceledException)

--- a/src/RegistraceOvcina.Web/Program.cs
+++ b/src/RegistraceOvcina.Web/Program.cs
@@ -1145,7 +1145,7 @@ public class Program
             .RequireAuthorization(AuthorizationPolicies.StaffOnly);
         app.MapPost(
                 "/organizace/posta/odeslat",
-                async ([FromForm] string toEmail, [FromForm] string subject, [FromForm] string body, HttpContext httpContext, UserManager<ApplicationUser> userManager, InboxService inboxService) =>
+                async ([FromForm] string toEmail, [FromForm] string subject, [FromForm] string body, [FromForm] bool? isHtml, HttpContext httpContext, UserManager<ApplicationUser> userManager, InboxService inboxService) =>
                 {
                     var user = await userManager.GetUserAsync(httpContext.User);
                     if (user is null)
@@ -1160,7 +1160,7 @@ public class Program
 
                     try
                     {
-                        await inboxService.SendNewMessageAsync(toEmail.Trim(), subject.Trim(), body.Trim(), null, user.Id, httpContext.RequestAborted);
+                        await inboxService.SendNewMessageAsync(toEmail.Trim(), subject.Trim(), body.Trim(), null, user.Id, isHtml: isHtml ?? false, ct: httpContext.RequestAborted);
                         return Results.LocalRedirect("/organizace/posta?sent=1");
                     }
                     catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException or TaskCanceledException)
@@ -1171,7 +1171,7 @@ public class Program
             .RequireAuthorization(AuthorizationPolicies.StaffOnly);
         app.MapPost(
                 "/organizace/posta/hromadne",
-                async ([FromForm] string subject, [FromForm] string body, [FromForm] string? recipientMode, [FromForm] int? gameId, HttpContext httpContext, UserManager<ApplicationUser> userManager, InboxService inboxService) =>
+                async ([FromForm] string subject, [FromForm] string body, [FromForm] string? recipientMode, [FromForm] int? gameId, [FromForm] bool? isHtml, HttpContext httpContext, UserManager<ApplicationUser> userManager, InboxService inboxService) =>
                 {
                     var user = await userManager.GetUserAsync(httpContext.User);
                     if (user is null)
@@ -1211,7 +1211,7 @@ public class Program
                     try
                     {
                         var (sent, failed) = await inboxService.SendBulkEmailAsync(
-                            recipients, subject.Trim(), body.Trim(), user.Id, httpContext.RequestAborted);
+                            recipients, subject.Trim(), body.Trim(), user.Id, isHtml: isHtml ?? false, ct: httpContext.RequestAborted);
                         return Results.LocalRedirect($"/organizace/posta?bulkSent={sent}&bulkFailed={failed}");
                     }
                     catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException or TaskCanceledException)

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.38</Version>
+    <Version>0.9.39</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.39</Version>
+    <Version>0.9.40</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
- Replaces both compose forms in `/organizace/posta` (single + bulk) with an interactive `EmailComposeCard` that wraps the existing `RichTextEditor` (HTML / Náhled / Editor tabs — same component used at `/admin/osloveni`).
- `InboxService.SendNewMessageAsync` + `SendBulkEmailAsync` gain a `bool isHtml` param that switches Microsoft Graph `contentType` between `Text` and `HTML`.
- `InboxMessage.razor` now renders bodies as `MarkupString` when they look like HTML (heuristic: starts with `<` and contains `</` / `<br` / `<!doctype`); otherwise the existing pre-wrap escaped view is preserved.
- Form-post handlers `/posta/odeslat` and `/posta/hromadne` keep working; they now accept `[FromForm] bool? isHtml` for any legacy callers.

## Why now
Need to send a hand-crafted HTML pre-game email to 91 Ovčina 2026 attendees from the existing pošta UI without losing table-based formatting. The previous textarea + Text contentType path showed raw markup to recipients.

## Test plan
- [ ] CI green (build + 335 unit tests)
- [ ] Verify on prod after deploy: `/organizace/posta` → **Hromadná zpráva** → editor shows HTML / Náhled / Editor tabs
- [ ] Paste `~/source/repos/azra/.tmp/ovcina-pre-game-email-2026-04-29.html` into the **HTML** tab, switch to **Náhled** to confirm rendering
- [ ] Pick **Účastníci konkrétní hry** → **30. Ovčina Balinova pozvánka (91 příjemců)**, send to self first as a smoke test (use **Nová zpráva** with own email), then to the 91
- [ ] Open the resulting message in `/organizace/posta/{id}` — should render the HTML, not raw markup
- [ ] Sanity-check `/admin/osloveni` and other unrelated pošta features still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)