### PR TITLE
feat(kingdom-export): Kategorie column on per-kingdom sheets [v0.9.41]

### DIFF
--- a/src/RegistraceOvcina.Web/Data/DatabaseInitializer.cs
+++ b/src/RegistraceOvcina.Web/Data/DatabaseInitializer.cs
@@ -294,16 +294,22 @@ public static class DatabaseInitializer
             return;
         }
 
+        // Original anchor: 30. Ovčina was 2026-05-01 with registration closing 2026-04-28.
+        // Production seeded once on those exact dates and is unaffected by this code path
+        // (the AnyAsync guard above means the seed never re-runs in prod). We compute
+        // dates relative to nowUtc so fresh envs (E2E test DBs, new dev installs) get a
+        // game with registration still open instead of a time-bombed past deadline.
+        var startsAt = nowUtc.Date.AddDays(7).AddHours(7);
         var game = new Game
         {
             Name = "30. Ovčina Balinova pozvánka",
             Description = "Co se skrývá v Morii?",
-            StartsAtUtc = new DateTime(2026, 5, 1, 7, 0, 0, DateTimeKind.Utc),
-            EndsAtUtc = new DateTime(2026, 5, 2, 16, 0, 0, DateTimeKind.Utc),
-            RegistrationClosesAtUtc = new DateTime(2026, 4, 28, 15, 0, 0, DateTimeKind.Utc),
-            MealOrderingClosesAtUtc = new DateTime(2026, 4, 28, 15, 0, 0, DateTimeKind.Utc),
-            PaymentDueAtUtc = new DateTime(2026, 4, 29, 15, 0, 0, DateTimeKind.Utc),
-            AssignmentFreezeAtUtc = new DateTime(2026, 4, 30, 21, 30, 0, DateTimeKind.Utc),
+            StartsAtUtc = startsAt,
+            EndsAtUtc = startsAt.AddDays(1).AddHours(9),
+            RegistrationClosesAtUtc = startsAt.AddDays(-3),
+            MealOrderingClosesAtUtc = startsAt.AddDays(-3),
+            PaymentDueAtUtc = startsAt.AddDays(-2),
+            AssignmentFreezeAtUtc = startsAt.AddDays(-1).AddHours(14).AddMinutes(30),
             PlayerBasePrice = 100m,
             AdultHelperBasePrice = 0m,
             BankAccount = "CZ6508000000192000145399",

--- a/src/RegistraceOvcina.Web/Features/Kingdoms/KingdomExportService.cs
+++ b/src/RegistraceOvcina.Web/Features/Kingdoms/KingdomExportService.cs
@@ -1,4 +1,5 @@
 using ClosedXML.Excel;
+using RegistraceOvcina.Web.Data;
 
 namespace RegistraceOvcina.Web.Features.Kingdoms;
 
@@ -49,7 +50,7 @@ public sealed class KingdomExportService
 
             var headers = new[]
             {
-                "Jméno", "Příjmení", "Věk", "Skupina", "Preference",
+                "Jméno", "Příjmení", "Věk", "Kategorie", "Skupina", "Preference",
                 "Postava", "Poznámka hráče", "Poznámka skupiny",
                 "Org. poznámky", "Zákonný zástupce", "Předchozí království"
             };
@@ -71,14 +72,15 @@ public sealed class KingdomExportService
                 sheet.Cell(xlRow, 1).Value = firstName;
                 sheet.Cell(xlRow, 2).Value = lastName;
                 sheet.Cell(xlRow, 3).Value = p.Age(currentYear);
-                sheet.Cell(xlRow, 4).Value = p.GroupName ?? "";
-                sheet.Cell(xlRow, 5).Value = p.PreferredKingdomName ?? "";
-                sheet.Cell(xlRow, 6).Value = p.CharacterName ?? "";
-                sheet.Cell(xlRow, 7).Value = p.RegistrantNote ?? "";
-                sheet.Cell(xlRow, 8).Value = p.SubmissionNote ?? "";
-                sheet.Cell(xlRow, 9).Value = p.OrganizerNotes ?? "";
-                sheet.Cell(xlRow, 10).Value = p.GuardianName ?? "";
-                sheet.Cell(xlRow, 11).Value = p.PreviousKingdomName ?? "";
+                sheet.Cell(xlRow, 4).Value = PlayerSubTypeLabel(p.PlayerSubType);
+                sheet.Cell(xlRow, 5).Value = p.GroupName ?? "";
+                sheet.Cell(xlRow, 6).Value = p.PreferredKingdomName ?? "";
+                sheet.Cell(xlRow, 7).Value = p.CharacterName ?? "";
+                sheet.Cell(xlRow, 8).Value = p.RegistrantNote ?? "";
+                sheet.Cell(xlRow, 9).Value = p.SubmissionNote ?? "";
+                sheet.Cell(xlRow, 10).Value = p.OrganizerNotes ?? "";
+                sheet.Cell(xlRow, 11).Value = p.GuardianName ?? "";
+                sheet.Cell(xlRow, 12).Value = p.PreviousKingdomName ?? "";
             }
 
             sheet.Columns().AdjustToContents(1, players.Count + 1, 8, 40);
@@ -93,4 +95,13 @@ public sealed class KingdomExportService
         workbook.SaveAs(stream);
         return stream.ToArray();
     }
+
+    private static string PlayerSubTypeLabel(PlayerSubType? subType) => subType switch
+    {
+        PlayerSubType.Pvp => "PVP hráč (10+)",
+        PlayerSubType.Independent => "Samostatné dítě (8+)",
+        PlayerSubType.WithRanger => "S hraničářem (5–7)",
+        PlayerSubType.WithParent => "S rodičem (4+)",
+        _ => ""
+    };
 }

--- a/src/RegistraceOvcina.Web/Features/Kingdoms/KingdomExportService.cs
+++ b/src/RegistraceOvcina.Web/Features/Kingdoms/KingdomExportService.cs
@@ -96,12 +96,15 @@ public sealed class KingdomExportService
         return stream.ToArray();
     }
 
+    // Same wording as SubmissionDetail.razor:638-641 / SubmissionEditor.razor:1184.
+    // TODO: extract a shared helper once we're past the 2026-05-01 game — currently 4 places.
     private static string PlayerSubTypeLabel(PlayerSubType? subType) => subType switch
     {
+        null => "",
         PlayerSubType.Pvp => "PVP hráč (10+)",
         PlayerSubType.Independent => "Samostatné dítě (8+)",
         PlayerSubType.WithRanger => "S hraničářem (5–7)",
         PlayerSubType.WithParent => "S rodičem (4+)",
-        _ => ""
+        var value => value.ToString() ?? ""
     };
 }

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.42</Version>
+    <Version>0.9.43</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.40</Version>
+    <Version>0.9.41</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.41</Version>
+    <Version>0.9.42</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
- Adds **Kategorie** column right after **Věk** on the per-kingdom sheets (Sheets 2+) of the kingdom assignment Excel export at `/organizace/hry/{id}/qr-stitky`.
- Values come from `Player.PlayerSubType` using the same human-readable labels already used on `SubmissionDetail.razor:638-641`:
  - `Pvp` → **PVP hráč (10+)**
  - `Independent` → **Samostatné dítě (8+)**
  - `WithRanger` → **S hraničářem (5–7)**
  - `WithParent` → **S rodičem (4+)**
  - null → empty cell
- The **Přehled** overview sheet is unchanged (one cell per player).

## Test plan
- [ ] CI green
- [ ] After deploy: download fresh export from `/organizace/hry/1/qr-stitky` → confirm each per-kingdom sheet has 12 columns with `Kategorie` between `Věk` and `Skupina`
- [ ] Spot-check a row with a 4-year-old → should show `S rodičem (4+)`; a 12-year-old → `PVP hráč (10+)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)