### PR TITLE
feat(pre-game): adult-notes API + QR sticker layout [v0.9.46]

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/QrStickers.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/QrStickers.razor
@@ -9,27 +9,50 @@
 <PageTitle>QR štítky pro hru</PageTitle>
 
 <style>
+    /* 7×7 cm physical sticker. Fixed box on screen + print so the preview matches the
+       cut size. Text hierarchy per issue #195: character name dominates, player name
+       second, person ID third (smallest). */
     .sticker {
+        box-sizing: border-box;
+        width: 70mm;
+        height: 70mm;
         border: 1px dashed #ccc;
-        padding: 8px;
+        padding: 4mm;
         text-align: center;
-        margin-bottom: 8px;
-    }
-
-    .sticker-qr img {
-        width: 80px;
-        height: 80px;
-    }
-
-    .sticker-name {
-        font-weight: bold;
-        font-size: 12px;
+        margin: 0 auto 8mm auto;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: center;
     }
 
     .sticker-character {
-        font-size: 11px;
-        color: #666;
-        margin-bottom: 4px;
+        font-weight: 700;
+        font-size: 5mm;
+        line-height: 1.15;
+        color: #1a1a1a;
+        margin-bottom: 1mm;
+        word-break: break-word;
+    }
+
+    .sticker-name {
+        font-weight: 500;
+        font-size: 3.5mm;
+        line-height: 1.1;
+        color: #444;
+        margin-bottom: 1mm;
+    }
+
+    .sticker-person-id {
+        font-size: 2.6mm;
+        color: #888;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .sticker-qr img {
+        width: 38mm;
+        height: 38mm;
+        display: block;
     }
 
     @@media print {
@@ -37,14 +60,8 @@
         body { margin: 0; padding: 0; }
         .sticker {
             border: 1px dashed #999;
-            padding: 8px;
-            text-align: center;
             break-inside: avoid;
-            height: 120px;
         }
-        .sticker-qr svg { width: 80px; height: 80px; }
-        .sticker-name { font-weight: bold; font-size: 11px; }
-        .sticker-character { font-size: 10px; color: #666; margin-bottom: 4px; }
     }
 </style>
 
@@ -69,10 +86,13 @@ else
     <div class="row">
         @foreach (var reg in registrations)
         {
-            <div class="col-4">
+            <div class="col-auto">
                 <div class="sticker">
-                    <div class="sticker-name">@reg.FirstName @reg.LastName</div>
-                    <div class="sticker-character">@reg.CharacterName</div>
+                    <div>
+                        <div class="sticker-character">@(string.IsNullOrWhiteSpace(reg.CharacterName) ? $"{reg.FirstName} {reg.LastName}" : reg.CharacterName)</div>
+                        <div class="sticker-name">@reg.FirstName @reg.LastName</div>
+                        <div class="sticker-person-id">#@reg.PersonId</div>
+                    </div>
                     <div class="sticker-qr"><img src="@GenerateQrDataUri(reg.PersonId)" alt="QR" /></div>
                 </div>
             </div>

--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiDtos.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiDtos.cs
@@ -97,6 +97,18 @@ public sealed record AdultDto(
     string? Email,
     List<string> Roles);
 
+/// <summary>All free-text notes attached to one adult on a game — for pre-game review.</summary>
+public sealed record AdultNoteDto(
+    int PersonId,
+    string FirstName,
+    string LastName,
+    int BirthYear,
+    string GroupName,
+    string? PersonNotes,
+    List<string> RegistrationRegistrantNotes,
+    List<string> SubmissionRegistrantNotes,
+    List<string> OrganizerNotes);
+
 /// <summary>Character seed data for hra import.</summary>
 public sealed record CharacterSeedDto(
     int? CharacterId,

--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
@@ -234,6 +234,83 @@ public static class IntegrationApiEndpoints
             return Results.Ok(adults);
         });
 
+        // GET /api/v1/games/{id}/adult-notes — every active adult on this game, with all
+        // free-text note fields rolled up: Person.Notes (personal), Registration.RegistrantNote
+        // (per-attendee note from the registrant), Submission.RegistrantNote (household-wide
+        // note), and Person.OrganizerNotes (internal staff notes). Used for pre-game review
+        // of preferences, accommodations, and special asks.
+        group.MapGet("/games/{id:int}/adult-notes", async (
+            int id,
+            IDbContextFactory<ApplicationDbContext> dbFactory,
+            CancellationToken ct) =>
+        {
+            await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+            var gameExists = await db.Games.AsNoTracking().AnyAsync(g => g.Id == id, ct);
+            if (!gameExists)
+                return Results.NotFound();
+
+            var rows = await db.Registrations
+                .AsNoTracking()
+                .Where(r =>
+                    r.Submission.GameId == id &&
+                    r.Submission.Status == SubmissionStatus.Submitted &&
+                    r.Status == RegistrationStatus.Active &&
+                    !r.Submission.IsDeleted &&
+                    !r.Person.IsDeleted &&
+                    r.AttendeeType == AttendeeType.Adult)
+                .Select(r => new
+                {
+                    r.PersonId,
+                    r.Person.FirstName,
+                    r.Person.LastName,
+                    r.Person.BirthYear,
+                    r.Submission.GroupName,
+                    PersonNotes = r.Person.Notes,
+                    RegistrationRegistrantNote = r.RegistrantNote,
+                    SubmissionRegistrantNote = r.Submission.RegistrantNote,
+                    OrganizerNotes = r.Person.OrganizerNotes
+                        .Where(n => !string.IsNullOrWhiteSpace(n.Note))
+                        .Select(n => n.Note)
+                        .ToList()
+                })
+                .ToListAsync(ct);
+
+            // Same adult can sit on multiple submissions; group by PersonId and union notes.
+            var grouped = rows
+                .GroupBy(r => r.PersonId)
+                .Select(g =>
+                {
+                    var head = g.First();
+                    return new AdultNoteDto(
+                        g.Key,
+                        head.FirstName,
+                        head.LastName,
+                        head.BirthYear,
+                        head.GroupName,
+                        head.PersonNotes,
+                        g.Select(r => r.RegistrationRegistrantNote)
+                            .Where(n => !string.IsNullOrWhiteSpace(n))
+                            .Select(n => n!.Trim())
+                            .Distinct(StringComparer.Ordinal)
+                            .ToList(),
+                        g.Select(r => r.SubmissionRegistrantNote)
+                            .Where(n => !string.IsNullOrWhiteSpace(n))
+                            .Select(n => n!.Trim())
+                            .Distinct(StringComparer.Ordinal)
+                            .ToList(),
+                        g.SelectMany(r => r.OrganizerNotes)
+                            .Select(n => n.Trim())
+                            .Distinct(StringComparer.Ordinal)
+                            .ToList());
+                })
+                .OrderBy(a => a.LastName, StringComparer.Ordinal)
+                .ThenBy(a => a.FirstName, StringComparer.Ordinal)
+                .ToList();
+
+            return Results.Ok(grouped);
+        });
+
         // GET /api/v1/users/by-email?email=... — user existence check for OvčinaHra auth
         group.MapGet("/users/by-email", async (
             string email,

--- a/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
+++ b/src/RegistraceOvcina.Web/Features/Integration/IntegrationApiEndpoints.cs
@@ -277,17 +277,27 @@ public static class IntegrationApiEndpoints
                 .ToListAsync(ct);
 
             // Same adult can sit on multiple submissions; group by PersonId and union notes.
+            // FirstName / LastName / BirthYear / PersonNotes come from Person and are
+            // identical across rows in the group. GroupName comes from Submission and
+            // can differ per submission — join the distinct, ordered set so the value
+            // is deterministic regardless of DB row order.
             var grouped = rows
                 .GroupBy(r => r.PersonId)
                 .Select(g =>
                 {
                     var head = g.First();
+                    var groupNames = string.Join(
+                        " / ",
+                        g.Select(r => r.GroupName)
+                            .Where(n => !string.IsNullOrWhiteSpace(n))
+                            .Distinct(StringComparer.Ordinal)
+                            .OrderBy(n => n, StringComparer.Ordinal));
                     return new AdultNoteDto(
                         g.Key,
                         head.FirstName,
                         head.LastName,
                         head.BirthYear,
-                        head.GroupName,
+                        groupNames,
                         head.PersonNotes,
                         g.Select(r => r.RegistrationRegistrantNote)
                             .Where(n => !string.IsNullOrWhiteSpace(n))

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.45</Version>
+    <Version>0.9.46</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.46</Version>
+    <Version>0.9.47</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
Two pre-game-day items, single deploy.

### 1. New integration API endpoint — adult notes
`GET /api/v1/games/{id}/adult-notes` returns every active adult on the game with all free-text notes rolled up by PersonId:
- `PersonNotes` — `Person.Notes`
- `RegistrationRegistrantNotes[]` — per-attendee `Registration.RegistrantNote` (one row per submission the adult sits on)
- `SubmissionRegistrantNotes[]` — household-wide `Submission.RegistrantNote`
- `OrganizerNotes[]` — internal staff notes from `Person.OrganizerNotes`

Used for last-pass pre-game review of preferences / accommodations / special asks. New `AdultNoteDto`. Same `X-Api-Key` gating as the rest of `/api/v1`.

### 2. QR sticker layout (issue #195)
- Fixed 7×7 cm box (mm-based CSS so screen preview matches print cut)
- Text hierarchy: **character name** dominant → **player name** secondary → **person ID** smallest
- Removed the 3-column grid wrap so stickers flow naturally and respect cut size on print
- Falls back to `firstName lastName` for character if `CharacterName` is null

## Test plan
- [ ] CI green
- [ ] After deploy: `curl https://registrace.ovcina.cz/api/v1/games/1/adult-notes -H "X-Api-Key: ..."` returns JSON list with notes
- [ ] `/organizace/hry/1/qr-stitky` renders 7×7 cm stickers, character name biggest, ready to print

🤖 Generated with [Claude Code](https://claude.com/claude-code)