### PR TITLE
fix: soft-delete Person on attendee removal, closes #203 [v0.9.48]

### DIFF
--- a/src/RegistraceOvcina.Web/Features/Submissions/SubmissionService.cs
+++ b/src/RegistraceOvcina.Web/Features/Submissions/SubmissionService.cs
@@ -634,6 +634,9 @@ public sealed class SubmissionService(
             ?? throw new ValidationException("Účastník nebyl nalezen.");
 
         var personId = registration.PersonId;
+        var removedFirstName = registration.Person?.FirstName ?? "";
+        var removedLastName = registration.Person?.LastName ?? "";
+        var removedAttendeeType = registration.AttendeeType;
         db.Registrations.Remove(registration);
 
         var hasOtherRegistrations = await db.Registrations
@@ -652,8 +655,30 @@ public sealed class SubmissionService(
             registration.Person.UpdatedAtUtc = timeProvider.GetUtcNow().UtcDateTime;
         }
 
-        submission.LastEditedAtUtc = timeProvider.GetUtcNow().UtcDateTime;
+        var nowUtc = timeProvider.GetUtcNow().UtcDateTime;
+        submission.LastEditedAtUtc = nowUtc;
         RecalculateIfSubmitted(submission);
+
+        // OrganizerSubmissionService timeline reads "AttendeeRemoved" entries
+        // (OrganizerSubmissionService.cs:286), so emit one to match AttendeeAdded /
+        // AttendeeUpdated.
+        db.AuditLogs.Add(new AuditLog
+        {
+            EntityType = nameof(Registration),
+            EntityId = registrationId.ToString(),
+            Action = "AttendeeRemoved",
+            ActorUserId = userId,
+            CreatedAtUtc = nowUtc,
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                submissionId,
+                FirstName = removedFirstName,
+                LastName = removedLastName,
+                AttendeeType = removedAttendeeType,
+                PersonSoftDeleted = !hasOtherRegistrations
+            })
+        });
+
         await db.SaveChangesAsync(cancellationToken);
     }
 

--- a/src/RegistraceOvcina.Web/Features/Submissions/SubmissionService.cs
+++ b/src/RegistraceOvcina.Web/Features/Submissions/SubmissionService.cs
@@ -641,7 +641,15 @@ public sealed class SubmissionService(
 
         if (!hasOtherRegistrations && registration.Person is not null)
         {
-            db.People.Remove(registration.Person);
+            // Soft-delete the Person — a hard Remove() throws on the Restrict FK from
+            // Character (and OrganizerNote) when the person has any history from past
+            // games. Soft-delete is the established pattern (see
+            // PeopleReviewService.cs:457). Email/Phone get nulled to free the unique
+            // email constraint so the same email can be reused on a fresh registration.
+            registration.Person.IsDeleted = true;
+            registration.Person.Email = null;
+            registration.Person.Phone = null;
+            registration.Person.UpdatedAtUtc = timeProvider.GetUtcNow().UtcDateTime;
         }
 
         submission.LastEditedAtUtc = timeProvider.GetUtcNow().UtcDateTime;

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.47</Version>
+    <Version>0.9.48</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.48</Version>
+    <Version>0.9.49</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>


### PR DESCRIPTION
## Summary
**Closes #203.** `RemoveAttendeeAsync` called `db.People.Remove()` on the Person when the deleted Registration was the last one referencing them. This throws on `SaveChanges` whenever the Person has any `Character` row (FK is `Restrict`, `ApplicationDbContext.cs:200`) or any `OrganizerNote` — both common for any returning player. The transaction rolls back and the user sees an un-surfaced 500.

## Repro (issue #203)
Submission 311 → Editovat → remove **Marek Vacata** (a child) → 500. He has Character history from past games → FK Restrict bites.

## Fix
Soft-delete the Person instead, matching the established pattern at `PeopleReviewService.cs:457-460`:
- `IsDeleted = true` (global `HasQueryFilter` already hides them)
- `Email = null` and `Phone = null` to free the unique-email constraint so the same email can be reused on a fresh registration

The Person stays referenced by `Characters` / `OrganizerNotes` / `EmailMessages` (those are now historical artifacts pointing at a hidden person row).

## Test plan
- [ ] CI green
- [ ] Post-deploy: editing submission 311 and removing a child attendee no longer 500s
- [ ] The removed attendee disappears from the submission editor
- [ ] Other attendees in the same submission still load fine
- [ ] Spot-check that pages doing `db.People.Where(...)` (kingdom assignment, role page) don't show the soft-deleted person

🤖 Generated with [Claude Code](https://claude.com/claude-code)