### PR TITLE
feat(character-prep-export): add Kingdom column [v0.9.52]

### DIFF
--- a/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepExportService.cs
+++ b/src/RegistraceOvcina.Web/Features/CharacterPrep/CharacterPrepExportService.cs
@@ -28,6 +28,19 @@ public sealed class CharacterPrepExportService(
                 x.Person.FirstName + " " + x.Person.LastName,
                 x.Person.BirthYear,
                 x.CharacterName,
+                // Kingdom = the per-game assignment from CharacterAppearance for THIS
+                // game. There can be multiple appearances for one registration in
+                // theory; pick deterministically (lowest CharacterId, then lowest
+                // appearance Id) the same way GameRolesViewService does, and only
+                // surface the assigned kingdom — preferred is not the final answer.
+                db.CharacterAppearances
+                    .Where(ca => ca.RegistrationId == x.Id
+                        && ca.GameId == gameId
+                        && !ca.Character.IsDeleted)
+                    .OrderBy(ca => ca.CharacterId)
+                    .ThenBy(ca => ca.Id)
+                    .Select(ca => ca.AssignedKingdom != null ? ca.AssignedKingdom.DisplayName : null)
+                    .FirstOrDefault(),
                 x.StartingEquipmentOption != null ? x.StartingEquipmentOption.DisplayName : null,
                 x.CharacterPrepNote,
                 x.Submission.PrimaryContactName,
@@ -42,6 +55,7 @@ public sealed class CharacterPrepExportService(
             "Hráč",
             "Rok narození",
             "Jméno postavy",
+            "Království",
             "Startovní výbava",
             "Poznámka",
             "Domácnost",
@@ -68,18 +82,23 @@ public sealed class CharacterPrepExportService(
                 sheet.Cell(xlRow, 3).Value = row.CharacterName;
             }
 
+            if (!string.IsNullOrEmpty(row.KingdomDisplayName))
+            {
+                sheet.Cell(xlRow, 4).Value = row.KingdomDisplayName;
+            }
+
             if (!string.IsNullOrEmpty(row.EquipmentDisplayName))
             {
-                sheet.Cell(xlRow, 4).Value = row.EquipmentDisplayName;
+                sheet.Cell(xlRow, 5).Value = row.EquipmentDisplayName;
             }
 
             if (!string.IsNullOrEmpty(row.CharacterPrepNote))
             {
-                sheet.Cell(xlRow, 5).Value = row.CharacterPrepNote;
+                sheet.Cell(xlRow, 6).Value = row.CharacterPrepNote;
             }
 
-            sheet.Cell(xlRow, 6).Value = row.PrimaryContactName;
-            sheet.Cell(xlRow, 7).Value = row.PrimaryEmail;
+            sheet.Cell(xlRow, 7).Value = row.PrimaryContactName;
+            sheet.Cell(xlRow, 8).Value = row.PrimaryEmail;
         }
 
         // Formatting: frozen header, autofilter on header, auto-width capped at 40 chars.
@@ -96,6 +115,7 @@ public sealed class CharacterPrepExportService(
         string PersonFullName,
         int BirthYear,
         string? CharacterName,
+        string? KingdomDisplayName,
         string? EquipmentDisplayName,
         string? CharacterPrepNote,
         string PrimaryContactName,

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.49</Version>
+    <Version>0.9.52</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.52</Version>
+    <Version>0.9.53</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepExportServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/CharacterPrep/CharacterPrepExportServiceTests.cs
@@ -42,7 +42,7 @@ public sealed class CharacterPrepExportServiceTests
     }
 
     [Fact]
-    public async Task BuildAsync_header_row_has_7_columns_in_correct_order()
+    public async Task BuildAsync_header_row_has_8_columns_in_correct_order()
     {
         var options = CreateOptions();
         await SeedAsync(options);
@@ -58,11 +58,12 @@ public sealed class CharacterPrepExportServiceTests
         Assert.Equal("Hráč", sheet.Cell(1, 1).GetString());
         Assert.Equal("Rok narození", sheet.Cell(1, 2).GetString());
         Assert.Equal("Jméno postavy", sheet.Cell(1, 3).GetString());
-        Assert.Equal("Startovní výbava", sheet.Cell(1, 4).GetString());
-        Assert.Equal("Poznámka", sheet.Cell(1, 5).GetString());
-        Assert.Equal("Domácnost", sheet.Cell(1, 6).GetString());
-        Assert.Equal("Email domácnosti", sheet.Cell(1, 7).GetString());
-        Assert.Equal("", sheet.Cell(1, 8).GetString());
+        Assert.Equal("Království", sheet.Cell(1, 4).GetString());
+        Assert.Equal("Startovní výbava", sheet.Cell(1, 5).GetString());
+        Assert.Equal("Poznámka", sheet.Cell(1, 6).GetString());
+        Assert.Equal("Domácnost", sheet.Cell(1, 7).GetString());
+        Assert.Equal("Email domácnosti", sheet.Cell(1, 8).GetString());
+        Assert.Equal("", sheet.Cell(1, 9).GetString());
         Assert.True(sheet.Cell(1, 1).Style.Font.Bold);
     }
 
@@ -122,11 +123,13 @@ public sealed class CharacterPrepExportServiceTests
         using var workbook = new XLWorkbook(stream);
         var sheet = workbook.Worksheet("Příprava postav");
 
-        // Anna Adamová (row 2) has no character name, equipment, or note.
+        // Anna Adamová (row 2) has no character name, kingdom assignment,
+        // equipment, or note.
         Assert.Equal("Anna Adamová", sheet.Cell(2, 1).GetString());
         Assert.Equal("", sheet.Cell(2, 3).GetString()); // Jméno postavy
-        Assert.Equal("", sheet.Cell(2, 4).GetString()); // Startovní výbava
-        Assert.Equal("", sheet.Cell(2, 5).GetString()); // Poznámka
+        Assert.Equal("", sheet.Cell(2, 4).GetString()); // Království
+        Assert.Equal("", sheet.Cell(2, 5).GetString()); // Startovní výbava
+        Assert.Equal("", sheet.Cell(2, 6).GetString()); // Poznámka
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
The `/organizace/hry/{id}/priprava-postav/export.xlsx` export now includes a **Království** column between **Jméno postavy** and **Startovní výbava**.

Value comes from `CharacterAppearance.AssignedKingdom.DisplayName` (per-game assignment, not Preferred). When a registration has multiple appearances we pick deterministically by lowest `CharacterId` then lowest appearance `Id`, matching the pattern in `GameRolesViewService` / `IntegrationApiEndpoints`.

Empty cells stay empty (no placeholder), matching the existing column conventions in this exporter.

## Test plan
- [ ] CI green
- [ ] Post-deploy: download `/organizace/hry/1/priprava-postav/export.xlsx` — header row reads `Hráč | Rok narození | Jméno postavy | Království | Startovní výbava | Poznámka | Domácnost | Email domácnosti`
- [ ] Spot-check a row whose player has been kingdom-assigned — Království cell shows the kingdom display name; an unassigned row leaves the cell empty

## Versioning note
Skipped 0.9.50 / 0.9.51 because PR #205 is in flight on those numbers. If #205 lands first this PR is unaffected; if this lands first, #205 needs a one-line rebase on the version line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)