### PR TITLE
hotfix(feedback): unbreak prod startup [v0.9.56]

### DIFF
--- a/src/RegistraceOvcina.Web/Features/Feedback/FeedbackOptions.cs
+++ b/src/RegistraceOvcina.Web/Features/Feedback/FeedbackOptions.cs
@@ -1,12 +1,12 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace RegistraceOvcina.Web.Features.Feedback;
 
 /// <summary>
 /// Configuration for the post-game Feedback feature. <see cref="PublicBaseUrl"/> is the
 /// absolute origin to prefix every <c>/zpetna-vazba/{token}</c> link in outbound mail, so
 /// we don't depend on whichever host actually served the request that triggered the send.
-/// Mirrors <c>CharacterPrepOptions</c> shape for consistency.
+/// Mirrors <c>CharacterPrepOptions</c> shape for consistency: the URL is checked at
+/// email-send time, not at startup, so a missing value doesn't crash the host (the
+/// dashboard, form pages, and export still work without sending mail).
 /// </summary>
 public sealed class FeedbackOptions
 {
@@ -14,10 +14,9 @@ public sealed class FeedbackOptions
 
     /// <summary>
     /// Absolute base URL, no trailing slash — e.g. <c>https://registrace.ovcina.cz</c>.
-    /// Required: validated on startup so a missing value surfaces as a clear bind error
-    /// instead of an <see cref="InvalidOperationException"/> at the first send attempt.
+    /// Optional at startup: the mail service throws a clear <see cref="InvalidOperationException"/>
+    /// if a send is attempted while this is null, mirroring CharacterPrep's behaviour.
     /// </summary>
-    [Required]
     public string? PublicBaseUrl { get; set; }
 
     /// <summary>

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.55</Version>
+    <Version>0.9.56</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/src/RegistraceOvcina.Web/appsettings.json
+++ b/src/RegistraceOvcina.Web/appsettings.json
@@ -41,6 +41,10 @@
     "PublicBaseUrl": "https://registrace.ovcina.cz",
     "OrganizerContactEmail": ""
   },
+  "Feedback": {
+    "PublicBaseUrl": "https://registrace.ovcina.cz",
+    "OrganizerContactEmail": ""
+  },
   "Cors": {
     "OidcOrigins": [ "https://glejt.ovcina.cz" ]
   }


### PR DESCRIPTION
v0.9.55 crashed on Azure Container Apps deploy: `DataAnnotation validation failed for 'FeedbackOptions' members: 'PublicBaseUrl' with the error: 'The PublicBaseUrl field is required.'`

Prod has no `Feedback` config section / env var. `[Required]` + `ValidateOnStart` turned that into a startup crash that took the site down.

CharacterPrep handles this scenario by keeping `PublicBaseUrl` nullable and throwing only at email-send time. This hotfix mirrors that pattern:

- Drop `[Required]` from `FeedbackOptions.PublicBaseUrl`
- Add baked-in default in `appsettings.json` (`https://registrace.ovcina.cz`)

The runtime null check in `FeedbackMailService` already throws a clear `InvalidOperationException` if a send is attempted without the URL, mirroring CharacterPrep behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)