### PR TITLE
feat(feedback): test-send buttons on template editor [v0.9.58]

### DIFF
--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/FeedbackTemplateEditor.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/FeedbackTemplateEditor.razor
@@ -221,6 +221,7 @@ else
     private string? statusMessage;
     private string? errorMessage;
     private bool _needsEditorSync;
+    private string? currentUserId;
     private string? currentUserEmail;
     private bool testAsReminder;
 
@@ -247,6 +248,7 @@ else
         // up here without forcing a re-login.
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         var user = await UserManager.GetUserAsync(authState.User);
+        currentUserId = user?.Id;
         currentUserEmail = user?.Email;
     }
 
@@ -369,7 +371,7 @@ else
     private async Task SendTestAsync(bool isAdult)
     {
         if (busy) return;
-        if (string.IsNullOrWhiteSpace(currentUserEmail))
+        if (string.IsNullOrWhiteSpace(currentUserEmail) || string.IsNullOrWhiteSpace(currentUserId))
         {
             errorMessage = "U tvého účtu chybí e-mailová adresa — zkušební e-mail nelze odeslat.";
             return;
@@ -394,12 +396,12 @@ else
             if (isAdult)
             {
                 await FeedbackMailService.SendTestAdultIndividualAsync(
-                    GameId, currentUserEmail!, testAsReminder, CancellationToken.None);
+                    GameId, currentUserId!, currentUserEmail!, testAsReminder, CancellationToken.None);
             }
             else
             {
                 await FeedbackMailService.SendTestBundleAsync(
-                    GameId, currentUserEmail!, testAsReminder, CancellationToken.None);
+                    GameId, currentUserId!, currentUserEmail!, testAsReminder, CancellationToken.None);
             }
 
             statusMessage = $"Odesláno na {currentUserEmail}.";

--- a/src/RegistraceOvcina.Web/Components/Pages/Organizer/FeedbackTemplateEditor.razor
+++ b/src/RegistraceOvcina.Web/Components/Pages/Organizer/FeedbackTemplateEditor.razor
@@ -2,12 +2,17 @@
 @attribute [Authorize(Policy = AuthorizationPolicies.StaffOnly)]
 @rendermode InteractiveServer
 
+@using Microsoft.AspNetCore.Identity
+@using RegistraceOvcina.Web.Data
 @using RegistraceOvcina.Web.Features.Feedback
 @using RegistraceOvcina.Web.Security
 @using RegistraceOvcina.Web.Components.Shared
 
 @inject FeedbackService FeedbackService
+@inject FeedbackMailService FeedbackMailService
 @inject IFeedbackEmailRenderer EmailRenderer
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject UserManager<ApplicationUser> UserManager
 @inject NavigationManager Nav
 
 <PageTitle>Šablony e-mailů — @(header?.GameName ?? "Načítání…")</PageTitle>
@@ -115,6 +120,45 @@ else
 
     <section class="card mb-4">
         <div class="card-body">
+            <h3 class="h5 mb-3">Zkušební e-mail (sobě)</h3>
+            <p class="small text-secondary mb-2">
+                Test e-mail půjde na tvou aktuálně přihlášenou adresu
+                @if (!string.IsNullOrWhiteSpace(currentUserEmail))
+                {
+                    <strong>(@currentUserEmail)</strong>
+                }
+                . Odkazy v něm jsou jen ukázkové.
+            </p>
+            <div class="form-check mb-3">
+                <input class="form-check-input" type="checkbox" id="testAsReminder"
+                       @bind="testAsReminder" disabled="@busy" />
+                <label class="form-check-label" for="testAsReminder">
+                    Poslat jako připomínku
+                </label>
+            </div>
+            <div class="d-flex flex-wrap gap-2">
+                <button type="button" class="btn btn-outline-secondary btn-sm"
+                        @onclick="SendTestBundleAsync"
+                        disabled="@(busy || string.IsNullOrWhiteSpace(currentUserEmail))">
+                    Poslat zkušebně mně — rodinná verze
+                </button>
+                <button type="button" class="btn btn-outline-secondary btn-sm"
+                        @onclick="SendTestAdultAsync"
+                        disabled="@(busy || string.IsNullOrWhiteSpace(currentUserEmail))">
+                    Poslat zkušebně mně — verze pro dospělé
+                </button>
+            </div>
+            @if (string.IsNullOrWhiteSpace(currentUserEmail))
+            {
+                <p class="small text-danger mt-2 mb-0">
+                    U tvého účtu chybí e-mailová adresa — zkušební e-mail nelze odeslat.
+                </p>
+            }
+        </div>
+    </section>
+
+    <section class="card mb-4">
+        <div class="card-body">
             <h3 class="h5 mb-3">Náhled (s ukázkovými hodnotami)</h3>
             <p class="small text-secondary mb-3">
                 Náhled se obnoví po stisku „Aktualizovat náhled". Ukazuje
@@ -177,6 +221,8 @@ else
     private string? statusMessage;
     private string? errorMessage;
     private bool _needsEditorSync;
+    private string? currentUserEmail;
+    private bool testAsReminder;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -194,6 +240,14 @@ else
         adultSubject = templates.AdultIndividualSubjectTemplate ?? "";
         adultHtml = templates.AdultIndividualHtmlTemplate ?? "";
         _needsEditorSync = true;
+
+        // Resolve the logged-in organizer's email so the "test-send" buttons
+        // know where to deliver the preview. Pulled from the Identity store
+        // (UserManager) rather than the email claim so a profile-edit picks
+        // up here without forcing a re-login.
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = await UserManager.GetUserAsync(authState.User);
+        currentUserEmail = user?.Email;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -293,6 +347,66 @@ else
         catch (Exception ex)
         {
             errorMessage = "Uložení selhalo: " + ex.Message;
+        }
+        finally
+        {
+            busy = false;
+        }
+    }
+
+    private Task SendTestBundleAsync() =>
+        SendTestAsync(isAdult: false);
+
+    private Task SendTestAdultAsync() =>
+        SendTestAsync(isAdult: true);
+
+    /// <summary>
+    /// Saves the current edits + dispatches a sample email of the requested
+    /// shape to the logged-in organizer's address. Saving first means the test
+    /// email reflects exactly what real recipients will see — same renderer,
+    /// same per-game template overrides, same sender pipeline.
+    /// </summary>
+    private async Task SendTestAsync(bool isAdult)
+    {
+        if (busy) return;
+        if (string.IsNullOrWhiteSpace(currentUserEmail))
+        {
+            errorMessage = "U tvého účtu chybí e-mailová adresa — zkušební e-mail nelze odeslat.";
+            return;
+        }
+
+        busy = true;
+        statusMessage = null;
+        errorMessage = null;
+        try
+        {
+            // Persist current edits so the test send picks them up — the
+            // service reads templates from the Game row, not from this form's
+            // in-memory state.
+            await SyncFromEditorsAsync();
+            var dto = new FeedbackEmailTemplates(
+                NullIfBlank(bundleSubject),
+                NullIfBlank(bundleHtml),
+                NullIfBlank(adultSubject),
+                NullIfBlank(adultHtml));
+            await FeedbackService.SaveEmailTemplatesAsync(GameId, dto, CancellationToken.None);
+
+            if (isAdult)
+            {
+                await FeedbackMailService.SendTestAdultIndividualAsync(
+                    GameId, currentUserEmail!, testAsReminder, CancellationToken.None);
+            }
+            else
+            {
+                await FeedbackMailService.SendTestBundleAsync(
+                    GameId, currentUserEmail!, testAsReminder, CancellationToken.None);
+            }
+
+            statusMessage = $"Odesláno na {currentUserEmail}.";
+        }
+        catch (Exception ex)
+        {
+            errorMessage = "Chyba: " + ex.Message;
         }
         finally
         {

--- a/src/RegistraceOvcina.Web/Features/Feedback/FeedbackMailService.cs
+++ b/src/RegistraceOvcina.Web/Features/Feedback/FeedbackMailService.cs
@@ -318,4 +318,134 @@ public sealed class FeedbackMailService(
 
         return $"{baseUrl}/zpetna-vazba/{token}";
     }
+
+    // -------------------------------------------------------------------------
+    // Test-send: organizer "send to me" preview from the template editor
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Renders + sends a sample bundle (household-contact) feedback email to
+    /// <paramref name="toEmail"/> using the same renderer + sender + per-game
+    /// template overrides as the real bulk send. The link targets in the body
+    /// are randomly generated GUIDs — they do NOT resolve to any real
+    /// Registration. Used by the organizer template editor's "send a test to
+    /// me" buttons so the organizer sees exactly what real recipients will get
+    /// before triggering the bulk send.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="toEmail"/> is null/blank, when the game
+    /// does not exist, or when <see cref="FeedbackOptions.PublicBaseUrl"/> is
+    /// unconfigured (mirrors the real-send safeguard).
+    /// </exception>
+    public async Task SendTestBundleAsync(
+        int gameId,
+        string toEmail,
+        bool isReminder,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(toEmail))
+        {
+            throw new InvalidOperationException("Cieľová e-mailová adresa je prázdná.");
+        }
+
+        var options = feedbackOptions.Value;
+        var baseUrl = (options.PublicBaseUrl ?? "").TrimEnd('/');
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new InvalidOperationException(
+                "Feedback:PublicBaseUrl is not configured; cannot build feedback URL.");
+        }
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+        var game = await db.Games
+            .AsNoTracking()
+            .FirstOrDefaultAsync(g => g.Id == gameId, ct)
+            ?? throw new InvalidOperationException($"Game {gameId} not found.");
+
+        // Mirror FeedbackService.ComputeWindow: closes-at falls back to
+        // EndsAtUtc + 30 days when not configured. Keeps the rendered deadline
+        // string consistent with whatever the organizer sees on the dashboard.
+        var endsAt = new DateTimeOffset(DateTime.SpecifyKind(game.EndsAtUtc, DateTimeKind.Utc));
+        var closesAt = game.FeedbackClosesAtUtc ?? endsAt.AddDays(30);
+
+        var sample = new FeedbackContactBundleEmail(
+            ToEmail: toEmail,
+            ContactName: "Testovací rodič",
+            GameName: game.Name,
+            FeedbackClosesAtLocal: closesAt,
+            Entries: new List<FeedbackBundleEntry>
+            {
+                new("Anička (test)", AttendeeType.Player,
+                    $"{baseUrl}/zpetna-vazba/{Guid.NewGuid()}"),
+                new("Kuba (test)", AttendeeType.Player,
+                    $"{baseUrl}/zpetna-vazba/{Guid.NewGuid()}"),
+            },
+            IsReminder: isReminder,
+            SubjectTemplate: game.FeedbackBundleSubjectTemplate,
+            HtmlTemplate: game.FeedbackBundleHtmlTemplate);
+
+        var rendered = emailRenderer.RenderContactBundle(sample);
+        await emailSender.SendAsync(toEmail, rendered.Subject, rendered.HtmlBody, ct);
+
+        logger.LogInformation(
+            "FeedbackMailService: test bundle email sent to {ToEmail} (game {GameId}, isReminder={IsReminder}).",
+            toEmail, gameId, isReminder);
+    }
+
+    /// <summary>
+    /// Renders + sends a sample adult-individual feedback email to
+    /// <paramref name="toEmail"/> using the same renderer + sender + per-game
+    /// template overrides as the real bulk send. The link target is a random
+    /// GUID — it does NOT resolve to any real Registration.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="toEmail"/> is null/blank, when the game
+    /// does not exist, or when <see cref="FeedbackOptions.PublicBaseUrl"/> is
+    /// unconfigured.
+    /// </exception>
+    public async Task SendTestAdultIndividualAsync(
+        int gameId,
+        string toEmail,
+        bool isReminder,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(toEmail))
+        {
+            throw new InvalidOperationException("Cieľová e-mailová adresa je prázdná.");
+        }
+
+        var options = feedbackOptions.Value;
+        var baseUrl = (options.PublicBaseUrl ?? "").TrimEnd('/');
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new InvalidOperationException(
+                "Feedback:PublicBaseUrl is not configured; cannot build feedback URL.");
+        }
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(ct);
+        var game = await db.Games
+            .AsNoTracking()
+            .FirstOrDefaultAsync(g => g.Id == gameId, ct)
+            ?? throw new InvalidOperationException($"Game {gameId} not found.");
+
+        var endsAt = new DateTimeOffset(DateTime.SpecifyKind(game.EndsAtUtc, DateTimeKind.Utc));
+        var closesAt = game.FeedbackClosesAtUtc ?? endsAt.AddDays(30);
+
+        var sample = new FeedbackAdultIndividualEmail(
+            ToEmail: toEmail,
+            AttendeeName: "Testovací dospělý",
+            GameName: game.Name,
+            FeedbackClosesAtLocal: closesAt,
+            TokenLink: $"{baseUrl}/zpetna-vazba/{Guid.NewGuid()}",
+            IsReminder: isReminder,
+            SubjectTemplate: game.FeedbackAdultIndividualSubjectTemplate,
+            HtmlTemplate: game.FeedbackAdultIndividualHtmlTemplate);
+
+        var rendered = emailRenderer.RenderAdultIndividual(sample);
+        await emailSender.SendAsync(toEmail, rendered.Subject, rendered.HtmlBody, ct);
+
+        logger.LogInformation(
+            "FeedbackMailService: test adult-individual email sent to {ToEmail} (game {GameId}, isReminder={IsReminder}).",
+            toEmail, gameId, isReminder);
+    }
 }

--- a/src/RegistraceOvcina.Web/Features/Feedback/FeedbackMailService.cs
+++ b/src/RegistraceOvcina.Web/Features/Feedback/FeedbackMailService.cs
@@ -324,28 +324,37 @@ public sealed class FeedbackMailService(
     // -------------------------------------------------------------------------
 
     /// <summary>
-    /// Renders + sends a sample bundle (household-contact) feedback email to
+    /// Renders + sends a real bundle (household-contact) feedback email to
     /// <paramref name="toEmail"/> using the same renderer + sender + per-game
-    /// template overrides as the real bulk send. The link targets in the body
-    /// are randomly generated GUIDs — they do NOT resolve to any real
-    /// Registration. Used by the organizer template editor's "send a test to
-    /// me" buttons so the organizer sees exactly what real recipients will get
-    /// before triggering the bulk send.
+    /// template overrides as the real bulk send. Resolves the logged-in
+    /// organizer's own <see cref="RegistrationSubmission"/> for this game and
+    /// uses the actual Registrations + freshly issued FeedbackTokens, so the
+    /// links in the email lead to real, working feedback forms. This makes the
+    /// test a fully functional preview — the organizer can click through and
+    /// experience the form end-to-end before triggering the bulk send.
+    /// <para>Does NOT call <see cref="FeedbackService.MarkInvitedAsync"/>; a
+    /// test send must not pollute the dashboard's "Pozváno" count.</para>
     /// </summary>
     /// <exception cref="InvalidOperationException">
     /// Thrown when <paramref name="toEmail"/> is null/blank, when the game
-    /// does not exist, or when <see cref="FeedbackOptions.PublicBaseUrl"/> is
-    /// unconfigured (mirrors the real-send safeguard).
+    /// does not exist, when <see cref="FeedbackOptions.PublicBaseUrl"/> is
+    /// unconfigured (mirrors the real-send safeguard), or when the logged-in
+    /// user has no own submission in this game.
     /// </exception>
     public async Task SendTestBundleAsync(
         int gameId,
+        string currentUserId,
         string toEmail,
         bool isReminder,
         CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(toEmail))
         {
-            throw new InvalidOperationException("Cieľová e-mailová adresa je prázdná.");
+            throw new InvalidOperationException("Cílová e-mailová adresa je prázdná.");
+        }
+        if (string.IsNullOrWhiteSpace(currentUserId))
+        {
+            throw new InvalidOperationException("Přihlášený uživatel není rozpoznán.");
         }
 
         var options = feedbackOptions.Value;
@@ -362,24 +371,58 @@ public sealed class FeedbackMailService(
             .FirstOrDefaultAsync(g => g.Id == gameId, ct)
             ?? throw new InvalidOperationException($"Game {gameId} not found.");
 
+        // Resolve the logged-in user's own submission for this game. This is
+        // the same predicate FeedbackScribe uses for ownership checks: the
+        // submission's RegistrantUserId === current user, GameId matches, and
+        // the soft-deleted flag is off. Tracked load (no AsNoTracking) so the
+        // FeedbackTokenService writes below participate in change tracking
+        // through its own DbContext — but we still re-include navigations
+        // here to render names without a second round-trip.
+        var submission = await db.RegistrationSubmissions
+            .AsNoTracking()
+            .Include(s => s.Registrations)
+                .ThenInclude(r => r.Person)
+            .FirstOrDefaultAsync(
+                s => s.GameId == gameId
+                    && s.RegistrantUserId == currentUserId
+                    && !s.IsDeleted,
+                ct)
+            ?? throw new InvalidOperationException(
+                "Test bundle e-mail vyžaduje vaši vlastní přihlášku do této hry.");
+
+        // Lazily mint tokens for any registration that doesn't have one yet.
+        // EnsureTokenAsync is idempotent — never rotates an existing token —
+        // so it's safe to call from the test path. Real bulk-send will call
+        // it again later for the same registrations and get the same Guids.
+        var tokens = new Dictionary<int, Guid>(submission.Registrations.Count);
+        foreach (var reg in submission.Registrations)
+        {
+            ct.ThrowIfCancellationRequested();
+            tokens[reg.Id] = await tokenService.EnsureTokenAsync(reg.Id, ct);
+        }
+
         // Mirror FeedbackService.ComputeWindow: closes-at falls back to
         // EndsAtUtc + 30 days when not configured. Keeps the rendered deadline
         // string consistent with whatever the organizer sees on the dashboard.
         var endsAt = new DateTimeOffset(DateTime.SpecifyKind(game.EndsAtUtc, DateTimeKind.Utc));
         var closesAt = game.FeedbackClosesAtUtc ?? endsAt.AddDays(30);
 
+        var entries = submission.Registrations
+            .OrderBy(r => r.Id)
+            .Select(r => new FeedbackBundleEntry(
+                AttendeeName: $"{r.Person.FirstName} {r.Person.LastName}".Trim(),
+                AttendeeType: r.AttendeeType,
+                TokenLink: $"{baseUrl}/zpetna-vazba/{tokens[r.Id]}"))
+            .ToList();
+
         var sample = new FeedbackContactBundleEmail(
             ToEmail: toEmail,
-            ContactName: "Testovací rodič",
+            ContactName: string.IsNullOrWhiteSpace(submission.PrimaryContactName)
+                ? toEmail
+                : submission.PrimaryContactName,
             GameName: game.Name,
             FeedbackClosesAtLocal: closesAt,
-            Entries: new List<FeedbackBundleEntry>
-            {
-                new("Anička (test)", AttendeeType.Player,
-                    $"{baseUrl}/zpetna-vazba/{Guid.NewGuid()}"),
-                new("Kuba (test)", AttendeeType.Player,
-                    $"{baseUrl}/zpetna-vazba/{Guid.NewGuid()}"),
-            },
+            Entries: entries,
             IsReminder: isReminder,
             SubjectTemplate: game.FeedbackBundleSubjectTemplate,
             HtmlTemplate: game.FeedbackBundleHtmlTemplate);
@@ -388,30 +431,40 @@ public sealed class FeedbackMailService(
         await emailSender.SendAsync(toEmail, rendered.Subject, rendered.HtmlBody, ct);
 
         logger.LogInformation(
-            "FeedbackMailService: test bundle email sent to {ToEmail} (game {GameId}, isReminder={IsReminder}).",
-            toEmail, gameId, isReminder);
+            "FeedbackMailService: test bundle email sent to {ToEmail} (game {GameId}, submission {SubmissionId}, isReminder={IsReminder}).",
+            toEmail, gameId, submission.Id, isReminder);
     }
 
     /// <summary>
-    /// Renders + sends a sample adult-individual feedback email to
+    /// Renders + sends a real adult-individual feedback email to
     /// <paramref name="toEmail"/> using the same renderer + sender + per-game
-    /// template overrides as the real bulk send. The link target is a random
-    /// GUID — it does NOT resolve to any real Registration.
+    /// template overrides as the real bulk send. Resolves the logged-in
+    /// user's own adult Registration in this game (matched by Person.Email
+    /// case-insensitively against <paramref name="toEmail"/>) and uses its
+    /// real FeedbackToken so the link in the email leads to a working form.
+    /// <para>Does NOT call <see cref="FeedbackService.MarkInvitedAsync"/>; a
+    /// test send must not pollute the dashboard's "Pozváno" count.</para>
     /// </summary>
     /// <exception cref="InvalidOperationException">
     /// Thrown when <paramref name="toEmail"/> is null/blank, when the game
-    /// does not exist, or when <see cref="FeedbackOptions.PublicBaseUrl"/> is
-    /// unconfigured.
+    /// does not exist, when <see cref="FeedbackOptions.PublicBaseUrl"/> is
+    /// unconfigured, or when the logged-in user has no adult registration in
+    /// this game (matched by email).
     /// </exception>
     public async Task SendTestAdultIndividualAsync(
         int gameId,
+        string currentUserId,
         string toEmail,
         bool isReminder,
         CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(toEmail))
         {
-            throw new InvalidOperationException("Cieľová e-mailová adresa je prázdná.");
+            throw new InvalidOperationException("Cílová e-mailová adresa je prázdná.");
+        }
+        if (string.IsNullOrWhiteSpace(currentUserId))
+        {
+            throw new InvalidOperationException("Přihlášený uživatel není rozpoznán.");
         }
 
         var options = feedbackOptions.Value;
@@ -428,15 +481,40 @@ public sealed class FeedbackMailService(
             .FirstOrDefaultAsync(g => g.Id == gameId, ct)
             ?? throw new InvalidOperationException($"Game {gameId} not found.");
 
+        // Mirror the real bulk-send classifier: an "adult-individual" recipient
+        // is a Registration where AttendeeType != Player AND Person.Email is
+        // set. The simplest robust mapping from the logged-in user to such a
+        // Registration is by email: Person.Email == currentUser.Email
+        // case-insensitive, joined to a non-deleted submission in this game.
+        // EF Core in-memory provider doesn't honour StringComparison overloads
+        // on Where, so we lower both sides explicitly.
+        var emailLower = toEmail.Trim().ToLowerInvariant();
+        var registration = await db.Registrations
+            .AsNoTracking()
+            .Include(r => r.Person)
+            .Include(r => r.Submission)
+            .Where(r => r.Submission.GameId == gameId
+                && !r.Submission.IsDeleted
+                && r.AttendeeType != AttendeeType.Player
+                && r.Person.Email != null
+                && r.Person.Email.ToLower() == emailLower)
+            .OrderBy(r => r.Id)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new InvalidOperationException(
+                "Test e-mail pro dospělé vyžaduje, abyste byli sami zaregistrováni jako dospělý účastník této hry.");
+
+        // Lazy token issue (idempotent — never rotates).
+        var token = await tokenService.EnsureTokenAsync(registration.Id, ct);
+
         var endsAt = new DateTimeOffset(DateTime.SpecifyKind(game.EndsAtUtc, DateTimeKind.Utc));
         var closesAt = game.FeedbackClosesAtUtc ?? endsAt.AddDays(30);
 
         var sample = new FeedbackAdultIndividualEmail(
             ToEmail: toEmail,
-            AttendeeName: "Testovací dospělý",
+            AttendeeName: $"{registration.Person.FirstName} {registration.Person.LastName}".Trim(),
             GameName: game.Name,
             FeedbackClosesAtLocal: closesAt,
-            TokenLink: $"{baseUrl}/zpetna-vazba/{Guid.NewGuid()}",
+            TokenLink: $"{baseUrl}/zpetna-vazba/{token}",
             IsReminder: isReminder,
             SubjectTemplate: game.FeedbackAdultIndividualSubjectTemplate,
             HtmlTemplate: game.FeedbackAdultIndividualHtmlTemplate);
@@ -445,7 +523,7 @@ public sealed class FeedbackMailService(
         await emailSender.SendAsync(toEmail, rendered.Subject, rendered.HtmlBody, ct);
 
         logger.LogInformation(
-            "FeedbackMailService: test adult-individual email sent to {ToEmail} (game {GameId}, isReminder={IsReminder}).",
-            toEmail, gameId, isReminder);
+            "FeedbackMailService: test adult-individual email sent to {ToEmail} (game {GameId}, registration {RegistrationId}, isReminder={IsReminder}).",
+            toEmail, gameId, registration.Id, isReminder);
     }
 }

--- a/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
+++ b/src/RegistraceOvcina.Web/RegistraceOvcina.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.9.57</Version>
+    <Version>0.9.58</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-RegistraceOvcina_Web-a86d1b4a-2dd0-47b4-baa0-79e72288dbbd</UserSecretsId>

--- a/tests/RegistraceOvcina.Web.Tests/Features/Feedback/FeedbackMailServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/Feedback/FeedbackMailServiceTests.cs
@@ -239,14 +239,24 @@ public sealed class FeedbackMailServiceTests
     }
 
     // -------------------------------------------------- SendTest* methods
+    //
+    // Test-send now uses the logged-in user's REAL submission/registration
+    // data rather than dummy fixtures: bundle test resolves the user's own
+    // submission for this game, adult-individual resolves a Person.Email
+    // match. Tokens are issued lazily via FeedbackTokenService.EnsureTokenAsync
+    // and the test path must NOT mark anyone invited.
+
+    private const string TestUserId = "user-1";
+    private const string TestUserEmail = "tom@example.cz";
 
     [Fact]
-    public async Task SendTestBundleAsync_renders_through_existing_renderer_and_calls_sender()
+    public async Task SendTestBundleAsync_renders_through_existing_renderer_with_real_submission()
     {
         var options = CreateOptions();
         await SeedGameAsync(options);
-        // Per-game template override that the renderer should pick up. Subject
-        // template includes the {GameName} token to prove the renderer ran.
+        // Seed a submission owned by TestUserId with two players. Submission
+        // PrimaryContactName flows into the {ContactName} token.
+        await AddSubmissionAsync(options, submissionId: 1, players: 2, adultsWithEmail: 0, adultsWithoutEmail: 0);
         await using (var db = new ApplicationDbContext(options))
         {
             var game = await db.Games.SingleAsync();
@@ -256,25 +266,116 @@ public sealed class FeedbackMailServiceTests
         }
         var (service, sender) = CreateService(options);
 
-        await service.SendTestBundleAsync(GameId, "tom@example.cz", isReminder: false, CancellationToken.None);
+        await service.SendTestBundleAsync(
+            GameId, TestUserId, TestUserEmail, isReminder: false, CancellationToken.None);
 
         var captured = Assert.Single(sender.Captured);
-        Assert.Equal("tom@example.cz", captured.To);
-        // Game name token substituted by FeedbackTemplateRenderer.
+        Assert.Equal(TestUserEmail, captured.To);
         Assert.Equal("TEST-Ovčina 2026", captured.Subject);
-        // Entries token expanded into a <ul> with the two dummy player rows.
-        Assert.Contains("Anička (test)", captured.HtmlBody);
-        Assert.Contains("Kuba (test)", captured.HtmlBody);
-        Assert.Contains("Testovací rodič", captured.HtmlBody);
+        // Real Person names from the seed (see AddSubmissionAsync).
+        Assert.Contains("Kid0 S1", captured.HtmlBody);
+        Assert.Contains("Kid1 S1", captured.HtmlBody);
+        // Real PrimaryContactName from the seed.
+        Assert.Contains("Contact 1", captured.HtmlBody);
     }
 
     [Fact]
-    public async Task SendTestAdultIndividualAsync_renders_and_calls_sender()
+    public async Task SendTestBundleAsync_throws_when_user_has_no_submission_in_game()
     {
         var options = CreateOptions();
         await SeedGameAsync(options);
+        // No submission seeded for TestUserId — the resolver should refuse.
+        var (service, sender) = CreateService(options);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SendTestBundleAsync(
+                GameId, TestUserId, TestUserEmail, isReminder: false, CancellationToken.None));
+        Assert.Contains("vlastní přihlášku", ex.Message);
+        Assert.Empty(sender.Captured);
+    }
+
+    [Fact]
+    public async Task SendTestBundleAsync_does_not_mark_anyone_invited()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, players: 2, adultsWithEmail: 0, adultsWithoutEmail: 0);
+        var (service, _) = CreateService(options);
+
+        await service.SendTestBundleAsync(
+            GameId, TestUserId, TestUserEmail, isReminder: false, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var regs = await verify.Registrations.ToListAsync();
+        Assert.NotEmpty(regs);
+        // Test-send must NOT touch the dashboard's "Pozváno" / reminder counters.
+        Assert.All(regs, r => Assert.Null(r.FeedbackInvitedAtUtc));
+        Assert.All(regs, r => Assert.Null(r.FeedbackReminderLastSentAtUtc));
+    }
+
+    [Fact]
+    public async Task SendTestBundleAsync_issues_tokens_on_unminted_registrations()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, players: 2, adultsWithEmail: 0, adultsWithoutEmail: 0);
+        // Sanity: tokens should start out null.
+        await using (var pre = new ApplicationDbContext(options))
+        {
+            Assert.All(await pre.Registrations.ToListAsync(), r => Assert.Null(r.FeedbackToken));
+        }
+        var (service, sender) = CreateService(options);
+
+        await service.SendTestBundleAsync(
+            GameId, TestUserId, TestUserEmail, isReminder: false, CancellationToken.None);
+
+        await using var verify = new ApplicationDbContext(options);
+        var regs = await verify.Registrations.ToListAsync();
+        Assert.All(regs, r =>
+        {
+            Assert.NotNull(r.FeedbackToken);
+            Assert.NotEqual(Guid.Empty, r.FeedbackToken!.Value);
+        });
+        // The captured HTML must reference each freshly issued token (proves the
+        // entries are wired off the real ids, not random Guids).
+        var captured = Assert.Single(sender.Captured);
+        foreach (var reg in regs)
+        {
+            Assert.Contains(reg.FeedbackToken!.Value.ToString(), captured.HtmlBody);
+        }
+    }
+
+    [Fact]
+    public async Task SendTestAdultIndividualAsync_renders_with_real_registration()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        // Seed a submission for TestUserId then add one adult Person whose
+        // Email matches TestUserEmail — that's how the service maps the
+        // logged-in user to a Registration.
+        await AddSubmissionAsync(options, submissionId: 1, players: 0, adultsWithEmail: 0, adultsWithoutEmail: 0);
         await using (var db = new ApplicationDbContext(options))
         {
+            db.People.Add(new Person
+            {
+                Id = 9001,
+                FirstName = "Tomáš",
+                LastName = "Pajonk",
+                BirthYear = 1985,
+                Email = TestUserEmail,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc,
+            });
+            db.Registrations.Add(new Registration
+            {
+                Id = 9001,
+                SubmissionId = 1,
+                PersonId = 9001,
+                AttendeeType = AttendeeType.Adult,
+                Status = RegistrationStatus.Active,
+                CreatedAtUtc = FixedUtc,
+                UpdatedAtUtc = FixedUtc,
+            });
             var game = await db.Games.SingleAsync();
             game.FeedbackAdultIndividualSubjectTemplate = "ADULT-{GameName}";
             game.FeedbackAdultIndividualHtmlTemplate = "<p>Ahoj {AttendeeName}, link: {TokenLink}</p>";
@@ -282,14 +383,39 @@ public sealed class FeedbackMailServiceTests
         }
         var (service, sender) = CreateService(options);
 
-        await service.SendTestAdultIndividualAsync(GameId, "tom@example.cz", isReminder: false, CancellationToken.None);
+        await service.SendTestAdultIndividualAsync(
+            GameId, TestUserId, TestUserEmail, isReminder: false, CancellationToken.None);
 
         var captured = Assert.Single(sender.Captured);
-        Assert.Equal("tom@example.cz", captured.To);
+        Assert.Equal(TestUserEmail, captured.To);
         Assert.Equal("ADULT-Ovčina 2026", captured.Subject);
-        Assert.Contains("Testovací dospělý", captured.HtmlBody);
-        // Token link must use the configured PublicBaseUrl prefix.
+        // Real attendee name from the seeded Person.
+        Assert.Contains("Tomáš Pajonk", captured.HtmlBody);
         Assert.Contains("https://registrace.ovcina.cz/zpetna-vazba/", captured.HtmlBody);
+
+        // Token must have been minted on the seeded Registration.
+        await using var verify = new ApplicationDbContext(options);
+        var reg = await verify.Registrations.SingleAsync(r => r.Id == 9001);
+        Assert.NotNull(reg.FeedbackToken);
+        Assert.Contains(reg.FeedbackToken!.Value.ToString(), captured.HtmlBody);
+        // No invited-marking side effect.
+        Assert.Null(reg.FeedbackInvitedAtUtc);
+    }
+
+    [Fact]
+    public async Task SendTestAdultIndividualAsync_throws_when_user_has_no_adult_registration_in_game()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        // Submission with only kids — no adult registration matches the user's email.
+        await AddSubmissionAsync(options, submissionId: 1, players: 1, adultsWithEmail: 0, adultsWithoutEmail: 0);
+        var (service, sender) = CreateService(options);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SendTestAdultIndividualAsync(
+                GameId, TestUserId, TestUserEmail, isReminder: false, CancellationToken.None));
+        Assert.Contains("zaregistrováni jako dospělý", ex.Message);
+        Assert.Empty(sender.Captured);
     }
 
     [Fact]
@@ -300,9 +426,9 @@ public sealed class FeedbackMailServiceTests
         var (service, sender) = CreateService(options);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.SendTestBundleAsync(GameId, "", isReminder: false, CancellationToken.None));
+            service.SendTestBundleAsync(GameId, TestUserId, "", isReminder: false, CancellationToken.None));
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.SendTestBundleAsync(GameId, "   ", isReminder: false, CancellationToken.None));
+            service.SendTestBundleAsync(GameId, TestUserId, "   ", isReminder: false, CancellationToken.None));
 
         Assert.Empty(sender.Captured);
     }
@@ -315,7 +441,8 @@ public sealed class FeedbackMailServiceTests
         var (service, sender) = CreateService(options);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.SendTestBundleAsync(GameId, "tom@example.cz", isReminder: false, CancellationToken.None));
+            service.SendTestBundleAsync(
+                GameId, TestUserId, TestUserEmail, isReminder: false, CancellationToken.None));
 
         Assert.Empty(sender.Captured);
     }
@@ -325,9 +452,11 @@ public sealed class FeedbackMailServiceTests
     {
         var options = CreateOptions();
         await SeedGameAsync(options);
+        await AddSubmissionAsync(options, submissionId: 1, players: 1, adultsWithEmail: 0, adultsWithoutEmail: 0);
         var (service, sender) = CreateService(options);
 
-        await service.SendTestBundleAsync(GameId, "tom@example.cz", isReminder: true, CancellationToken.None);
+        await service.SendTestBundleAsync(
+            GameId, TestUserId, TestUserEmail, isReminder: true, CancellationToken.None);
 
         var captured = Assert.Single(sender.Captured);
         // Default reminder subject (no template override) starts with "Připomínka:".
@@ -344,7 +473,8 @@ public sealed class FeedbackMailServiceTests
         var (service, sender) = CreateService(options);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.SendTestAdultIndividualAsync(GameId, "", isReminder: false, CancellationToken.None));
+            service.SendTestAdultIndividualAsync(
+                GameId, TestUserId, "", isReminder: false, CancellationToken.None));
 
         Assert.Empty(sender.Captured);
     }

--- a/tests/RegistraceOvcina.Web.Tests/Features/Feedback/FeedbackMailServiceTests.cs
+++ b/tests/RegistraceOvcina.Web.Tests/Features/Feedback/FeedbackMailServiceTests.cs
@@ -238,6 +238,117 @@ public sealed class FeedbackMailServiceTests
         Assert.Equal(3, distinct);
     }
 
+    // -------------------------------------------------- SendTest* methods
+
+    [Fact]
+    public async Task SendTestBundleAsync_renders_through_existing_renderer_and_calls_sender()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        // Per-game template override that the renderer should pick up. Subject
+        // template includes the {GameName} token to prove the renderer ran.
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var game = await db.Games.SingleAsync();
+            game.FeedbackBundleSubjectTemplate = "TEST-{GameName}";
+            game.FeedbackBundleHtmlTemplate = "<p>Hello {ContactName}!</p>{Entries}";
+            await db.SaveChangesAsync();
+        }
+        var (service, sender) = CreateService(options);
+
+        await service.SendTestBundleAsync(GameId, "tom@example.cz", isReminder: false, CancellationToken.None);
+
+        var captured = Assert.Single(sender.Captured);
+        Assert.Equal("tom@example.cz", captured.To);
+        // Game name token substituted by FeedbackTemplateRenderer.
+        Assert.Equal("TEST-Ovčina 2026", captured.Subject);
+        // Entries token expanded into a <ul> with the two dummy player rows.
+        Assert.Contains("Anička (test)", captured.HtmlBody);
+        Assert.Contains("Kuba (test)", captured.HtmlBody);
+        Assert.Contains("Testovací rodič", captured.HtmlBody);
+    }
+
+    [Fact]
+    public async Task SendTestAdultIndividualAsync_renders_and_calls_sender()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        await using (var db = new ApplicationDbContext(options))
+        {
+            var game = await db.Games.SingleAsync();
+            game.FeedbackAdultIndividualSubjectTemplate = "ADULT-{GameName}";
+            game.FeedbackAdultIndividualHtmlTemplate = "<p>Ahoj {AttendeeName}, link: {TokenLink}</p>";
+            await db.SaveChangesAsync();
+        }
+        var (service, sender) = CreateService(options);
+
+        await service.SendTestAdultIndividualAsync(GameId, "tom@example.cz", isReminder: false, CancellationToken.None);
+
+        var captured = Assert.Single(sender.Captured);
+        Assert.Equal("tom@example.cz", captured.To);
+        Assert.Equal("ADULT-Ovčina 2026", captured.Subject);
+        Assert.Contains("Testovací dospělý", captured.HtmlBody);
+        // Token link must use the configured PublicBaseUrl prefix.
+        Assert.Contains("https://registrace.ovcina.cz/zpetna-vazba/", captured.HtmlBody);
+    }
+
+    [Fact]
+    public async Task SendTestBundleAsync_throws_when_toEmail_is_blank()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        var (service, sender) = CreateService(options);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SendTestBundleAsync(GameId, "", isReminder: false, CancellationToken.None));
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SendTestBundleAsync(GameId, "   ", isReminder: false, CancellationToken.None));
+
+        Assert.Empty(sender.Captured);
+    }
+
+    [Fact]
+    public async Task SendTestBundleAsync_throws_when_game_does_not_exist()
+    {
+        var options = CreateOptions();
+        // No game seeded.
+        var (service, sender) = CreateService(options);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SendTestBundleAsync(GameId, "tom@example.cz", isReminder: false, CancellationToken.None));
+
+        Assert.Empty(sender.Captured);
+    }
+
+    [Fact]
+    public async Task SendTestBundleAsync_uses_isReminder_flag()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        var (service, sender) = CreateService(options);
+
+        await service.SendTestBundleAsync(GameId, "tom@example.cz", isReminder: true, CancellationToken.None);
+
+        var captured = Assert.Single(sender.Captured);
+        // Default reminder subject (no template override) starts with "Připomínka:".
+        Assert.StartsWith("Připomínka:", captured.Subject);
+        // Default reminder body includes the gentle reminder phrasing.
+        Assert.Contains("tichou připomínku", captured.HtmlBody);
+    }
+
+    [Fact]
+    public async Task SendTestAdultIndividualAsync_throws_when_toEmail_is_blank()
+    {
+        var options = CreateOptions();
+        await SeedGameAsync(options);
+        var (service, sender) = CreateService(options);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SendTestAdultIndividualAsync(GameId, "", isReminder: false, CancellationToken.None));
+
+        Assert.Empty(sender.Captured);
+    }
+
     // ------------------------------------------------------------------ helpers
 
     private static DbContextOptions<ApplicationDbContext> CreateOptions() =>


### PR DESCRIPTION
## Summary
- Two new **Poslat zkušebně mně** buttons on the feedback template editor (rodinná verze + verze pro dospělé) plus a **Poslat jako připomínku** toggle that flips the reminder copy.
- Test e-mail goes to the logged-in organizer's address (resolved via `UserManager.GetUserAsync(authState.User)` → `user.Email`) and runs through the **same renderer + same sender** as the real bulk send, so per-game template overrides are exercised end-to-end.
- New `FeedbackMailService.SendTestBundleAsync` / `SendTestAdultIndividualAsync` build a sample model with dummy attendees (Anička/Kuba for the bundle, Testovací dospělý for the individual) and random GUID token links — the links are intentionally not resolvable; the buttons are a visual preview.
- The buttons save the current template edits before sending, so the test e-mail always reflects the in-form state. All buttons disable themselves while a send is in flight.

5 new tests added to `FeedbackMailServiceTests` (renderer wiring, blank-email guard, missing-game guard, isReminder flag).